### PR TITLE
Update docs for FileStorage

### DIFF
--- a/docs/datastructures.rst
+++ b/docs/datastructures.rst
@@ -128,14 +128,6 @@ Others
 
       The name of the form field.
 
-   .. attribute:: content_type
-
-      The content type (mimetype) of the file.
-
-   .. attribute:: content_length
-
-      The length of the file in bytes.
-
    .. attribute:: headers
 
       The multipart headers as :class:`Headers` object.  This usually contains

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2486,12 +2486,12 @@ class FileStorage(object):
 
     @property
     def content_type(self):
-        """The file's content type.  Usually not available"""
+        """The content-type sent in the header.  Usually not available"""
         return self.headers.get('content-type')
 
     @property
     def content_length(self):
-        """The file's content length.  Usually not available"""
+        """The content-length sent in the header.  Usually not available"""
         return int(self.headers.get('content-length') or 0)
 
     @property


### PR DESCRIPTION
http://werkzeug.pocoo.org/docs/datastructures/#werkzeug.datastructures.FileStorage

FileStorage's .content_length and .content_type have duplicate documentation with different descriptions. The member documentation has been removed from datastructures.rst and the docstring in the @property's in datastructures.py has been updated to reflect the code. 
