### PR TITLE
Modified FileObject.save() method so that the file pointer

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2521,7 +2521,9 @@ class FileStorage(object):
         """Save the file to a destination path or file object.  If the
         destination is a file object you have to close it yourself after the
         call.  The buffer size is the number of bytes held in memory during
-        the copy process.  It defaults to 16KB.
+        the copy process.  It defaults to 16KB. The file pointer is reset
+        after the copy is complete to enable the save method to be invoked
+        multiple times.
 
         For secure file saving also have a look at :func:`secure_filename`.
 
@@ -2538,6 +2540,7 @@ class FileStorage(object):
             close_dst = True
         try:
             copyfileobj(self.stream, dst, buffer_size)
+            self.stream.seek(0)
         finally:
             if close_dst:
                 dst.close()


### PR DESCRIPTION
for the underlying stream is reset before the copyfileobj
call. This ensures that the FileObject.save() method can
be used multiple times (e.g. if you want to save the same
file in multiple locations)
