### PR TITLE
Add iPad check in useragents.py

### DIFF
--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -19,6 +19,7 @@ class UserAgentParser(object):
 
     platforms = (
         ('iphone|ios', 'iphone'),
+        ('ipad', 'ipad'),
         (r'darwin|mac|os\s*x', 'macos'),
         ('win', 'windows'),
         (r'android', 'android'),
@@ -107,6 +108,7 @@ class UserAgent(object):
        -   `bsd`
        -   `hpux`
        -   `iphone`
+       -   `ipad`
        -   `irix`
        -   `linux`
        -   `macos`


### PR DESCRIPTION
Currently, useragent.py doesn't detect iPads as an iOS device. This pull request adds 'ipad' as different useragent type, since it is foreseeable that one would want to differentiate between iPhones/iPods from iPads when serving content.
