### PR TITLE
HTTPException.code vs BaseResponse.status_code

### DIFF
--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -102,6 +102,10 @@ class HTTPException(Exception):
         return newcls
 
     @property
+    def status_code(self):
+        return self.code
+
+    @property
     def name(self):
         """The status name."""
         return HTTP_STATUS_CODES.get(self.code, 'Unknown Error')


### PR DESCRIPTION
Small change here: I just added a `status_code` property to `HTTPException`, which makes it more consistent with `BaseResponse`. 

It's just a basic `@property`, since `HTTPException`s aren't really writable responses (the HTTP headers always return `Content-Type: text/html`, for instance). Maybe someday there'll be a merger? In the meantime, this.
