### PR TITLE
Add support for X-Forwarded-Proto to werkzeug.wsgi.get_current_url.

### DIFF
--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -57,7 +57,7 @@ def get_current_url(environ, root_only=False, strip_querystring=False,
     :param strip_querystring: set to `True` if you don't want the querystring.
     :param host_only: set to `True` if the host URL should be returned.
     """
-    tmp = [environ['wsgi.url_scheme'], '://', get_host(environ)]
+    tmp = [get_url_scheme(environ), '://', get_host(environ)]
     cat = tmp.append
     if host_only:
         return ''.join(tmp) + '/'
@@ -88,6 +88,19 @@ def get_host(environ):
        in (('https', '443'), ('http', '80')):
         result += ':' + environ['SERVER_PORT']
     return result
+
+
+def get_url_scheme(environ):
+    """Return the real URL scheme for the given WSGI environment.  This takes
+    care of the `X-Forwarded-Proto` header.
+
+    :param environ: the WSGI environment to get the host of.
+    """
+    if 'HTTP_X_FORWARDED_PROTO' in environ:
+        result = environ['HTTP_X_FORWARDED_PROTO']
+        if result in ('http', 'https'):
+            return result
+    return environ['wsgi.url_scheme']
 
 
 def pop_path_info(environ):


### PR DESCRIPTION
As per [my comment on issue 106](https://github.com/mitsuhiko/werkzeug/pull/106#issuecomment-2739221), this change adds another helper method - `werkzeug.wsgi.get_url_scheme` - which is modeled after `get_host` in the same module.

Added several new tests for the new helper, as well as `get_current_url` which has been modified to call it instead of relying solely on `wsgi.url_scheme`. All tests pass including the old ones.
