### PR TITLE
Add assert_true, assert_false proxies

### DIFF
--- a/werkzeug/testsuite/__init__.py
+++ b/werkzeug/testsuite/__init__.py
@@ -99,6 +99,12 @@ class WerkzeugTestCase(unittest.TestCase):
     def assert_is_instance(self, x, y):
         return self.assertIsInstance(x, y)
 
+    def assert_true(self, x):
+        return self.assertTrue(x)
+
+    def assert_false(self, x):
+        return self.assertFalse(x)
+
 
 class _ExceptionCatcher(object):
 


### PR DESCRIPTION
Those were used by the datastructures tests, but didn't exist.
