### PR TITLE
Fix debug console scrolling issue

### DIFF
--- a/werkzeug/debug/shared/debugger.js
+++ b/werkzeug/debug/shared/debugger.js
@@ -150,7 +150,7 @@ function openShell(consoleNode, target, frameID) {
         });
         output.append(tmp);
         command.focus();
-        consoleNode.scrollTop(command.position().top);
+        consoleNode.scrollTop(consoleNode.get(0).scrollHeight);
         var old = history.pop();
         history.push(cmd);
         if (typeof old != 'undefined')


### PR DESCRIPTION
Fix a bug that would scroll upwards once a certain console height was reached. scrollHeight is an underlying DOM property which represents the height of an element's scrollable area.

I've been able to reproduce this issue both on firefox and chrome. Simply enter text into the debugger console 30 or so times, and the vertical scrollbar no longer scrolls along to the bottom.
