### PR TITLE
EnvironHeaders returns unicode values

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1224,8 +1224,8 @@ class EnvironHeaders(ImmutableHeadersMixin, Headers):
         # used because get() calls it.
         key = key.upper().replace('-', '_')
         if key in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
-            return self.environ[key]
-        return self.environ['HTTP_' + key]
+            return _unicodify_value(self.environ[key])
+        return _unicodify_value(self.environ['HTTP_' + key])
 
     def __len__(self):
         # the iter is necessary because otherwise list calls our
@@ -1236,9 +1236,11 @@ class EnvironHeaders(ImmutableHeadersMixin, Headers):
         for key, value in iteritems(self.environ):
             if key.startswith('HTTP_') and key not in \
                ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
-                yield key[5:].replace('_', '-').title(), value
+                yield (key[5:].replace('_', '-').title(),
+                       _unicodify_value(value))
             elif key in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
-                yield key.replace('_', '-').title(), value
+                yield (key.replace('_', '-').title(),
+                       _unicodify_value(value))
 
     def copy(self):
         raise TypeError('cannot create %r copies' % self.__class__.__name__)

--- a/werkzeug/testsuite/datastructures.py
+++ b/werkzeug/testsuite/datastructures.py
@@ -23,6 +23,7 @@ import pickle
 from copy import copy
 from werkzeug.testsuite import WerkzeugTestCase
 from six.moves import xrange
+from six import text_type
 from werkzeug._compat import iterkeys, itervalues, iteritems, iterlists, \
     iterlistvalues
 
@@ -625,6 +626,20 @@ class EnvironHeadersTestCase(WerkzeugTestCase):
         ])
         assert not self.storage_class({'wsgi.version': (1, 0)})
         self.assert_equal(len(self.storage_class({'wsgi.version': (1, 0)})), 0)
+
+    def test_return_type_is_unicode(self):
+        # environ contains native strings; we return unicode
+        headers = self.storage_class({
+            'HTTP_FOO': '\xe2\x9c\x93',
+            'CONTENT_TYPE': 'text/plain',
+        })
+        self.assert_equal(headers['Foo'], u"\xe2\x9c\x93")
+        assert isinstance(headers['Foo'], text_type)
+        assert isinstance(headers['Content-Type'], text_type)
+        iter_output = dict(iter(headers))
+        self.assert_equal(iter_output['Foo'], u"\xe2\x9c\x93")
+        assert isinstance(iter_output['Foo'], text_type)
+        assert isinstance(iter_output['Content-Type'], text_type)
 
 
 class HeaderSetTestCase(WerkzeugTestCase):


### PR DESCRIPTION
Resubmitting patch. This time it keeps the original environ and coerces to unicode on output.
