### PR TITLE
Adding BlackBerry as UserAgent platform

### DIFF
--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -30,7 +30,8 @@ class UserAgentParser(object):
         ('aix', 'aix'),
         ('sco|unix_sv', 'sco'),
         ('bsd', 'bsd'),
-        ('amiga', 'amiga')
+        ('amiga', 'amiga'),
+        ('blackberry|playbook', 'blackberry')
     )
     browsers = (
         ('googlebot', 'google'),


### PR DESCRIPTION
Currently any BlackBerry device shows `None` as the user agent platform. Adding in the rule to check the user agent string for either `blackberry` or `playbook` would now show `blackberry` as the platform. The check for `playbook` is necessary as the playbook browser's default user agent string does not contain the word blackberry.
