### PR TITLE
Support for db number in redis cache with db defaulted to 0

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -484,7 +484,7 @@ class RedisCache(BaseCache):
                 import redis
             except ImportError:
                 raise RuntimeError('no redis module found')
-            self._client = redis.Redis(host=host, port=port, password=password)
+            self._client = redis.Redis(host=host, port=port, password=password, db=db)
         else:
             self._client = host
         self.key_prefix = key_prefix or ''


### PR DESCRIPTION
Redis allows multiple dbs with zero based numeric index. Added a option to select db on which to connect.
