### PR TITLE
fix Location header key to Unicode

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1190,7 +1190,7 @@ class Headers(object):
         :return: list
         """
         if PY2:
-            return [(k, v.encode('latin1')) for k, v in self]
+            return [(k.encode('ascii'), v.encode('latin1')) for k, v in self]
         return list(self)
 
     def copy(self):


### PR DESCRIPTION
Location header key is unicode in case of relative redirects, breaks uwsgi.
See https://github.com/mitsuhiko/flask/issues/758

@mitsuhiko fixed the bug however reopened by @puzzlet's patch(https://github.com/mitsuhiko/werkzeug/commit/6049a4ff3c5224bedd24cdb29a23a5f1a9c2bf43)
