### PR TITLE
Fix issue 185

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -771,18 +771,47 @@ class Rule(RuleFactory):
     def match_compare_key(self):
         """The match compare key for sorting.
 
-        Current implementation:
+        Sort the rule by the function:
+        (
+            number of static parts + weight fnc,
+            number of variable parts + weight fnc,
+            number of path parts + weight fnc
+        )
 
-        1.  rules without any arguments come first for performance
-            reasons only as we expect them to match faster and some
-            common ones usually don't have any arguments (index pages etc.)
-        2.  The more complex rules come first so the second argument is the
-            negative length of the number of weights.
-        3.  lastly we order by the actual weights.
+        where the weight function is the sum of the normalized
+        positions of the parts.
 
         :internal:
         """
-        return bool(self.arguments), -len(self._weights), self._weights
+
+
+        def weights(parts):
+            if parts == []:
+                  return (1000,1000,1000)
+
+            weights = [0,0,0]
+            count = len(parts)
+            norm = sum(range(1,count+1))
+
+
+            for part in zip(parts, range(count,0,-1)):
+                  pos = part[1]
+                  part_type = part[0][0]
+                  if part_type == None:
+                        index = 0
+                  elif part_type == 'path':
+                        index = 2
+                  else:
+                        index = 1
+                  weights[index] += 1 + pos / float(norm)
+
+            weights = [round(weight,3) for weight in weights]
+            return tuple(weights)
+
+
+        parts = parse_rule(self.rule)
+        parts = [part for part in parts if part != (None, None, '/')]
+        return weights(parts)
 
     def build_compare_key(self):
         """The build compare key for sorting.
@@ -1201,7 +1230,7 @@ class Map(object):
         in the correct order after things changed.
         """
         if self._remap:
-            self._rules.sort(key=lambda x: x.match_compare_key())
+            self._rules.sort(key=lambda x: x.match_compare_key(), reverse=True)
             for rules in self._rules_by_endpoint.itervalues():
                 rules.sort(key=lambda x: x.build_compare_key())
             self._remap = False

--- a/werkzeug/testsuite/routing.py
+++ b/werkzeug/testsuite/routing.py
@@ -175,6 +175,18 @@ class RoutingTestCase(WerkzeugTestCase):
         assert adapter.match('/Files/downloads/werkzeug/0.2.zip') == \
             ('files', {'file':'downloads/werkzeug/0.2.zip'})
 
+    def test_path_complex(self):
+        map = r.Map([
+            r.Rule('/', endpoint='index'),
+            r.Rule('/static/<path:filename>', endpoint='static'),
+            r.Rule('/<first>/', endpoint='first'),
+            r.Rule('/<first>/<second>/', endpoint='second'),
+            r.Rule('/<first>/<second>/<third>', endpoint='third'),
+        ])
+        adapter = map.bind('example.org', '/')
+        self.assertEquals(adapter.match('/'), ('index', {}))
+        self.assertEquals(adapter.match('/static/img/favicon.ico'), ('static', {'filename': 'img/favicon.ico'}))
+
     def test_dispatch(self):
         env = create_environ('/')
         map = r.Map([

--- a/werkzeug/testsuite/routing.py
+++ b/werkzeug/testsuite/routing.py
@@ -157,6 +157,7 @@ class RoutingTestCase(WerkzeugTestCase):
             r.Rule('/User:<username>', endpoint='user'),
             r.Rule('/User:<username>/<path:name>', endpoint='userpage'),
             r.Rule('/Files/<path:file>', endpoint='files'),
+            r.Rule('/<country>/<city>/<county>/<town>', endpoint='countrymap')
         ])
         adapter = map.bind('example.org', '/')
 
@@ -174,18 +175,6 @@ class RoutingTestCase(WerkzeugTestCase):
             ('userpage', {'username':'thomas', 'name':'projects/werkzeug'})
         assert adapter.match('/Files/downloads/werkzeug/0.2.zip') == \
             ('files', {'file':'downloads/werkzeug/0.2.zip'})
-
-    def test_path_complex(self):
-        map = r.Map([
-            r.Rule('/', endpoint='index'),
-            r.Rule('/static/<path:filename>', endpoint='static'),
-            r.Rule('/<first>/', endpoint='first'),
-            r.Rule('/<first>/<second>/', endpoint='second'),
-            r.Rule('/<first>/<second>/<third>', endpoint='third'),
-        ])
-        adapter = map.bind('example.org', '/')
-        self.assertEquals(adapter.match('/'), ('index', {}))
-        self.assertEquals(adapter.match('/static/img/favicon.ico'), ('static', {'filename': 'img/favicon.ico'}))
 
     def test_dispatch(self):
         env = create_environ('/')


### PR DESCRIPTION
This patch fixes the inconsistency brought up in issue #185 "Complex URL routes are sorted incorrectly".

Instead of simply sorting by the number of parts in a rule, the router would now be smart enough to sort by the types of parts in the rule as well. The new heuristic counts the number of static parts, path parts, and other parts and then sorts lexographically in order:
- number of static parts + weight fnc
- number of other parts + weight fnc
- number of path parts + weight fnc

where the weight function normalizes for the position of the various parts in the rule.
