### PR TITLE
Small tweak to prevent a test failure on PyPy on OS X

### DIFF
--- a/werkzeug/testsuite/debug.py
+++ b/werkzeug/testsuite/debug.py
@@ -92,9 +92,7 @@ class DebugReprTestCase(WerkzeugTestCase):
             def __repr__(self):
                 1/0
 
-        assert debug_repr(Foo()) == \
-            u'<span class="brokenrepr">&lt;broken repr (ZeroDivisionError: ' \
-            u'integer division or modulo by zero)&gt;</span>'
+        assert debug_repr(Foo()).startswith(u'<span class="brokenrepr">&lt;broken repr (ZeroDivisionError: ')
 
 
 class DebugHelpersTestCase(WerkzeugTestCase):


### PR DESCRIPTION
On my machine at least with OS X 10.6.8 and PyPy 1.8.0, the
`ZeroDivisionError` text is slightly different:

```
debug_repr(Foo()) == u'<span class="brokenrepr">&lt;broken repr
(ZeroDivisionError: integer division by zero)&gt;</span>'
```

resulting in this test failure:

```
[last: 0] marca@SCML-MarcA:~/dev/git-repos/werkzeug$ .tox/pypy/bin/python run-tests.py 
.........................................................F........................................................................................................................................................................................................
======================================================================
FAIL: test_broken_repr (werkzeug.testsuite.debug.DebugReprTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/marca/dev/git-repos/werkzeug/werkzeug/testsuite/debug.py", line 96, in test_broken_repr
    u'<span class="brokenrepr">&lt;broken repr (ZeroDivisionError: ' \
AssertionError

----------------------------------------------------------------------
Ran 258 tests in 1.588s

FAILED (failures=1)
```
