### PR TITLE
Changed naked except statements to catch only subclasses of Exception

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -54,7 +54,7 @@ def prepare_environ_pickle(environ):
     for key, value in environ.iteritems():
         try:
             pickle.dumps((key, value))
-        except:
+        except Exception:
             continue
         result[key] = value
     return result

--- a/werkzeug/__init__.py
+++ b/werkzeug/__init__.py
@@ -138,7 +138,7 @@ class module(ModuleType):
             try:
                 version = __import__('pkg_resources') \
                           .get_distribution('Werkzeug').version
-            except:
+            except Exception:
                 version = 'unknown'
         return version
 

--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -188,7 +188,7 @@ def _patch_wrapper(old, new):
         new.__module__ = old.__module__
         new.__doc__ = old.__doc__
         new.__dict__ = old.__dict__
-    except:
+    except Exception:
         pass
     return new
 

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -301,7 +301,7 @@ class MemcachedCache(BaseCache):
                 client = memcache.Client(map(str, servers))
                 try:
                     client.debuglog = lambda *a: None
-                except:
+                except Exception:
                     pass
             else:
                 if is_pylibmc:
@@ -487,7 +487,7 @@ class FileSystemCache(BaseCache):
                     finally:
                         if f is not None:
                             f.close()
-                except:
+                except Exception:
                     pass
                 if remove:
                     try:
@@ -516,7 +516,7 @@ class FileSystemCache(BaseCache):
             finally:
                 f.close()
             os.remove(filename)
-        except:
+        except Exception:
             return None
 
     def add(self, key, value, timeout=None):

--- a/werkzeug/contrib/iterio.py
+++ b/werkzeug/contrib/iterio.py
@@ -41,7 +41,7 @@ r"""
 """
 try:
     from py.magic import greenlet
-except:
+except ImportError:
     greenlet = None
 
 

--- a/werkzeug/contrib/lint.py
+++ b/werkzeug/contrib/lint.py
@@ -176,7 +176,7 @@ class GuardedIterator(object):
             try:
                 warn(WSGIWarning('Iterator was garbage collected before '
                                  'it was closed.'))
-            except:
+            except Exception:
                 pass
 
 

--- a/werkzeug/contrib/securecookie.py
+++ b/werkzeug/contrib/securecookie.py
@@ -203,7 +203,7 @@ class SecureCookie(ModificationTrackingDict):
             if cls.serialization_method is not None:
                 value = cls.serialization_method.loads(value)
             return value
-        except:
+        except Exception:
             # unfortunately pickle and other serialization modules can
             # cause pretty every error here.  if we get one we catch it
             # and convert it into an UnquoteError

--- a/werkzeug/contrib/testtools.py
+++ b/werkzeug/contrib/testtools.py
@@ -56,7 +56,7 @@ class ContentAccessors(object):
             raise AttributeError('Not a JSON response')
         try:
             from simplejson import loads
-        except:
+        except ImportError:
             from json import loads
         return loads(self.data)
     json = cached_property(json)

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2302,7 +2302,7 @@ class FileStorage(object):
         """Close the underlying file if possible."""
         try:
             self.stream.close()
-        except:
+        except Exception:
             pass
 
     def __nonzero__(self):

--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -78,7 +78,7 @@ class DebuggedApplication(object):
                 yield item
             if hasattr(app_iter, 'close'):
                 app_iter.close()
