### PR TITLE
Adding support for multiprocess servers to werkzeug.debug

### DIFF
--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import mimetypes
+from os import getpid
 from os.path import join, dirname, basename, isfile
 from werkzeug.wrappers import BaseRequest as Request, BaseResponse as Response
 from werkzeug.debug.tbtools import get_current_traceback, render_console_html
@@ -67,6 +68,7 @@ class DebuggedApplication(object):
     def __init__(self, app, evalex=False, request_key='werkzeug.request',
                  console_path='/console', console_init_func=None,
                  show_hidden_frames=False,
+                 multiprocess_support=False,
                  lodgeit_url='http://paste.pocoo.org/'):
         if not console_init_func:
             console_init_func = dict
@@ -80,6 +82,7 @@ class DebuggedApplication(object):
         self.show_hidden_frames = show_hidden_frames
         self.lodgeit_url = lodgeit_url
         self.secret = gen_salt(20)
+        self.multiprocess_support = multiprocess_support
 
     def debug_application(self, environ, start_response):
         """Run the application and conserve the traceback frames."""
@@ -116,7 +119,8 @@ class DebuggedApplication(object):
             else:
                 yield traceback.render_full(evalex=self.evalex,
                                             lodgeit_url=self.lodgeit_url,
-                                            secret=self.secret) \
+                                            secret=self.secret,
+                                            pid=self.multiprocess_support and getpid() or '') \
                                .encode('utf-8', 'replace')
 
             traceback.log(environ['wsgi.errors'])
@@ -156,6 +160,9 @@ class DebuggedApplication(object):
                 f.close()
         return Response('Not Found', status=404)
 
+    def mp_redirect(self, request):
+        return Response('Wrong Process', status=302, headers=[('Location', request.url)])
+
     def __call__(self, environ, start_response):
         """Dispatch the requests."""
         # important: don't ever access a function here that reads the incoming
@@ -164,12 +171,15 @@ class DebuggedApplication(object):
         request = Request(environ)
         response = self.debug_application
         if request.args.get('__debugger__') == 'yes':
+            pid = request.args.get('p')
             cmd = request.args.get('cmd')
             arg = request.args.get('f')
             secret = request.args.get('s')
             traceback = self.tracebacks.get(request.args.get('tb', type=int))
             frame = self.frames.get(request.args.get('frm', type=int))
-            if cmd == 'resource' and arg:
+            if self.multiprocess_support and pid and pid != str(getpid()):
+              response = self.mp_redirect(request)
+            elif cmd == 'resource' and arg:
                 response = self.get_resource(request, arg)
             elif cmd == 'paste' and traceback is not None and \
                  secret == self.secret:

--- a/werkzeug/debug/shared/debugger.js
+++ b/werkzeug/debug/shared/debugger.js
@@ -45,7 +45,7 @@ $(function() {
               sourceView.slideUp('fast');
             });
         $.get(document.location.pathname, {__debugger__: 'yes', cmd:
-            'source', frm: frameID, s: SECRET}, function(data) {
+            'source', frm: frameID, s: SECRET, p: PID}, function(data) {
           $('table', sourceView)
             .replaceWith(data);
           if (!sourceView.is(':visible'))
@@ -135,7 +135,7 @@ function openShell(consoleNode, target, frameID) {
     .submit(function() {
       var cmd = command.val();
       $.get(document.location.pathname, {
-          __debugger__: 'yes', cmd: cmd, frm: frameID, s: SECRET}, function(data) {
+          __debugger__: 'yes', cmd: cmd, frm: frameID, s: SECRET, p: PID}, function(data) {
         var tmp = $('<div>').html(data);
         $('span.extended', tmp).each(function() {
           var hidden = $(this).wrap('<span>').hide();

--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -43,6 +43,7 @@ HEADER = u'''\
       var TRACEBACK = %(traceback_id)d,
           CONSOLE_MODE = %(console)s,
           EVALEX = %(evalex)s,
+          PID = "%(pid)s",
           SECRET = "%(secret)s";
     </script>
   </head>
@@ -299,7 +300,7 @@ class Traceback(object):
         }
 
     def render_full(self, evalex=False, lodgeit_url=None,
-                    secret=None):
+                    secret=None, pid=''):
         """Render the Full HTML page with the traceback info."""
         exc = escape(self.exception)
         return PAGE_HTML % {
@@ -313,6 +314,7 @@ class Traceback(object):
             'plaintext':        self.plaintext,
             'plaintext_cs':     re.sub('-{2,}', '-', self.plaintext),
             'traceback_id':     self.id,
+            'pid':              pid,
             'secret':           secret
         }
 


### PR DESCRIPTION
In server environments that use a shared pool of processes, the Werkzeug debbugger is unable to properly serve up traceback and frame information.  This is a patch to allow it to work in that environment.

You can find a quick test script that sets up a process pool to allow testing this functionality here:

~~~python
import os
import select
from werkzeug.wrappers import Request, Response
from werkzeug.debug import DebuggedApplication
import SocketServer

class PreForkingPoolMixIn(SocketServer.ForkingMixIn):
  """Mix-In class that keeps a pool of children to use for handling requests."""

  def process_request(self, request, client_address):
      """Handle the request."""

      try:
          self.finish_request(request, client_address)
          self.close_request(request)
      except:
          try:
              self.handle_error(request, client_address)
          finally:
              self.close_request(request)

  def serve_forever(self, poll_interval=0.5):
      """Handle one request at a time until shutdown.
      Polls for shutdown every poll_interval seconds. Ignores
      self.timeout. If you need to do periodic tasks, do them in
      another thread.
      """

      pid = True
      self.active_children = []
      for x in xrange(self.max_children):
        if pid:
          pid = os.fork()
          if pid:
            self.active_children.append(pid)
      self._BaseServer__serving = True
      self._BaseServer__is_shut_down.clear()
      while self._BaseServer__serving:
          # XXX: Consider using another file descriptor or
          # connecting to the socket to wake this up instead of
          # polling. Polling reduces our responsiveness to a
          # shutdown request and wastes cpu at all other times.
          if pid:
            import time
            time.sleep(1)
            self.collect_children()
          else:
            r, w, e = select.select([self], [], [], poll_interval)
            if r:
                self._handle_request_noblock()
      self._BaseServer__is_shut_down.set()

# Monkeypatch SocketServer with our Forking Pool
SocketServer.ForkingMixIn = PreForkingPoolMixIn

@Request.application
def application(request):
  raise Exception('Forced')
  return Response('Hello World!')

if __name__ == '__main__':
  from werkzeug.serving import run_simple
  run_simple('localhost', 4000, DebuggedApplication(application, evalex=True, multiprocess_support=True), processes=5)
~~~