### PR TITLE
Allow exceptions to modify debugging tracebacks.

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -157,9 +157,7 @@ def get_current_traceback(ignore_system_exceptions=False,
             break
         tb = tb.tb_next
 
-    TB = Traceback
-    if hasattr(exc_value, "werkzeug_debug_traceback"):
-        TB = exc_value.werkzeug_debug_traceback
+    TB = getattr(exc_value, "werkzeug_debug_traceback", Traceback)
     tb = TB(exc_type, exc_value, tb)
 
     if not show_hidden_frames:

--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -156,7 +156,12 @@ def get_current_traceback(ignore_system_exceptions=False,
         if tb.tb_next is None:
             break
         tb = tb.tb_next
-    tb = Traceback(exc_type, exc_value, tb)
+
+    TB = Traceback
+    if hasattr(exc_value, "werkzeug_debug_traceback"):
+        TB = exc_value.werkzeug_debug_traceback
+    tb = TB(exc_type, exc_value, tb)
+
     if not show_hidden_frames:
         tb.filter_hidden_frames()
     return tb


### PR DESCRIPTION
Extremely simple, checks for a "exc.werkzeug_debug_traceback" method and invokes that instead of the Traceback constructor when the corresponding exception is raised. This is useful for packages (like Mako) that autogenerate code and need to separately annotate tracebacks to translate source lines.

For an example of this project's usefulness, see this commit in the flask-mako extension: AnIrishDuck/flask-mako@ea6a05171caba6ec2e094467cb8087a148e391e3. This commit vastly improves the debugging environment when errors occur inside Mako templates.
