### PR TITLE
Fix parse_multipart_headers

### DIFF
--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -248,8 +248,10 @@ def parse_multipart_headers(iterable):
         line, line_terminated = _line_parse(line)
         if not line_terminated:
             raise ValueError('unexpected end of line in multipart header')
-        if not line:
+        if not line and len(result) != 0:
             break
+        elif not line and len(result) == 0:
+            continue
         elif line[0] in ' \t' and result:
             key, value = result[-1]
             result[-1] = (key, value + '\n ' + line[1:])

--- a/werkzeug/testsuite/formparser.py
+++ b/werkzeug/testsuite/formparser.py
@@ -325,7 +325,10 @@ class MultiPartTestCase(WerkzeugTestCase):
         self.assert_raises(ValueError, parse_multipart, StringIO(data), 'foo', len(data))
 
         x = formparser.parse_multipart_headers(['foo: bar\r\n', ' x test\r\n'])
+        y = formparser.parse_multipart_headers(['\n', 'start: end\r\n'])
+
         self.assert_equal(x['foo'], 'bar\n x test')
+        self.assert_equal(y['start'], 'end')
         self.assert_raises(ValueError, formparser.parse_multipart_headers,
                            ['foo: bar\r\n', ' x test'])
 


### PR DESCRIPTION
Hello!

I found a bug in the parsing of multipart request headers.

When we do iterated line-based representation message could break into pieces like ['...\r\nboundary\r', '\n', 'Header: header value\r\n']. To the parse_multipart_headers function input we send ['\n', 'Header: header value\r\n' ]. It does not support this format and returns Headers([]). It breaks function parse_form_data fwith error 'Missing Content-Disposition header'. My patch fixed the bug. After patching function returns Headers([('Header', 'header value')]).
