### PR TITLE
Add default templates for HTTP 504 & 505

### DIFF
--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -536,6 +536,30 @@ class ServiceUnavailable(HTTPException):
     )
 
 
+class GatewayTimeout(HTTPException):
+    """*504* `Gateway Timeout`
+
+    Status code you should return if a connection to an upstream server
+    times out.
+    """
+    code = 504
+    description = (
+        'The connection to an upstream server timed out.'
+    )
+
+
+class HTTPVersionNotSupported(HTTPException):
+    """*505* `HTTP Version Not Supported`
+
+    The server does not support the HTTP protocol version used in the request.
+    """
+    code = 505
+    description = (
+        'The server does not support the HTTP protocol version used in the '
+        'request.'
+    )
+
+
 default_exceptions = {}
 __all__ = ['HTTPException']
 

--- a/werkzeug/testsuite/exceptions.py
+++ b/werkzeug/testsuite/exceptions.py
@@ -54,6 +54,8 @@ class ExceptionsTestCase(WerkzeugTestCase):
         self.assert_raises(exceptions.NotImplemented, abort, 501)
         self.assert_raises(exceptions.BadGateway, abort, 502)
         self.assert_raises(exceptions.ServiceUnavailable, abort, 503)
+        self.assert_raises(exceptions.GatewayTimeout, abort, 504)
+        self.assert_raises(exceptions.HTTPVersionNotSupported, abort, 505)
 
         myabort = exceptions.Aborter({1: exceptions.NotFound})
         self.assert_raises(LookupError, myabort, 404)


### PR DESCRIPTION
I use flask quite a lot for building restful web services. There often comes a time for the app to `abort(504)`, however this results in a `TemplateNotFound` exception being thrown, as flask doesn't come with a template for this HTTP error out of the box. 

This branch fixes this for HTTP 504 and 505. I scanned over http://en.wikipedia.org/wiki/List_of_HTTP_status_codes for others to add, but didn't find any that were missing and that looked like they could be useful. 

If there were some I missed which I should add to this branch, just let me know.
