### PR TITLE
Remove docs reference to import_module

### DIFF
--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -391,9 +391,6 @@ def import_string(import_name, silent=False):
 
     If `silent` is True the return value will be `None` if the import fails.
 
-    For better debugging we recommend the new :func:`import_module`
-    function to be used instead.
-
     :param import_name: the dotted name for the object to import.
     :param silent: if set to `True` import errors are ignored and
                    `None` is returned instead.


### PR DESCRIPTION
`import_module` was removed in 51bed5b, but a reference to it lives on in `import_string`'s docstring.
