### PR TITLE
Fix relying on order of unordered types

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -700,6 +700,12 @@ class OrderedMultiDict(MultiDict):
     def itervalues(self):
         return (value for key, value in self.iteritems())
 
+    def keys(self):
+        return list(self.iterkeys())
+
+    def values(self):
+        return list(self.itervalues())
+
     def iteritems(self, multi=False):
         ptr = self._first_bucket
         if multi:

--- a/werkzeug/testsuite/http.py
+++ b/werkzeug/testsuite/http.py
@@ -238,8 +238,8 @@ class HTTPUtilityTestCase(WerkzeugTestCase):
     def test_dump_options_header(self):
         assert http.dump_options_header('foo', {'bar': 42}) == \
             'foo; bar=42'
-        assert http.dump_options_header('foo', {'bar': 42, 'fizz': None}) == \
-            'foo; bar=42; fizz'
+        assert http.dump_options_header('foo', {'bar': 42, 'fizz': None}) in \
+            ('foo; bar=42; fizz', 'foo; fizz; bar=42')
 
     def test_dump_header(self):
         assert http.dump_header([1, 2, 3]) == '1, 2, 3'

--- a/werkzeug/testsuite/urls.py
+++ b/werkzeug/testsuite/urls.py
@@ -63,7 +63,7 @@ class URLsTestCase(WerkzeugTestCase):
     def test_sorted_url_encode(self):
         assert urls.url_encode({"a": 42, "b": 23, 1: 1, 2: 2}, sort=True) == '1=1&2=2&a=42&b=23'
         assert urls.url_encode({'A': 1, 'a': 2, 'B': 3, 'b': 4}, sort=True,
-                          key=lambda x: x[0].lower()) == 'A=1&a=2&B=3&b=4'
+                          key=lambda x: x[0].lower() + x[0]) == 'A=1&a=2&B=3&b=4'
 
     def test_streamed_url_encoding(self):
         out = StringIO()

--- a/werkzeug/testsuite/wrappers.py
+++ b/werkzeug/testsuite/wrappers.py
@@ -307,7 +307,8 @@ class WrappersTestCase(WerkzeugTestCase):
         response.cache_control.must_revalidate = True
         response.cache_control.max_age = 60
         response.headers['Content-Length'] = len(response.data)
-        assert response.headers['Cache-Control'] == 'must-revalidate, max-age=60'
+        assert response.headers['Cache-Control'] in ('must-revalidate, max-age=60',
+                                                     'max-age=60, must-revalidate')
 
         assert 'date' not in response.headers
         env = create_environ()


### PR DESCRIPTION
Modified version of #234

All changed tests have in common that they assert a specific ordering of
an unordered data structure (dict or set). The assertions have been made
more liberal with respect to the order of entries.

Command used for finding failures of this kind:
for i in `seq 100`; do echo PYTHONHASHSEED=$i;
PYTHONHASHSEED=$i $PYTHON run-tests.py || break; done
