### PR TITLE
Parametrize the Response class in utils.redirect.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,8 @@ Release date and codename to be decided
 - Added message that explains how to quit the server.
 - Fixed a bug on Python 2, that caused ``len`` for 
   :class:`werkzeug.datastructures.CombinedMultiDict` to crash.
+- Added support for specifying a ``Response`` subclass to use when calling
+  :func:`~werkzeug.utils.redirect`\ .
 
 Version 0.9.5
 -------------

--- a/werkzeug/testsuite/utils.py
+++ b/werkzeug/testsuite/utils.py
@@ -61,6 +61,16 @@ class GeneralUtilityTestCase(WerkzeugTestCase):
         resp = utils.redirect(location)
         self.assert_not_in(b'href="http://example.com/?xss="onmouseover="alert(1)"', resp.get_data())
 
+    def test_redirect_with_custom_Response(self):
+        class MyResponse(BaseResponse):
+            pass
+
+        location = "http://example.com/redirect"
+        resp = utils.redirect(location, Response=MyResponse)
+
+        self.assert_is_instance(resp, MyResponse)
+        self.assert_equal(resp.headers['Location'], location)
+
     def test_cached_property(self):
         foo = []
         class A(object):

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -335,7 +335,7 @@ def unescape(s):
     return _entity_re.sub(handle_match, s)
 
 
-def redirect(location, code=302):
+def redirect(location, code=302, Response=None):
     """Return a response object (a WSGI application) that, if called,
     redirects the client to the target location.  Supported codes are 301,
     302, 303, 305, and 307.  300 is not supported because it's not a real
@@ -346,10 +346,18 @@ def redirect(location, code=302):
        The location can now be a unicode string that is encoded using
        the :func:`iri_to_uri` function.
 
+    .. versionadded:: 0.10
+        The class used for the Response object can now be passed in.
+
     :param location: the location the response should redirect to.
     :param code: the redirect status code. defaults to 302.
+    :param class Response: a Response class to use when instantiating a
+        response. The default is :class:`werkzeug.wrappers.Response` if
+        unspecified.
     """
-    from werkzeug.wrappers import Response
+    if Response is None:
+        from werkzeug.wrappers import Response
+
     display_location = escape(location)
     if isinstance(location, text_type):
         from werkzeug.urls import iri_to_uri


### PR DESCRIPTION
Allows specifying a custom Response class (subclass) when redirecting.
