### PR TITLE
Made source code input encoding explicitly UTF-8

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -460,7 +460,7 @@ class Frame(object):
 
         if source is None:
             try:
-                f = open(self.filename)
+                f = open(self.filename, encoding='utf-8')
             except IOError:
                 return []
             try:


### PR DESCRIPTION
I was using werkzeug with flask and I got an internal server error because the traceback code failed at displaying a unicode string.
