### PR TITLE
Fix utils test suite errors

### DIFF
--- a/werkzeug/testsuite/__init__.py
+++ b/werkzeug/testsuite/__init__.py
@@ -99,6 +99,12 @@ class WerkzeugTestCase(unittest.TestCase):
     def assert_is_instance(self, x, y):
         return self.assertIsInstance(x, y)
 
+    def assert_true(self, x):
+        return self.assertTrue(x)
+
+    def assert_false(self, x):
+        return self.assertFalse(x)
+
 
 class _ExceptionCatcher(object):
 

--- a/werkzeug/testsuite/utils.py
+++ b/werkzeug/testsuite/utils.py
@@ -127,7 +127,7 @@ class GeneralUtilityTestCase(WerkzeugTestCase):
 
         app_iter, status, headers = run_wsgi_app(foo, {})
         self.assert_equal(status, '200 OK')
-        self.assert_equal(headers, [('Content-Type', 'text/plain')])
+        self.assert_equal(list(headers), [('Content-Type', 'text/plain')])
         self.assert_equal(next(app_iter), '1')
         self.assert_equal(next(app_iter), '2')
         self.assert_equal(next(app_iter), '3')
@@ -153,7 +153,7 @@ class GeneralUtilityTestCase(WerkzeugTestCase):
 
         app_iter, status, headers = run_wsgi_app(bar, {})
         self.assert_equal(status, '200 OK')
-        self.assert_equal(headers, [('Content-Type', 'text/plain')])
+        self.assert_equal(list(headers), [('Content-Type', 'text/plain')])
         self.assert_equal(next(app_iter), 'bar')
         self.assert_raises(StopIteration, partial(next, app_iter))
         app_iter.close()


### PR DESCRIPTION
Previous fix was apparently overwritten, this re-adds `assert_true`, `assert_false` and coerces Header objects to lists for comparisons.
