### PR TITLE
redis.StrictRedis compatibility for contrib.cache.RedisCache

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -527,7 +527,8 @@ class RedisCache(BaseCache):
         try:
             import redis
             #redis.StrictRedis reverses the 2nd and 3rd arguments to setex
-            if isinstance(self._client, redis.StrictRedis):
+            if isinstance(self._client, redis.StrictRedis) \
+                    and not isinstance(self._client, redis.Redis):
                 (dump, timeout) = (timeout, dump)
         except ImportError:
             pass
@@ -550,7 +551,8 @@ class RedisCache(BaseCache):
             try:
                 import redis
                 #redis.StrictRedis reverses the 2nd and 3rd arguments to setex
-                if isinstance(self._client, redis.StrictRedis):
+                if isinstance(self._client, redis.StrictRedis) \
+                        and not isinstance(self._client, redis.Redis):
                     (dump, timeout) = (timeout, dump)
             except ImportError:
                 pass


### PR DESCRIPTION
redis's StrictRedis changes the argument order for a few methods: `lrem`, `setex`, `zadd`. Of the 3, RedisCache uses `setex`, so swap the arguments if we can possibly detect that it's necessary.
