### PR TITLE
more hop-by-hop fixes

### DIFF
--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -685,8 +685,10 @@ def remove_hop_by_hop_headers(headers):
 
     :param headers: a list or :class:`Headers` object.
     """
+    connkeys = set(i.strip() for i in headers.get('connection', '').split(',')
+        if i.strip())
     headers[:] = [(key, value) for key, value in headers if
-                  not is_hop_by_hop_header(key)]
+                  not is_hop_by_hop_header(key) and key not in connkeys]
 
 
 def is_entity_header(header):


### PR DESCRIPTION
This accompanies https://github.com/mitsuhiko/werkzeug/pull/96 to make it easier to comply with http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10

My concern about this patch is it unconditionally removes headers matching the connection tokens without first checking what they are, making us vulnerable to bogus Connection headers. But I didn't see a set of headers which are unsafe to remove which we could check against. I could submit a better patch if you provide feedback.
