### PR TITLE
Fix decode error when using wsgi container and enter erroneous url.

### DIFF
--- a/werkzeug/_compat.py
+++ b/werkzeug/_compat.py
@@ -89,12 +89,12 @@ if PY2:
     wsgi_get_bytes = _identity
 
     def wsgi_decoding_dance(s, charset='utf-8', errors='replace'):
-        return s.decode(charset)
+        return s.decode(charset, errors)
 
     def wsgi_encoding_dance(s, charset='utf-8', errors='replace'):
         if isinstance(s, bytes):
             return s
-        return s.encode(charset)
+        return s.encode(charset, errors)
 
     def to_bytes(x, charset=sys.getdefaultencoding(), errors='strict'):
         if x is None:


### PR DESCRIPTION
You can know below url is erroneous utf-8 url.
 http://foo.bar/%EB%82%98%EC%99

If upper one inputted default server, it hasn't problem. But upper one inputted wsgi container, occur below error.

```
      File "/home/username/pyenv/local/lib/python2.7/site-packages/werkzeug/routing.py", line 1202, in bind_to_environ
        path_info = _get_wsgi_string('PATH_INFO')
      File "/home/username/pyenv/local/lib/python2.7/site-packages/werkzeug/routing.py", line 1199, in _get_wsgi_string
        return wsgi_decoding_dance(val, self.charset)
      File "/home/username/pyenv/local/lib/python2.7/site-packages/werkzeug/_compat.py", line 92, in wsgi_decoding_dance
        return s.decode(charset)
      File "/home/username/pyenv/lib/python2.7/encodings/utf_8.py", line 16, in decode
        return codecs.utf_8_decode(input, errors, True)
    UnicodeDecodeError: 'utf8' codec can't decode bytes in position 3-4: unexpected end of data
```

This pull request fixed that error.
