### PR TITLE
fix test_socket of reloader mechanism for IPv6

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -607,7 +607,8 @@ def run_simple(hostname, port, application, use_reloader=False,
     if use_reloader:
         # Create and destroy a socket so that any exceptions are raised before
         # we spawn a separate Python interpreter and lose this ability.
-        test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        address_family = select_ip_version(hostname, port)
+        test_socket = socket.socket(address_family, socket.SOCK_STREAM)
         test_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         test_socket.bind((hostname, port))
         test_socket.close()


### PR DESCRIPTION
fix test_socket of reloader mechanism for IPv6 (without this fix, you get "socket.gaierror: [Errno -9] Address family for hostname not supported" for the bind() call).

You'll have to use the numeric IPv6 address so the select_ip_version call works correctly.
