### PR TITLE
Make Atom to print time zone offset for aware datetime

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ Release date and codename to be decided
   (issue ``#434``). This means that OpenSSL contexts are not supported anymore,
   but instead ``ssl.SSLContext`` from the stdlib.
 - Allow protocol-relative URLs when building external URLs.
+- Fixed Atom syndication to print time zone offset for tz-aware datetime
+  objects (pull request ``#254``).
 
 Version 0.9.7
 -------------

--- a/tests/contrib/test_atom.py
+++ b/tests/contrib/test_atom.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""
+    tests.atom
+    ~~~~~~~~~~
+
+    Tests the cache system
+
+    :copyright: (c) 2014 by Armin Ronacher.
+    :license: BSD, see LICENSE for more details.
+"""
+import datetime
+
+from werkzeug.contrib.atom import format_iso8601
+
+
+def test_format_iso8601():
+    # naive datetime should be treated as utc
+    dt = datetime.datetime(2014, 8, 31, 2, 5, 6)
+    assert format_iso8601(dt) == '2014-08-31T02:05:06Z'
+
+    # tz-aware datetime
+    dt = datetime.datetime(2014, 8, 31, 11, 5, 6, tzinfo=KST())
+    assert format_iso8601(dt) == '2014-08-31T11:05:06+09:00'
+
+
+class KST(datetime.tzinfo):
+    """KST implementation for test_format_iso8601()."""
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(hours=9)
+
+    def tzname(self, dt):
+        return 'KST'
+
+    def dst(self, dt):
+        return datetime.timedelta(0)

--- a/werkzeug/contrib/atom.py
+++ b/werkzeug/contrib/atom.py
@@ -44,7 +44,10 @@ def _make_text_block(name, content, content_type=None):
 
 def format_iso8601(obj):
     """Format a datetime object for iso8601"""
-    return obj.strftime('%Y-%m-%dT%H:%M:%SZ')
+    iso8601 = obj.isoformat()
+    if obj.tzinfo:
+        return iso8601
+    return iso8601 + 'Z'
 
 
 @implements_to_string
@@ -61,6 +64,7 @@ class AtomFeed(object):
     :param updated: the time the feed was modified the last time.  Must
                     be a :class:`datetime.datetime` object.  If not
                     present the latest entry's `updated` is used.
+                    Treated as UTC if naive datetime.
     :param feed_url: the URL to the feed.  Should be the URL that was
                      requested.
     :param author: the author of the feed.  Must be either a string (the
@@ -239,7 +243,8 @@ class FeedEntry(object):
     :param id: a globally unique id for the entry.  Must be an URI.  If
                not present the URL is used, but one of both is required.
     :param updated: the time the entry was modified the last time.  Must
-                    be a :class:`datetime.datetime` object. Required.
+                    be a :class:`datetime.datetime` object.  Treated as
+                    UTC if naive datetime. Required.
     :param author: the author of the entry.  Must be either a string (the
                    name) or a dict with name (required) and uri or
                    email (both optional).  Can be a list of (may be
@@ -247,7 +252,8 @@ class FeedEntry(object):
                    multiple authors. Required if the feed does not have an
                    author element.
     :param published: the time the entry was initially published.  Must
-                      be a :class:`datetime.datetime` object.
+                      be a :class:`datetime.datetime` object.  Treated as
+                      UTC if naive datetime.
     :param rights: copyright information for the entry.
     :param rights_type: the type attribute for the rights element.  One of
                         ``'html'``, ``'text'`` or ``'xhtml'``.  Default is


### PR DESCRIPTION
Previously it simply treated every `datetime.datetime` as UTC even if it has `tzinfo`.  It definitely seemed a bug, for example it printed `2013-01-22T01:56:30Z` for `datetime(2013, 1, 22, 1, 56, 30, tzinfo=FixedOffset(9))`.

(I could not find any unit test for `werkzeug.contrib.atom` module, so I skipped it.)
