### PR TITLE
Support url parameters that start with an underscore

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -115,7 +115,7 @@ _rule_re = re.compile(r'''
         (?:\((?P<args>.*?)\))?                  # converter arguments
         \:                                      # variable delimiter
     )?
-    (?P<variable>[a-zA-Z][a-zA-Z0-9_]*)         # variable name
+    (?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)        # variable name
     >
 ''', re.VERBOSE)
 _simple_rule_re = re.compile(r'<([^>]+)>')


### PR DESCRIPTION
This is useful, for example, when trying to map the arguments from the url to fields in a mongo query.  (Mongo uses a field called `_id` by default.)
