### PR TITLE
Fixed potential XSS risk in redirect page

### DIFF
--- a/werkzeug/testsuite/utils.py
+++ b/werkzeug/testsuite/utils.py
@@ -40,6 +40,15 @@ class GeneralUtilityTestCase(WerkzeugTestCase):
         assert resp.headers['Location'] == 'http://example.com/'
         assert resp.status_code == 305
 
+    def test_redirect_xss(self):
+        location = 'http://example.com/?xss="><script>alert(1)</script>'
+        resp = utils.redirect(location)
+        assert '<script>alert(1)</script>' not in resp.data
+
+        location = 'http://example.com/?xss="onmouseover="alert(1)'
+        resp = utils.redirect(location)
+        assert 'href="http://example.com/?xss="onmouseover="alert(1)"' not in resp.data
+
     def test_cached_property(self):
         foo = []
         class A(object):

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -353,7 +353,7 @@ def redirect(location, code=302):
     :param code: the redirect status code. defaults to 302.
     """
     from werkzeug.wrappers import BaseResponse
-    display_location = location
+    display_location = escape(location)
     if isinstance(location, unicode):
         from werkzeug.urls import iri_to_uri
         location = iri_to_uri(location)
@@ -363,7 +363,7 @@ def redirect(location, code=302):
         '<h1>Redirecting...</h1>\n'
         '<p>You should be redirected automatically to target URL: '
         '<a href="%s">%s</a>.  If not click the link.' %
-        (location, display_location), code, mimetype='text/html')
+        (escape(location, True), display_location), code, mimetype='text/html')
     response.headers['Location'] = location
     return response
 


### PR DESCRIPTION
If the application using werkzeug is permitting user input in redirect URL parameter, the redirect page has XSS risk.
I think this is not major case, but it is good to escape URL in redirect page by the werkzeug side.
