### PR TITLE
Handle pop() and setdefault() correctly in UpdateDictMixin and add some testcases

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -227,12 +227,27 @@ class UpdateDictMixin(object):
         oncall.__name__ = name
         return oncall
 
+    def setdefault(self, key, default=None):
+        modified = key not in self
+        rv = super(UpdateDictMixin, self).setdefault(key, default)
+        if modified and self.on_update is not None:
+            self.on_update(self)
+        return rv
+
+    def pop(self, key, default=_missing):
+        modified = key in self
+        if default is _missing:
+            rv = super(UpdateDictMixin, self).pop(key)
+        else:
+            rv = super(UpdateDictMixin, self).pop(key, default)
+        if modified and self.on_update is not None:
+            self.on_update(self)
+        return rv
+
     __setitem__ = calls_update('__setitem__')
     __delitem__ = calls_update('__delitem__')
     clear = calls_update('clear')
-    pop = calls_update('pop')
     popitem = calls_update('popitem')
-    setdefault = calls_update('setdefault')
     update = calls_update('update')
     del calls_update
 

--- a/werkzeug/testsuite/datastructures.py
+++ b/werkzeug/testsuite/datastructures.py
@@ -729,6 +729,10 @@ class CallbackDictTestCase(WerkzeugTestCase):
             'a' in dct
             list(iter(dct))
             dct.copy()
+        with assert_calls(0, 'callback triggered without modification'):
+            # methods that may write but don't
+            dct.pop('z', None)
+            dct.setdefault('a')
 
     def test_callback_dict_writes(self):
         assert_calls, func = make_call_asserter(self.assert_equal)
@@ -744,8 +748,10 @@ class CallbackDictTestCase(WerkzeugTestCase):
             dct.popitem()
             dct.update([])
             dct.clear()
-        with assert_calls(0, 'callback triggered by failed write'):
+        with assert_calls(0, 'callback triggered by failed del'):
             self.assert_raises(KeyError, lambda: dct.__delitem__('x'))
+        with assert_calls(0, 'callback triggered by failed pop'):
+            self.assert_raises(KeyError, lambda: dct.pop('x'))
 
 
 def suite():


### PR DESCRIPTION
`pop()` and `setdefault()` should only trigger `on_update` if the dict was actually modified.

Additionally there were no testcases so I added some.
