### PR TITLE
Add default callback and release callbacks to LocalStack

### DIFF
--- a/werkzeug/local.py
+++ b/werkzeug/local.py
@@ -112,11 +112,17 @@ class LocalStack(object):
     .. versionadded:: 0.6.1
     """
 
-    def __init__(self):
+    def __init__(self, default_callback=None, release_callbacks=()):
         self._local = Local()
+        self.default_callback = default_callback
+        self.release_callbacks = release_callbacks
 
     def __release_local__(self):
-        self._local.__release_local__()
+        try:
+            self._local.__release_local__()
+        finally:
+            for callback in self.release_callbacks:
+                callback()
 
     def _get__ident_func__(self):
         return self._local.__ident_func__
@@ -162,6 +168,10 @@ class LocalStack(object):
         try:
             return self._local.stack[-1]
         except (AttributeError, IndexError):
+            if self.default_callback is not None:
+                rv = self.default_callback()
+                self.push(rv)
+                return rv
             return None
 
 


### PR DESCRIPTION
A possible use, with SQLAlchemy

``` python
_dbsession_stack = LocalStack(DBSession, (DBSession.remove, ))
dbsession = _dbsession_stack()
local_manager = LocalManager([_dbsession_stack])

@local_manager.middleware
def application(environ, start_response):
    # Do something with dbsession here
    start_response('200 OK', [('Content-Type', 'text/plain')])
    return ['Hello World']
```

compared to pushing everytime, if the callback consumes a lot of resource (CPU, memory, etc.) this approach can save the resource when the stack is not used anywhere.
