### PR TITLE
added Request.scheme (w/tests)

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -130,6 +130,10 @@ def test_url_request_descriptors():
     assert req.url_root == 'http://example.com/test/'
     assert req.host_url == 'http://example.com/'
     assert req.host == 'example.com'
+    assert req.scheme == 'http'
+
+    req = Request.from_values('/bar?foo=baz', 'https://example.com/test')
+    assert req.scheme == 'https'
 
 
 def test_authorization_mixin():

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -482,6 +482,9 @@ class BaseRequest(object):
         protected, this attribute contains the username the user has
         authenticated as.''')
 
+    scheme = environ_property('wsgi.url_scheme', doc='''
+        URL scheme (http or https).''')
+
     is_xhr = property(lambda x: x.environ.get('HTTP_X_REQUESTED_WITH', '')
                       .lower() == 'xmlhttprequest', doc='''
         True if the request was triggered via a JavaScript XMLHttpRequest.


### PR DESCRIPTION
When generating external urls, e.g.: for scripts in a CDN, it's nicer to be able to say {{ request.scheme }} instead of "http{% if request.is_secure %}s{% endif %}
