### PR TITLE
Properly show tracebacks when filepaths contain non ascii values

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -378,7 +378,11 @@ class Frame(object):
         # if it's a file on the file system resolve the real filename.
         if os.path.isfile(fn):
             fn = os.path.realpath(fn)
-        self.filename = fn.decode('utf-8')
+        try:
+            fn = text_type(fn)
+        except UnicodeError:
+            fn = str(fn).decode('utf-8', 'replace')
+        self.filename = fn
         self.module = self.globals.get('__name__')
         self.loader = self.globals.get('__loader__')
         self.code = tb.tb_frame.f_code


### PR DESCRIPTION
I had a flask project running from a folder called "Arbeitsfläche" there was a bug in my code which caused werkzeug to show the debug page. The page could not be shown though because of the non ascii value in the path (werkzeug simply crashed). This small commit fixes this and allows me to see the traceback in the browser output.
