### PR TITLE
Making sure serving.run_with_reloader works as it should. Making sure th...

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -501,7 +501,12 @@ def _iter_module_files():
             else:
                 if filename[-4:] in ('.pyc', '.pyo'):
                     filename = filename[:-1]
-                yield filename
+
+                # Make sure that gevent semaphore as gevent core are excluded from the list
+                # If included, @werkzeug.serving.run_with_reloader is completely unusable. It will 
+                # detect change in gevent/_semaphore.so and gevent/core.so every second
+                if not filename.endswith('gevent/_semaphore.so') and not filename.endswith('gevent/core.so'):
+                    yield filename
 
 
 def _reloader_stat_loop(extra_files=None, interval=1):


### PR DESCRIPTION
Hi!

Probably there are better approaches to implement this but ...

When you try to use `@werkzeug.serving.run_with_reloader` with gevent-socketio like in the snippet bellow  it will become very unstable.

This is happening when using: gevent 1.0 RC2

``` python
@werkzeug.serving.run_with_reloader
def serve_programmableio():
    shared_app = SharedDataMiddleware(app, { '/': os.path.join(os.path.dirname(__file__), 'static') })

    SocketIOServer(
        (app.config['SERVICE_IP'], app.config['SERVICE_PORT']), 
        DebuggedApplication(shared_app),
        resource         = app.config['SOCKET_IO_NAMESPACE'], 
        policy_server    = app.config['SOCKET_IO_POLICY_SERVER'],
        policy_listener  = ( app.config['SOCKET_IO_POLICY_LISTENER_HOST'], app.config['SOCKET_IO_POLICY_LISTENER_PORT'] )
    ).serve_forever()
```

What happens is that 2 gevent files are constantly modified `/gevent/_semaphore.so` and `/gevent/core.so` so you will get  something like this executed every second:

``` shell
 * Restarting with reloader
 * Detected change in '/home/nevio/.python-eggs/gevent-1.0rc2-py2.7-linux-i686.egg-tmp/gevent/_semaphore.so', reloading
```

or

``` shell
 * Restarting with reloader
 * Detected change in '/home/nevio/.python-eggs/gevent-1.0rc2-py2.7-linux-i686.egg-tmp/gevent/core.so', reloading
```

Hope this helps!
