### PR TITLE
Improve uploaded file handling in multipart forms

### DIFF
--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -396,6 +396,12 @@ class MultiPartParser(object):
                 filename, container = self.start_file_streaming(
                     filename, headers, content_length)
                 _write = container.write
+                file_length = headers.get('content-length')
+                if file_length is None:
+                    file_length = 0
+                    count_file_length = True
+                else:
+                    count_file_length = False
 
             buf = ''
             for line in iterator:
@@ -436,6 +442,9 @@ class MultiPartParser(object):
                     cutoff = -1
                 _write(line[:cutoff])
 
+                if is_file and count_file_length:
+                    file_length += len(line)+cutoff
+
                 # if we write into memory and there is a memory size limit we
                 # count the number of bytes in memory and raise an exception if
                 # there is too much data in memory.
@@ -453,9 +462,11 @@ class MultiPartParser(object):
                 _write(buf)
 
             if is_file:
-                container.seek(0)
-                files.append((name, FileStorage(container, filename, name,
-                                                headers=headers)))
+                if filename or file_length:
+                    container.seek(0)
+                    files.append((name, FileStorage(container, filename, name,
+                                                    content_length=file_length,
+                                                    headers=headers)))
             else:
                 form.append((name, _decode_unicode(''.join(container),
                                                    part_charset, self.errors)))


### PR DESCRIPTION
This patch makes werkzeug's multipart form parser count the length of uploaded files and not put empty unnamed files in the list of files in the form.  The counting comes essentially for free since the file content is copied out of the request body anyway.  The main benefit of this is that constructs like "if 'somefile' in request.files" work as expected.  As a side-effect, the content_length member of files always contains a useful value even if the browser didn't supply it.

There's a remote possibility that if the user uploads an empty file and the browser supplies no filename for it, it will be ignored.  However, I don't think much is lost in that case.
