### PR TITLE
Allow dumping pstat.Stats file to a directory for each request.

### DIFF
--- a/werkzeug/contrib/profiler.py
+++ b/werkzeug/contrib/profiler.py
@@ -98,7 +98,7 @@ class ProfilerMiddleware(object):
 
         if self._profile_dir is not None:
             elapsedms = elapsed * 1000.0
-            prof_filename = os.path.join(self._profile_dir, "%s.%06dms.%d.prof" % ( (environ.get("PATH_INFO").strip("/").replace("/", ".") or "root"), elapsedms, time.time() ) )
+            prof_filename = os.path.join(self._profile_dir, "%s.%s.%06dms.%d.prof" % ( environ['REQUEST_METHOD'], (environ.get("PATH_INFO").strip("/").replace("/", ".") or "root"), elapsedms, time.time() ) )
             p.dump_stats(prof_filename)
 
         else:


### PR DESCRIPTION
This is inspired by django-extensions 'runprofileserver'. The ProfileMiddleware will, when given the `prof_directory` argument, will, for every request, save the profile stats to a file.

It allows more after-the-fact analysis looking at the output of print_stats. It also
allows use of graphical tools to analyse the stats.
