### PR TITLE
Disable Chrome reflected XSS protection on debug page

### DIFF
--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -102,7 +102,10 @@ class DebuggedApplication(object):
 
             try:
                 start_response('500 INTERNAL SERVER ERROR', [
-                    ('Content-Type', 'text/html; charset=utf-8')
+                    ('Content-Type', 'text/html; charset=utf-8'),
+                    # Disable Chrome's XSS protection, the debug
+                    # output can cause false-positives.
+                    ('X-XSS-Protection', '0'),
                 ])
             except Exception:
                 # if we end up here there has been output but an error


### PR DESCRIPTION
Chrome was falsely detecting a potential XSS attack on the debug
console. This patch disables it on the debug page only with
`X-XSS-Protection: 0`
