### PR TITLE
Use built-in ssl module

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -334,16 +334,17 @@ def make_ssl_devcert(base_path, host=None, cn=None):
 
 def generate_adhoc_ssl_context():
     """Generates an adhoc SSL context for the development server."""
+    from OpenSSL import crypto
     import tempfile
     cert, pkey = generate_adhoc_ssl_pair()
     cert_handle, cert_file = tempfile.mkstemp()
     pkey_handle, pkey_file = tempfile.mkstemp()
-    os.write(cert_handle, cert)
-    os.write(pkey_handle, key)
+    os.write(cert_handle, crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+    os.write(pkey_handle, crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
     os.close(cert_handle)
     os.close(pkey_handle)
     ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-    ctx.load_cert_chain(cert_file.name, pkey_file.name)
+    ctx.load_cert_chain(cert_file, pkey_file)
     os.unlink(cert_file)
     os.unlink(pkey_file)
     return ctx


### PR DESCRIPTION
I had some issues trying to get SSL/TLS to work with python version 3.3. Consistent with this experience, **test_ssl_context_adhoc** fails for me on that version. #434 reports one of several issues I saw.

To fix this, I've ripped out all direct dependence on **OpenSSL.SSL**, and replaced that with python's built-in (since v2.6) **ssl** module. The **_SSLConnectionFix** class is gone completely, and a few related functions use **ssl.SSLContext** instead of **OpenSSL.SSL.Context**. I've left in everything from **OpenSSL.crypto**, since that seemed not to cause any problems. All tests pass on v3.3 with this update.

I don't know if this is the sort of thing the maintainers want. There are a few issues with what I've done here. First, the API has changed, since **ssl.SSLContext** is not a direct replacement for **OpenSSL.SSL.Context**. Also, **load_ssl_context()** now takes an additional (optional) parameter, **protocol**. This parameter may be one of the _PROTOCOL_SSLv23_ (the default), _PROTOCOL_SSLv3_, or _PROTOCOL_TLSv1_ constants defined in **ssl**.

The existing code used the **OpenSSL.tsafe.Connection** class. Thread safety is probably important to _someone_ who is using werkzeug to serve SSL, and I think I'm breaking that. **tsafe** is not the best-supported of modules, however, since it still has an **apply()** call, and **apply()** has been deprecated since v2.3. I'm open to suggestions: should we just rip off the **tsafe** code and drop it directly in werkzeug? Or should we not worry about it and tell everyone not to share any particular **SSLContext** instance among multiple threads?
