### PR TITLE
Removed usage of werkzeug.templates from contrib.jsrouting, added depreca

### DIFF
--- a/werkzeug/templates.py
+++ b/werkzeug/templates.py
@@ -19,6 +19,11 @@ from werkzeug._internal import _decode_unicode
 from werkzeug.datastructures import MultiDict
 
 
+from warnings import warn
+warn(DeprecationWarning('werkzeug.templates is deprecated and '
+                        'will be removed in Werkzeug 1.0'))
+
+
 # Copyright notice: The `parse_data` method uses the string interpolation
 # algorithm by Ka-Ping Yee which originally was part of `Itpl20.py`_.
 #


### PR DESCRIPTION
Removed usage of werkzeug.templates from contrib.jsrouting, added deprecation warning to werkzeug.templates

This should fix #23, #22 already is fixed – werkzeug.debug.render can be removed safely
