### PR TITLE
Added option to build secure URLs

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1537,7 +1537,7 @@ class MapAdapter(object):
                     return rv
 
     def build(self, endpoint, values=None, method=None, force_external=False,
-              append_unknown=True):
+              force_secure=False, append_unknown=True):
         """Building URLs works pretty much the other way round.  Instead of
         `match` you call `build` and pass it the endpoint and a dict of
         arguments for the placeholders.
@@ -1559,6 +1559,8 @@ class MapAdapter(object):
         '/downloads/42'
         >>> urls.build("downloads/show", {'id': 42}, force_external=True)
         'http://example.com/downloads/42'
+        >>> urls.build("downloads/show", {'id': 42}, force_secure=True)
+        'https://example.com/downloads/42'
 
         Because URLs cannot contain non ASCII data you will always get
         bytestrings back.  Non ASCII characters are urlencoded with the
@@ -1586,6 +1588,7 @@ class MapAdapter(object):
         :param method: the HTTP method for the rule if there are different
                        URLs for different methods on the same endpoint.
         :param force_external: enforce full canonical external URLs.
+        :param force_secure: enforce absolute secure URLs.
         :param append_unknown: unknown parameters are appended to the generated
                                URL as query string argument.  Disable this
                                if you want the builder to ignore those.
@@ -1606,14 +1609,17 @@ class MapAdapter(object):
         domain_part, path = rv
 
         host = self.get_host(domain_part)
+        url_scheme = self.url_scheme
 
         # shortcut this.
-        if not force_external and (
+	if force_secure:
+            url_scheme = 'https'
+        elif not force_external and (
             (self.map.host_matching and host == self.server_name) or
             (not self.map.host_matching and domain_part == self.subdomain)):
             return str(urljoin(self.script_name, './' + path.lstrip('/')))
         return str('%s://%s%s/%s' % (
-            self.url_scheme,
+            url_scheme,
             host,
             self.script_name[:-1],
             path.lstrip('/')

--- a/werkzeug/testsuite/routing.py
+++ b/werkzeug/testsuite/routing.py
@@ -449,6 +449,30 @@ class RoutingTestCase(WerkzeugTestCase):
         assert a.build('x', {'foo': 'x:y'}, force_external=True) == \
             'http://example.org/x:y'
 
+    def test_protocol_joining_bug_with_secure(self):
+        m = r.Map([r.Rule('/<foo>', endpoint='x')])
+        a = m.bind('example.org')
+        assert a.build('x', {'foo': 'x:y'}) == '/x:y'
+        assert a.build('x', {'foo': 'x:y'}, force_secure=True) == \
+            'https://example.org/x:y'
+
+    def test_secure_building_with_port(self):
+        map = r.Map([
+            r.Rule('/', endpoint='index'),
+        ])
+        adapter = map.bind('example.org:5000', '/')
+        built_url = adapter.build('index', {}, force_secure=True)
+        assert built_url == 'https://example.org:5000/', built_url
+
+    def test_secure_with_external(self):
+        map = r.Map([
+            r.Rule('/', endpoint='index'),
+        ])
+        adapter = map.bind('example.org:5000', '/')
+        built_url = adapter.build('index', {}, force_external=True,
+                                  force_secure=True)
+        assert built_url == 'https://example.org:5000/', built_url
+
     def test_allowed_methods_querying(self):
         m = r.Map([r.Rule('/<foo>', methods=['GET', 'HEAD']),
                    r.Rule('/foo', methods=['POST'])])


### PR DESCRIPTION
This is a lower level change to aid the secure URL generation with url_for() by Flask. I've raised a pull request to Flask to add a field to url_for() to use this option.
