### PR TITLE
Fix: unicode fragments crash urls.iri_to_uri

### DIFF
--- a/werkzeug/testsuite/urls.py
+++ b/werkzeug/testsuite/urls.py
@@ -100,6 +100,11 @@ class URLsTestCase(WerkzeugTestCase):
         assert urls.iri_to_uri(u'http://☃.net/') == 'http://xn--n3h.net/'
         assert urls.iri_to_uri(u'http://üser:pässword@☃.net/påth') == \
             'http://%C3%BCser:p%C3%A4ssword@xn--n3h.net/p%C3%A5th'
+        self.assertEqual(urls.iri_to_uri(u'http://☃.net/?q=aع'),
+                         'http://xn--n3h.net/?q=a%D8%B9')
+        self.assertEqual(urls.iri_to_uri(u'http://☃.net/?q=a#bع'),
+                         'http://xn--n3h.net/?q=a#b%D8%B9')
+
 
         assert urls.uri_to_iri('http://test.com/%3Fmeh?foo=%26%2F') == \
             u'http://test.com/%3Fmeh?foo=%26%2F'

--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -143,6 +143,7 @@ def iri_to_uri(iri, charset='utf-8'):
 
     path = _quote(path.encode(charset), safe="/:~+%")
     query = _quote(query.encode(charset), safe="=%&[]:;$()+,!?*/")
+    fragment = _quote(fragment.encode(charset), safe="=%&[]:;$()+,!?*/")
 
     # this absolutely always must return a string.  Otherwise some parts of
     # the system might perform double quoting (#61)


### PR DESCRIPTION
Passing a URI containing a unicode fragment crashed urls.iri_to_uri
