### PR TITLE
unicode -> six.text_type where safe

### DIFF
--- a/werkzeug/contrib/sessions.py
+++ b/werkzeug/contrib/sessions.py
@@ -66,6 +66,8 @@ from werkzeug.utils import dump_cookie, parse_cookie
 from werkzeug.wsgi import ClosingIterator
 from werkzeug.posixemulation import rename
 
+import six
+
 
 _sha1_re = re.compile(r'^[a-f0-9]{40}$')
 
@@ -211,7 +213,7 @@ class FilesystemSessionStore(SessionStore):
         if path is None:
             path = tempfile.gettempdir()
         self.path = path
-        if isinstance(filename_template, unicode):
+        if isinstance(filename_template, six.text_type):
             filename_template = filename_template.encode(
                 sys.getfilesystemencoding() or 'utf-8')
         assert not filename_template.endswith(_fs_transaction_suffix), \
@@ -224,7 +226,7 @@ class FilesystemSessionStore(SessionStore):
         # out of the box, this should be a strict ASCII subset but
         # you might reconfigure the session object to have a more
         # arbitrary string.
-        if isinstance(sid, unicode):
+        if isinstance(sid, six.text_type):
             sid = sid.encode(sys.getfilesystemencoding() or 'utf-8')
         return path.join(self.path, self.filename_template % sid)
 

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -34,7 +34,7 @@ except ImportError: # pragma: no cover
 import base64
 
 
-from six import next, iteritems, binary_type
+from six import next, iteritems, binary_type, text_type
 
 
 #: HTTP_STATUS_CODES is "exported" from this module.
@@ -817,7 +817,7 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
         key = str(key)
     except UnicodeError:
         raise TypeError('invalid key %r' % key)
-    if isinstance(value, unicode):
+    if isinstance(value, text_type):
         value = value.encode(charset)
     value = quote_header_value(value)
     morsel = _ExtendedMorsel(key, value)

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -109,6 +109,8 @@ from werkzeug.exceptions import HTTPException, NotFound, MethodNotAllowed
 from werkzeug._internal import _get_environ
 from werkzeug.datastructures import ImmutableDict, MultiDict
 
+import six
+
 
 _rule_re = re.compile(r'''
     (?P<static>[^<]*)                           # static rule data
@@ -1123,7 +1125,7 @@ class Map(object):
             subdomain = self.default_subdomain
         if script_name is None:
             script_name = '/'
-        if isinstance(server_name, unicode):
+        if isinstance(server_name, six.text_type):
             server_name = server_name.encode('idna')
         return MapAdapter(self, server_name, script_name, subdomain,
                           url_scheme, path_info, default_method, query_args)
@@ -1367,7 +1369,7 @@ class MapAdapter(object):
         self.map.update()
         if path_info is None:
             path_info = self.path_info
-        if not isinstance(path_info, unicode):
+        if not isinstance(path_info, six.text_type):
             path_info = path_info.decode(self.map.charset,
                                          self.map.encoding_errors)
         if query_args is None:

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -15,6 +15,8 @@ from six.moves import zip, xrange
 from random import SystemRandom
 from werkzeug.exceptions import BadRequest
 
+import six
+
 
 SALT_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
@@ -71,14 +73,14 @@ def _hash_internal(method, salt, password):
     if salt:
         if method not in _hash_funcs:
             return None
-        if isinstance(salt, unicode):
+        if isinstance(salt, six.text_type):
             salt = salt.encode('utf-8')
         h = hmac.new(salt, None, _hash_funcs[method])
     else:
         if method not in _hash_funcs:
             return None
         h = _hash_funcs[method]()
-    if isinstance(password, unicode):
+    if isinstance(password, six.text_type):
         password = password.encode('utf-8')
     h.update(password)
     return h.hexdigest()

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -272,7 +272,7 @@ class EnvironBuilder(object):
             path = iri_to_uri(path, charset)
         self.path = path
         if base_url is not None:
-            if isinstance(base_url, unicode):
+            if isinstance(base_url, six.text_type):
                 base_url = iri_to_uri(base_url, charset)
             else:
                 base_url = url_fix(base_url, charset)
@@ -533,7 +533,7 @@ class EnvironBuilder(object):
             result.update(self.environ_base)
 
         def _path_encode(x):
-            if isinstance(x, unicode):
+            if isinstance(x, six.text_type):
                 x = x.encode(self.charset)
             return url_unquote(x)
 

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -279,7 +279,7 @@ def secure_filename(filename):
 
     :param filename: the filename to secure
     """
-    if isinstance(filename, unicode):
+    if isinstance(filename, six.text_type):
         from unicodedata import normalize
         filename = normalize('NFKD', filename).encode('ascii', 'ignore')
     for sep in os.path.sep, os.path.altsep:
@@ -357,7 +357,7 @@ def redirect(location, code=302):
     """
     from werkzeug.wrappers import BaseResponse
     display_location = escape(location)
-    if isinstance(location, unicode):
+    if isinstance(location, six.text_type):
         from werkzeug.urls import iri_to_uri
         location = iri_to_uri(location)
     response = BaseResponse(

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -782,7 +782,7 @@ class BaseResponse(object):
     def _set_data(self, value):
         # if an unicode string is set, it's encoded directly so that we
         # can set the content length
-        if isinstance(value, unicode):
+        if isinstance(value, six.text_type):
             value = value.encode(self.charset)
         self.response = [value]
         if self.automatically_set_content_length:
@@ -845,7 +845,7 @@ class BaseResponse(object):
         if __debug__:
             _warn_if_string(self.response)
         for item in self.response:
-            if isinstance(item, unicode):
+            if isinstance(item, six.text_type):
                 yield item.encode(charset)
             else:
                 yield str(item)
@@ -993,7 +993,7 @@ class BaseResponse(object):
         # make sure the location header is an absolute URL
         if location is not None:
             old_location = location
-            if isinstance(location, unicode):
+            if isinstance(location, six.text_type):
                 location = iri_to_uri(location)
             if self.autocorrect_location_header:
                 location = urlparse.urljoin(
@@ -1005,7 +1005,7 @@ class BaseResponse(object):
 
         # make sure the content location is a URL
         if content_location is not None and \
-           isinstance(content_location, unicode):
+           isinstance(content_location, six.text_type):
             headers['Content-Location'] = iri_to_uri(content_location)
 
         # remove entity headers and set content length to zero if needed.

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -18,7 +18,7 @@ from zlib import adler32
 from time import time, mktime
 from datetime import datetime
 from functools import partial
-from six import iteritems, next, Iterator
+from six import iteritems, next, Iterator, text_type
 
 from werkzeug._compat import urlparse
 from werkzeug._internal import _patch_wrapper
@@ -109,7 +109,7 @@ def host_is_trusted(hostname, trusted_list):
     def _normalize(hostname):
         if ':' in hostname:
             hostname = hostname.rsplit(':', 1)[0]
-        if isinstance(hostname, unicode):
+        if isinstance(hostname, text_type):
             hostname = hostname.encode('idna')
         return hostname
 
@@ -259,7 +259,7 @@ def extract_path_info(environ_or_baseurl, path_or_url, charset='utf-8',
     from werkzeug.urls import uri_to_iri, url_fix
 
     def _as_iri(obj):
-        if not isinstance(obj, unicode):
+        if not isinstance(obj, text_type):
             return uri_to_iri(obj, charset, errors)
         return obj
 


### PR DESCRIPTION
This replaces every occurence of `unicode` with `six.text_type` where it is safe to do so for example in isinstance checks
