### PR TITLE
fixing securecookie.py

### DIFF
--- a/werkzeug/contrib/securecookie.py
+++ b/werkzeug/contrib/securecookie.py
@@ -236,7 +236,7 @@ class SecureCookie(ModificationTrackingDict):
         if isinstance(string, unicode):
             string = string.encode('utf-8', 'replace')
         if isinstance(secret_key, unicode):
-            secret_key = secret_key.encode('utf-8','replace')
+            secret_key = secret_key.encode('utf-8', 'replace')
         try:
             base64_hash, data = string.split('?', 1)
         except (ValueError, IndexError):


### PR DESCRIPTION
was having a problem with the hmac module in python dealing with unicode strings in this module, so i checked the instance and dealt with it if it happened like this.

basically hmac does not deal with unicode at all, and it creates a problem when inputting a unicode secret key,  namely the following:

``` python
TypeError: character mapping must return integer None or unicode
```

the problem is that hmac does not deal with unicode like the error messages makes the user believe, and throws this error instead.

I should note that this is not the best solution, because dropping unicode characters is not a good idea when you are dealing with a secret key, however, it seems to be the only solution i could think of, and is already implemented for the string (2 lines above my changes) object.

It's been pointed out that a Secret Key should be a random bytestring, and not unicode. I understand this, however feel that it is good practice to be safe about this.
