### PR TITLE
Explain how to quit the debug server

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -695,8 +695,9 @@ def run_simple(hostname, port, application, use_reloader=False,
         display_hostname = hostname != '*' and hostname or 'localhost'
         if ':' in display_hostname:
             display_hostname = '[%s]' % display_hostname
-        _log('info', ' * Running on %s://%s:%d/', ssl_context is None
-             and 'http' or 'https', display_hostname, port)
+        quit_msg = '(Press CTRL+C to quit)'
+        _log('info', ' * Running on %s://%s:%d/ %s', ssl_context is None
+             and 'http' or 'https', display_hostname, port, quit_msg)
     if use_reloader:
         # Create and destroy a socket so that any exceptions are raised before
         # we spawn a separate Python interpreter and lose this ability.


### PR DESCRIPTION
Many new users start the server in debug mode locally, then don't know how to
kill it or "get their terminal back" after the Werkzeug server starts. This
adds a short message explaining how to quit the server and "get your terminal
back". CTRL+C works on Mac and Linux and according to the IRC channel, Windows
as well, otherwise we'd probably want to customize the message depending on the
host OS.

My frustration here comes from watching more than a few new Flask users struggle with 
the server and the terminal in general and a gentle hint might help explain how to get
back to the terminal prompt.

This message is similar to Python's "Use quit() or Ctrl-D (i.e. EOF) to exit"
when you type "quit" in the REPL.
