### PR TITLE
Fixes test suite failure under win32 (issue #275)

### DIFF
--- a/werkzeug/testsuite/formparser.py
+++ b/werkzeug/testsuite/formparser.py
@@ -134,7 +134,7 @@ class FormParserTestCase(WerkzeugTestCase):
                                   method='POST')
         # make sure we have a real file here, because we expect to be
         # on the disk.  > 1024 * 500
-        self.assert_(isinstance(req.files['foo'].stream, file))
+        self.assert_(hasattr(req.files['foo'].stream, 'fileno'))
 
 
 class MultiPartTestCase(WerkzeugTestCase):


### PR DESCRIPTION
`FormParserTestCase.test_large_file` failed on win32 because stdlib's `TemporaryFile` returns a `_TemporaryFileWrapper` and not a `file` as it does under posix systems. 
With this fix, the test checks that the stream has a `fileno` attribute instead of checking that it's a file with `isinstance(..., file)`.
