### PR TITLE
Pass extra named args from RedisCache.__init__ to the Redis.__init__

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -502,14 +502,14 @@ class RedisCache(BaseCache):
     """
 
     def __init__(self, host='localhost', port=6379, password=None,
-                 db=0, default_timeout=300, key_prefix=None):
+                 db=0, default_timeout=300, key_prefix=None, **kwargs):
         BaseCache.__init__(self, default_timeout)
         if isinstance(host, string_types):
             try:
                 import redis
             except ImportError:
                 raise RuntimeError('no redis module found')
-            self._client = redis.Redis(host=host, port=port, password=password, db=db)
+            self._client = redis.Redis(host=host, port=port, password=password, db=db, **kwargs)
         else:
             self._client = host
         self.key_prefix = key_prefix or ''


### PR DESCRIPTION
The Redis can be accessed not only via TCP socket but also by UNIX socket: [`unix_socket_path`](https://github.com/andymccurdy/redis-py#connections) parameter allows this.
But it is impossible now to pass such argument to `Redis` class through `RedisCache` class.

This change allows to feed `Redis` with any extra argument like `connection_pool` or `decode_responses`.
