### PR TITLE
hop-by-hop fixes

### DIFF
--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -52,7 +52,7 @@ _entity_headers = frozenset([
 ])
 _hop_by_pop_headers = frozenset([
     'connection', 'keep-alive', 'proxy-authenticate',
-    'proxy-authorization', 'te', 'trailers', 'transfer-encoding',
+    'proxy-authorization', 'te', 'trailer', 'transfer-encoding',
     'upgrade'
 ])
 


### PR DESCRIPTION
`_hop_by_pop_headers` includes "trailers", but it should be "trailer" according to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.40 and http://en.wikipedia.org/wiki/List_of_HTTP_header_fields.

Also, why "hop_by_pop" and not "hop_by_hop"?

Finally, http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10 says: "HTTP/1.1 proxies MUST parse the Connection header field before a message is forwarded and, for each connection-token in this field, remove any header field(s) from the message with the same name as the connection-token." Werkzeug is not currently doing this. Shouldn't it?
