### PR TITLE
recognize IE11 as MSIE, fix #460

### DIFF
--- a/werkzeug/testsuite/wrappers.py
+++ b/werkzeug/testsuite/wrappers.py
@@ -347,7 +347,9 @@ class WrappersTestCase(WerkzeugTestCase):
              'google', None, '2.1', None),
             ('Mozilla/5.0 (X11; CrOS armv7l 3701.81.0) AppleWebKit/537.31 '
              '(KHTML, like Gecko) Chrome/26.0.1410.57 Safari/537.31',
-             'chrome', 'chromeos', '26.0.1410.57', None)
+             'chrome', 'chromeos', '26.0.1410.57', None),
+            ('Mozilla/5.0 (Windows NT 6.3; Trident/7.0; .NET4.0E; rv:11.0) like Gecko',
+             'msie', 'windows', '11.0', None)
         ]
         for ua, browser, platform, version, lang in user_agents:
             request = wrappers.Request({'HTTP_USER_AGENT': ua})

--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -51,7 +51,7 @@ class UserAgentParser(object):
         ('konqueror', 'konqueror'),
         ('k-meleon', 'kmeleon'),
         ('netscape', 'netscape'),
-        (r'msie|microsoft\s+internet\s+explorer', 'msie'),
+        (r'msie|microsoft\s+internet\s+explorer|trident/.+? rv:', 'msie'),
         ('lynx', 'lynx'),
         ('links', 'links'),
         ('seamonkey|mozilla', 'seamonkey')


### PR DESCRIPTION
Detect IE11's new user agent based on:
- http://blogs.msdn.com/b/ieinternals/archive/2013/09/21/internet-explorer-11-user-agent-string-ua-string-sniffing-compatibility-with-gecko-webkit.aspx
- http://msdn.microsoft.com/en-us/library/ie/ms537503(v=vs.85).aspx#UATokenRef
