### PR TITLE
Make SharedDataMiddleware support overlapping paths

### DIFF
--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -434,7 +434,8 @@ class SharedDataMiddleware(object):
         self.exports = OrderedDict() if OrderedDict else {}
         self.cache = cache
         self.cache_timeout = cache_timeout
-        for key, value in getattr(exports, 'iteritems', exports.__iter__)():
+        iterator = exports.iteritems() if isinstance(exports, dict) else exports
+        for key, value in iterator:
             if isinstance(value, tuple):
                 loader = self.get_package_loader(*value)
             elif isinstance(value, string_types):

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -434,7 +434,7 @@ class SharedDataMiddleware(object):
         self.exports = OrderedDict() if OrderedDict else {}
         self.cache = cache
         self.cache_timeout = cache_timeout
-        iterator = exports.iteritems() if isinstance(exports, dict) else exports
+        iterator = iteritems(exports) if isinstance(exports, dict) else exports
         for key, value in iterator:
             if isinstance(value, tuple):
                 loader = self.get_package_loader(*value)

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -18,6 +18,13 @@ from zlib import adler32
 from time import time, mktime
 from datetime import datetime
 from functools import partial
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        OrderedDict = None
 
 from werkzeug._compat import iteritems, text_type, string_types, \
      implements_iterator, make_literal_wrapper, to_unicode, to_bytes, \
@@ -424,10 +431,10 @@ class SharedDataMiddleware(object):
     def __init__(self, app, exports, disallow=None, cache=True,
                  cache_timeout=60 * 60 * 12, fallback_mimetype='text/plain'):
         self.app = app
-        self.exports = {}
+        self.exports = OrderedDict() if OrderedDict else {}
         self.cache = cache
         self.cache_timeout = cache_timeout
-        for key, value in iteritems(exports):
+        for key, value in getattr(exports, 'iteritems', exports.__iter__)():
             if isinstance(value, tuple):
                 loader = self.get_package_loader(*value)
             elif isinstance(value, string_types):


### PR DESCRIPTION
I have a setup where I might have static dir mappings like this:

/static/cms/ => DirA
/static/cms/plugin => DirB

In other words, they overlap. To handle such a scenario properly, one would need to search the path by prefix length, trying the longest one first.

This seems like something the would be reasonable to support in the StaticMiddleware. I see two possible approaches:

(1) Make StaticMiddleware sort by prefix length while searching.

(2) Use a OrderedDict to maintain whatever order the user specified.

I went with (2) because it's the "don't involve yourself / don't introduce behaviour" option. The downside is that it requires a OrderedDict implementation, which werkzeug does not include as far as I can tell; so I made this optional: If OrderedDict is not available, it works as it always has.

I also allow the list of exports to be passed as a list of 2-tuples, so that the caller does not have to construct an additional OrderedDict.
