### PR TITLE
Use six.reraise where necessary

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -153,8 +153,8 @@ def get_current_traceback(ignore_system_exceptions=False,
     """
     exc_type, exc_value, tb = sys.exc_info()
     if ignore_system_exceptions and exc_type in system_exceptions:
-        raise
-    for x in xrange(skip):
+        six.reraise(exc_type, exc_value, tb)
+    for x in six.moves.xrange(skip):
         if tb.tb_next is None:
             break
         tb = tb.tb_next

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -432,7 +432,7 @@ class BaseWSGIServer(HTTPServer, object):
 
     def handle_error(self, request, client_address):
         if self.passthrough_errors:
-            raise
+            six.reraise(*sys.exc_info())
         else:
             return HTTPServer.handle_error(self, request, client_address)
 


### PR DESCRIPTION
Note: the re-raising in serving.py causes the serving testcases to hang
