### PR TITLE
Fixed contrib.fixers.ProxyFix for Apache 2.2

### DIFF
--- a/werkzeug/contrib/fixers.py
+++ b/werkzeug/contrib/fixers.py
@@ -104,9 +104,26 @@ class ProxyFix(object):
         if forwarded_for:
             return forwarded_for[0]
 
+    def get_protocol(self, environ):
+        """Determines the used protocol with either X-Forwarded-Proto or
+        X-Forwarded-Https.
+
+        .. versionadded:: 0.9
+        """
+        getter = environ.get
+        rv = getter('HTTP_X_FORWARDED_PROTO', '')
+        if not rv:
+            https = getter('HTTP_X_FORWARDED_HTTPS', '')
+            if https == 'on':
+                rv = 'https'
+            elif https == 'off':
+                rv = 'http'
+
+        return rv
+
     def __call__(self, environ, start_response):
         getter = environ.get
-        forwarded_proto = getter('HTTP_X_FORWARDED_PROTO', '')
+        forwarded_proto = self.get_protocol(environ)
         forwarded_for = getter('HTTP_X_FORWARDED_FOR', '').split(',')
         forwarded_host = getter('HTTP_X_FORWARDED_HOST', '')
         environ.update({


### PR DESCRIPTION
I am not using mod_proxy, but the following in a .htaccess for proxying:

```
RewriteEngine On
RewriteBase /
RewriteRule ^(.*)$ http://localhost:1234/$1 [P,L]
```

In this case, Apache doesn't seem to send a `X-Forwarded-Proto` header, but a `X-Forwarded-Https` which can have the value `on` or `off`. This pull request takes care of this misbehavior (?)
