### PR TITLE
contrib.atom: Fix empty author tag bug in FeedEntry.

### DIFF
--- a/werkzeug/contrib/atom.py
+++ b/werkzeug/contrib/atom.py
@@ -273,7 +273,7 @@ class FeedEntry(object):
         self.updated = kwargs.get('updated')
         self.summary = kwargs.get('summary')
         self.summary_type = kwargs.get('summary_type', 'html')
-        self.author = kwargs.get('author')
+        self.author = kwargs.get('author', ())
         self.published = kwargs.get('published')
         self.rights = kwargs.get('rights')
         self.links = kwargs.get('links', [])


### PR DESCRIPTION
If no author is given, don't generate an empty author tag anymore.
