### PR TITLE
Fixed DB path so that shorty runs on Windows

### DIFF
--- a/examples/manage-shorty.py
+++ b/examples/manage-shorty.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
+import os
+import tempfile
 from werkzeug import script
 
 def make_app():
     from shorty.application import Shorty
-    return Shorty('sqlite:////tmp/shorty.db')
+    filename = os.path.join(tempfile.gettempdir(), "shorty.db")
+    return Shorty('sqlite:///{0}'.format(filename))
 
 def make_shell():
     from shorty import models, utils


### PR DESCRIPTION
The shorty example used a hardcoded path for the db, and that makes it crash on Windows. Use tempfile.gettempdir instead.
