### PR TITLE
Redis Cache Enhancement

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -65,8 +65,38 @@ except ImportError:
     from md5 import new as md5
 from itertools import izip
 from time import time
-from cPickle import loads, dumps, load, dump, HIGHEST_PROTOCOL
 from werkzeug.posixemulation import rename
+
+try:
+    import msgpack
+
+    def loads(string):
+        return msgpack.loads(string)
+
+    def dumps(obj, protocol=None, bin=None):
+        return msgpack.dumps(obj)
+
+    def load(fp):
+        buf = b''
+        obj = None
+        while True:
+            b = fp.read(1)
+            if not b: break
+            buf += b
+            obj = msgpack.loads(buf)
+            if obj is not None: break
+        return obj
+
+    def dump(obj, fp, protocol=None, bin=None):
+        return msgpack.dump(obj, fp)
+
+    HIGHEST_PROTOCOL = None  # compatibility for pickle
+
+except ImportError:
+    try:
+        from cPickle import loads, dumps, load, dump, HIGHEST_PROTOCOL
+    except ImportError:
+        from pickle import loads, dumps, load, dump, HIGHEST_PROTOCOL
 
 def _items(mappingorseq):
     """Wrapper for efficient iteration over mappings represented by dicts


### PR DESCRIPTION
I push two commits about the redis cache.
1. Refactored redis support. Added serialization of cache data.
2. Tuned-up performance. We use messagepack instead of pickle if possible.

The redis stores values as string. We should serialize/deserialize objects when we put values into redis. However, current RedisCache does not support serialization. For instance, when we set a tuple (1, 2), we get the string '(1, 2)'. So I add serialization like FileSystemCache.

Speed of serialization/deserialization affects cache efficiency. I think the MessagePack is more suitable for cache because it is very fast. See a benchmark http://dsas.blog.klab.org/archives/51456004.html.
