### PR TITLE
Stop relying on the message text of ZeroDivisionError in tests.

### DIFF
--- a/werkzeug/testsuite/debug.py
+++ b/werkzeug/testsuite/debug.py
@@ -90,11 +90,11 @@ class DebugReprTestCase(WerkzeugTestCase):
     def test_broken_repr(self):
         class Foo(object):
             def __repr__(self):
-                1/0
+                raise Exception('broken!')
 
         assert debug_repr(Foo()) == \
-            u'<span class="brokenrepr">&lt;broken repr (ZeroDivisionError: ' \
-            u'integer division or modulo by zero)&gt;</span>'
+            u'<span class="brokenrepr">&lt;broken repr (Exception: ' \
+            u'broken!)&gt;</span>'
 
 
 class DebugHelpersTestCase(WerkzeugTestCase):


### PR DESCRIPTION
The test for broken_repr relied on the message text of
ZeroDivisionError, which is different on pypy (just "integer
division", not "integer division or modulo"). This causes a test
failure. Fix this by explicitly raising an exception with a message we
provide.
