### PR TITLE
fix TypeError in session.generate_key

### DIFF
--- a/werkzeug/contrib/sessions.py
+++ b/werkzeug/contrib/sessions.py
@@ -74,7 +74,7 @@ _sha1_re = re.compile(r'^[a-f0-9]{40}$')
 def _urandom():
     if hasattr(os, 'urandom'):
         return os.urandom(30)
-    return random()
+    return str(random())
 
 
 def generate_key(salt=None):


### PR DESCRIPTION
In genrate_key function (session.py), TypeError occurrs if os.urandom function does not exist.
This is because _urandom function in session.py return float object by random.random, and generate_key function intend to call join function with the float object.

This issue does not occurred if os.urandom exists, because os.urandom returns byte string.
