### PR TITLE
Unicode endpoints

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1611,8 +1611,8 @@ class MapAdapter(object):
         if not force_external and (
             (self.map.host_matching and host == self.server_name) or
             (not self.map.host_matching and domain_part == self.subdomain)):
-            return str(urljoin(self.script_name, './' + path.lstrip('/')))
-        return str('%s://%s%s/%s' % (
+            return unicode(urljoin(self.script_name, './' + path.lstrip('/')))
+        return unicode('%s://%s%s/%s' % (
             self.url_scheme,
             host,
             self.script_name[:-1],


### PR DESCRIPTION
Sorry if something go wrong at first because it was my first fork.

I've found Exception "UnicodeEncodeError" if i try something like that:

   @users.route(u"/войти", methods=['GET', 'POST'])
   def login():
    provider = request.args.get('provider')

Unicode endpoints support. Actual for local zones like '.рф' (for Russian Federation) for example "кемхобби.рф"
