### PR TITLE
Add convenience method to access the full path.

### DIFF
--- a/werkzeug/testsuite/wrappers.py
+++ b/werkzeug/testsuite/wrappers.py
@@ -126,6 +126,7 @@ class WrappersTestCase(WerkzeugTestCase):
     def test_url_request_descriptors(self):
         req = wrappers.Request.from_values('/bar?foo=baz', 'http://example.com/test')
         assert req.path == u'/bar'
+        assert req.full_path == u'/bar?foo=baz'
         assert req.script_root == u'/test'
         assert req.url == 'http://example.com/test/bar?foo=baz'
         assert req.base_url == 'http://example.com/test/bar'

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -434,6 +434,11 @@ class BaseRequest(object):
         return _decode_unicode(path, self.url_charset, self.encoding_errors)
 
     @cached_property
+    def full_path(self):
+        """Requested path as unicode, including the query string."""
+        return self.path + u'?' + self.query_string
+
+    @cached_property
     def script_root(self):
         """The root path of the script without the trailing slash."""
         path = (self.environ.get('SCRIPT_NAME') or '').rstrip('/')


### PR DESCRIPTION
The "full path" is terminology for the request's path plus the query string.

The term is borrowed from Django, which implements the [get_full_path()](https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.get_full_path) method on requests.
