### PR TITLE
Avoid jquery conflict when client has already loaded with other version ...

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -49,6 +49,7 @@ HEADER = u'''\
     <script type="text/javascript" src="?__debugger__=yes&amp;cmd=resource&amp;f=jquery.js"></script>
     <script type="text/javascript" src="?__debugger__=yes&amp;cmd=resource&amp;f=debugger.js"></script>
     <script type="text/javascript">
+      $.noConflict();
       var TRACEBACK = %(traceback_id)d,
           CONSOLE_MODE = %(console)s,
           EVALEX = %(evalex)s,


### PR DESCRIPTION
I client has been loaded with some version of jquery. Werkeug debugger traceback error page also have jquery dependency so it create mess at client side.  
