### PR TITLE
Add UUIDConverter to default converters

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -102,6 +102,7 @@ try:
     from urlparse import urljoin
 except ImportError:
     from urllib.parse import urljoin
+import uuid
 
 from werkzeug.urls import url_encode, url_quote
 from werkzeug.utils import redirect, format_string
@@ -971,6 +972,22 @@ class FloatConverter(NumberConverter):
         NumberConverter.__init__(self, map, 0, min, max)
 
 
+class UUIDConverter(BaseConverter):
+    """This converter only accepts UUID strings::
+
+        Rule('/object/<uuid:identifier>')
+
+    :param map: the :class:`Map`.
+    """
+    regex = r'[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}'
+
+    def to_python(self, value):
+        return uuid.UUID(value)
+
+    def to_url(self, value):
+        return str(value)
+
+
 #: the default converter mapping for the map.
 DEFAULT_CONVERTERS = {
     'default':          UnicodeConverter,
@@ -978,7 +995,8 @@ DEFAULT_CONVERTERS = {
     'any':              AnyConverter,
     'path':             PathConverter,
     'int':              IntegerConverter,
-    'float':            FloatConverter
+    'float':            FloatConverter,
+    'uuid':             UUIDConverter
 }
 
 

--- a/werkzeug/testsuite/routing.py
+++ b/werkzeug/testsuite/routing.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import unittest
+import uuid
 
 from werkzeug.testsuite import WerkzeugTestCase
 
@@ -421,6 +422,14 @@ class RoutingTestCase(WerkzeugTestCase):
         assert a.match('/b/2') == ('b', {'b': '2'})
         assert a.match('/c/3') == ('c', {'c': '3'})
         assert 'foo' not in r.Map.default_converters
+
+    def test_uuid_converter(self):
+        m = r.Map([
+            r.Rule('/a/<uuid:a_uuid>', endpoint='a')
+        ])
+        a = m.bind('example.org', '/')
+        rooute, kwargs =  a.match('/a/a8098c1a-f86e-11da-bd1a-00112444be1e')
+        assert type(kwargs['a_uuid']) == uuid.UUID
 
     def test_build_append_unknown(self):
         map = r.Map([


### PR DESCRIPTION
Defines a `UUIDConverter` class for matching uuids in URLs and
converting them into python `uuid.UUID` objects.
