### PR TITLE
Fixed documentation described in issue #232

### DIFF
--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -75,7 +75,7 @@ def parse_form_data(environ, stream_factory=None, charset='utf-8',
     :param max_form_memory_size: the maximum number of bytes to be accepted for
                            in-memory stored form data.  If the data
                            exceeds the value specified an
-                           :exc:`~exceptions.RequestURITooLarge`
+                           :exc:`~exceptions.RequestEntityTooLarge`
                            exception is raised.
     :param max_content_length: If this is provided and the transmitted data
                                is longer than this value an
@@ -118,7 +118,7 @@ class FormDataParser(object):
     :param max_form_memory_size: the maximum number of bytes to be accepted for
                            in-memory stored form data.  If the data
                            exceeds the value specified an
-                           :exc:`~exceptions.RequestURITooLarge`
+                           :exc:`~exceptions.RequestEntityTooLarge`
                            exception is raised.
     :param max_content_length: If this is provided and the transmitted data
                                is longer than this value an


### PR DESCRIPTION
The issue was described as: 

Positions of incorrect mention of `RequestURITooLarge`: 
- https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/formparser.py#L78
- https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/formparser.py#L121

Positions where `RequestEntityTooLarge` is raised from conditions relating to `max_form_memory_size`: 
- https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/formparser.py#L207
- https://github.com/mitsuhiko/werkzeug/blob/master/werkzeug/formparser.py#L339

I rebuilt the documentation and confirmed that the new documentation is correct.
