### PR TITLE
Remove URL fragments in EnvironBuilder.

### DIFF
--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -259,6 +259,7 @@ class EnvironBuilder(object):
                  content_length=None, errors_stream=None, multithread=False,
                  multiprocess=False, run_once=False, headers=None, data=None,
                  environ_base=None, environ_overrides=None, charset='utf-8'):
+        path = path.split('#', 1)[0]  # remove any fragment
         if query_string is None and '?' in path:
             path, query_string = path.split('?', 1)
         self.charset = charset


### PR DESCRIPTION
Browsers remove URL fragments such as #foo before making an HTTP request.

Without this patch, EnvironBuilder leaves it either in QUERY_STRING or in
PATH_INFO, neither of which (I think) is the expected behavior.
