### PR TITLE
Add Host RuleFactory, much like Subdomain

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -133,6 +133,8 @@ Rule Factories
 
 .. autoclass:: Subdomain
 
+.. autoclass:: Host
+
 .. autoclass:: Submount
 
 .. autoclass:: EndpointPrefix
@@ -194,6 +196,9 @@ the `host` argument to all routes::
         Rule('/', endpoint='www_index', host='www.example.com'),
         Rule('/', endpoint='help_index', host='help.example.com')
     ], host_matching=True)
+
+If you have many routes that require the same host name, you can use the
+:class:`Host` factory to avoid repeating yourself.
 
 Variable parts are of course also possible in the host section::
 

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -315,6 +315,36 @@ class Subdomain(RuleFactory):
                 yield rule
 
 
+class Host(RuleFactory):
+    """Like `Subdomain` but matches hosts::
+
+        url_map = Map([
+            Host('www.example.com', [
+                Rule('/', endpoint='commercial_index'),
+                Rule('/buy', endpoint='commercial_buy')
+            ]),
+            Host('www.example.org', [
+                Rule('/', endpoint='organization_index'),
+                Rule('/donate', endpoint='organization_donate')
+            ]),
+            Rule('/help', endpoint='help')
+        ], host_matching=True)
+
+    You must also pass `host_matching=True` to the :class:`Map` constructor.
+    """
+
+    def __init__(self, host, rules):
+        self.host = host
+        self.rules = rules
+
+    def get_rules(self, map):
+        for rulefactory in self.rules:
+            for rule in rulefactory.get_rules(map):
+                rule = rule.empty()
+                rule.host = self.host
+                yield rule
+
+
 class Submount(RuleFactory):
     """Like `Subdomain` but prefixes the URL rule with a given string::
 

--- a/werkzeug/testsuite/routing.py
+++ b/werkzeug/testsuite/routing.py
@@ -558,7 +558,11 @@ class RoutingTestCase(WerkzeugTestCase):
             r.Rule('/', endpoint='index', host='www.<domain>'),
             r.Rule('/', endpoint='files', host='files.<domain>'),
             r.Rule('/foo/', defaults={'page': 1}, host='www.<domain>', endpoint='x'),
-            r.Rule('/<int:page>', host='files.<domain>', endpoint='x')
+            r.Rule('/<int:page>', host='files.<domain>', endpoint='x'),
+            r.Host('api.<domain>', [
+                r.Rule('/', endpoint='api_index'),
+                r.Rule('/user/<name>', endpoint='api_user')
+            ])
         ], host_matching=True)
 
         a = m.bind('www.example.com')
@@ -580,6 +584,10 @@ class RoutingTestCase(WerkzeugTestCase):
             assert e.new_url == 'http://www.example.com/foo/'
         else:
             assert False, 'expected redirect'
+
+        a = m.bind('api.example.net')
+        assert a.match('/') == ('api_index', {'domain': 'example.net'})
+        assert a.match('/user/a') == ('api_user', {'domain': 'example.net', 'name': 'a'})
 
     def test_server_name_casing(self):
         m = r.Map([


### PR DESCRIPTION
This commit makes it a little easier to use host matching by allowing you to specify hostnames using a RuleFactory.
