### PR TITLE
Don't overwrite Content-Length header in make_conditional

### DIFF
--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1268,7 +1268,7 @@ class ETagResponseMixin(object):
             # wsgiref.
             if 'date' not in self.headers:
                 self.headers['Date'] = http_date()
-            if 'content-length' in self.headers:
+            if 'content-length' not in self.headers:
                 self.headers['Content-Length'] = len(self.data)
             if not is_resource_modified(environ, self.headers.get('etag'), None,
                                         self.headers.get('last-modified')):


### PR DESCRIPTION
I hope the patch is self-explanatory.

I'm using `make_conditional` on lazy-loaded (from the database) resources, and calling `len(self.data)` actually causes the file(-like object) to be loaded, causing extra system load and delay.
