### PR TITLE
Small fix to utils:get_content_type to use charset on application/json and application/javascript

### DIFF
--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -226,6 +226,8 @@ def get_content_type(mimetype, charset):
     """
     if mimetype.startswith('text/') or \
        mimetype == 'application/xml' or \
+       mimetype == 'application/json' or \
+       mimetype == 'application/javascript' or \
        (mimetype.startswith('application/') and
         mimetype.endswith('+xml')):
         mimetype += '; charset=' + charset


### PR DESCRIPTION
Without this fix, something like

response = make_response(some_json)
response.mimetype = 'application/json'

will strip the charset from the Content-Type header.