-        except:
+        except Exception:
             if hasattr(app_iter, 'close'):
                 app_iter.close()
             traceback = get_current_traceback(skip=1, show_hidden_frames=
@@ -92,7 +92,7 @@ class DebuggedApplication(object):
                 start_response('500 INTERNAL SERVER ERROR', [
                     ('Content-Type', 'text/html; charset=utf-8')
                 ])
-            except:
+            except Exception:
                 # if we end up here there has been output but an error
                 # occurred.  in that situation we can do nothing fancy any
                 # more, better log something into the error log and fall

--- a/werkzeug/debug/console.py
+++ b/werkzeug/debug/console.py
@@ -170,7 +170,7 @@ class _InteractiveConsole(code.InteractiveInterpreter):
     def runcode(self, code):
         try:
             exec code in self.globals, self.locals
-        except:
+        except Exception:
             self.showtraceback()
 
     def showtraceback(self):

--- a/werkzeug/debug/render.py
+++ b/werkzeug/debug/render.py
@@ -61,7 +61,7 @@ def var_table(var):
     def safe_pformat(x):
         try:
             lines = pprint.pformat(x).splitlines()
-        except:
+        except Exception:
             return '?'
         tmp = []
         for line in lines:

--- a/werkzeug/debug/repr.py
+++ b/werkzeug/debug/repr.py
@@ -189,7 +189,7 @@ class DebugReprGenerator(object):
     def fallback_repr(self):
         try:
             info = ''.join(format_exception_only(*sys.exc_info()[:2]))
-        except: # pragma: no cover
+        except Exception: # pragma: no cover
             info = '?'
         return u'<span class="brokenrepr">&lt;broken repr (%s)&gt;' \
                u'</span>' % escape(info.decode('utf-8', 'ignore').strip())
@@ -204,7 +204,7 @@ class DebugReprGenerator(object):
         try:
             try:
                 return self.dispatch_repr(obj, recursive)
-            except:
+            except Exception:
                 return self.fallback_repr()
         finally:
             self._stack.pop()
@@ -225,7 +225,7 @@ class DebugReprGenerator(object):
             for key in dir(obj):
                 try:
                     items.append((key, self.repr(getattr(obj, key))))
-                except:
+                except Exception:
                     pass
             title = 'Details for'
         title += ' ' + object.__repr__(obj)[1:-1]

--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -242,7 +242,7 @@ class Frame(object):
                     source = self.loader.get_source(self.module)
                 elif hasattr(self.loader, 'get_source_by_code'):
                     source = self.loader.get_source_by_code(self.code)
-            except:
+            except Exception:
                 # we munch the exception so that we don't cause troubles
                 # if the loader is broken.
                 pass

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -274,7 +274,7 @@ def parse_multipart(file, boundary, content_length, stream_factory=None,
                 if try_decode:
                     try:
                         line = line.decode(transfer_encoding)
-                    except:
+                    except Exception:
                         raise ValueError('could not decode transfer '
                                          'encoded chunk')
 

--- a/werkzeug/local.py
+++ b/werkzeug/local.py
@@ -15,7 +15,7 @@ except ImportError: # pragma: no cover
         from py.magic import greenlet
         get_current_greenlet = greenlet.getcurrent
         del greenlet
-    except:
+    except Exception:
         # catch all, py.* fails with so many different errors.
         get_current_greenlet = int
 try:

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -152,7 +152,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             execute(app)
         except (socket.error, socket.timeout), e:
             self.connection_dropped(e, environ)
-        except:
+        except Exception:
             if self.server.passthrough_errors:
                 raise
             from werkzeug.debug.tbtools import get_current_traceback
@@ -163,7 +163,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                 if not headers_sent:
                     del headers_set[:]
                 execute(InternalServerError())
-            except:
+            except Exception:
                 pass
             self.server.log('error', 'Error on request:\n%s',
                             traceback.plaintext)
@@ -174,7 +174,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             return BaseHTTPRequestHandler.handle(self)
         except (socket.error, socket.timeout), e:
             self.connection_dropped(e)
-        except:
+        except Exception:
             if self.server.ssl_context is None or not is_ssl_error():
                 raise
 

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -180,7 +180,7 @@ class BaseRequest(object):
         try:
             args.append("'%s'" % self.url)
             args.append('[%s]' % self.method)
-        except:
+        except Exception:
             args.append('(invalid WSGI environ)')
 
         return '<%s %s>' % (


### PR DESCRIPTION
Naked except statements catch subclasses of BaseException which
can occur anywhere (i.e. KeyboardInterrupt).

Unexpected issues can occur when the exception happens during the
loading of a module. The python interpreter doesn't know about a
module's failed load and does not remove it from sys.modules. This
is particularly a problem on AppEngine where DeadlineExceededErrors
can occur anywhere and modules that catch the error cause python to
think the module is loaded but in fact the module load has failed.

See: http://code.google.com/p/googleappengine/issues/detail?id=1409

If any of the changed imports look like they might be problematic please comment.
