### PR TITLE
Fixed digest auth header parsing at werkzeug/http.py in parse_authorization_header

### DIFF
--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -357,8 +357,12 @@ def parse_authorization_header(value):
                                        'password': password})
     elif auth_type == 'digest':
         auth_map = parse_dict_header(auth_info)
-        for key in 'username', 'realm', 'nonce', 'uri', 'nc', 'cnonce', \
-                   'response':
+        requires_map = {
+            'auth': ("username", "realm", "nonce", "uri", "response", "opaque"),
+            'auth-int': ("username", "realm", "nonce", "uri", "response", "opaque",
+                         "qop", "nc", "cnonce")}
+
+        for key in requires_map.get(auth_map.get('qop', 'auth')):
             if not key in auth_map:
                 return
         return Authorization('digest', auth_map)


### PR DESCRIPTION
parse_authorization_header can't parse auth header without cnonce, qop, nc, but

cnonce, nc, qop required only for qop=auth-int type
RESPONSE = MD5(HA1:nonce:nonceCount:clienNonce:qop:HA2)

qop=auth don't require its
RESPONSE = MD5(HA1:nonce:HA2)
