### PR TITLE
Fix BaseResponse.get_wsgi_headers

### DIFF
--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -996,10 +996,10 @@ class BaseResponse(object):
             if isinstance(location, six.text_type):
                 location = iri_to_uri(location)
             if self.autocorrect_location_header:
-                location = urlparse.urljoin(
-                    get_current_url(environ, root_only=True),
-                    location
-                )
+                current_url = get_current_url(environ, root_only=True)
+                if isinstance(current_url, six.text_type):
+                    current_url = iri_to_uri(current_url)
+                location = urlparse.urljoin(current_url, location)
             if location != old_location:
                 headers['Location'] = location
 


### PR DESCRIPTION
This fixes several errors related to "Cannot mix str and non-str arguments" on many tests.
