### PR TITLE
Fix #120, disable redis tests if no connection

### DIFF
--- a/werkzeug/testsuite/contrib/cache.py
+++ b/werkzeug/testsuite/contrib/cache.py
@@ -19,6 +19,11 @@ from werkzeug.contrib import cache
 
 try:
     import redis
+    try:
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        cache.RedisCache(key_prefix='werkzeug-test-case:')._client.set('test','connection')
+    except RedisConnectionError:
+        redis = None
 except ImportError:
     redis = None
 


### PR DESCRIPTION
If the redis library is installed, an attempt is made to automatically
run redis unit tests. This might not work if redis is not running,
not local, etc, etc, etc. This patch will attempt to connect to redis
after the redis import, and will set redis = None if an attempted
connection fails, skipping the unit tests for redis as a result.
