### PR TITLE
Do not quote percent sign when converting IRI to URI.

### DIFF
--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -141,7 +141,7 @@ def iri_to_uri(iri, charset='utf-8'):
     if port:
         hostname += ':' + port
 
-    path = _quote(path.encode(charset), safe="/:~+")
+    path = _quote(path.encode(charset), safe="/:~+%")
     query = _quote(query.encode(charset), safe="=%&[]:;$()+,!?*/")
 
     # this absolutely always must return a string.  Otherwise some parts of


### PR DESCRIPTION
According to RFC3987, percent-encoded parts are valid in IRIs as well as in URIs and do not need to be additionaly encoded.
