### PR TITLE
serving: restart with reloader manages the case when started from a frozen app

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -565,7 +565,11 @@ def restart_with_reloader():
     """
     while 1:
         _log('info', ' * Restarting with reloader')
-        args = [sys.executable] + sys.argv
+        args = [sys.executable]
+        if getattr(sys, 'frozen', False):
+            args.extend(sys.argv[1:])
+        else:
+            args.extend(sys.argv)
         new_environ = os.environ.copy()
         new_environ['WERKZEUG_RUN_MAIN'] = 'true'
 


### PR DESCRIPTION
This was once known as http://dev.pocoo.org/projects/werkzeug/ticket/475

The trouble happen when starting a werkzeug app from a mercurial extension from the tortoisehg's packaged mercurial (for instance). In this case hg.exe is the sys.executable and argv[0]. argv[0] then needs to be stripped off.
