### PR TITLE
Moved unquoting of slashes in url to after routing

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -834,6 +834,7 @@ class BaseConverter(object):
         self.map = map
 
     def to_python(self, value):
+        value = value.replace('%2F', '/')
         return value
 
     def to_url(self, value):

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -78,7 +78,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             self.server.shutdown_signal = True
 
         url_scheme = self.server.ssl_context is None and 'http' or 'https'
-        path_info = url_unquote(request_url.path)
+        path_info = url_unquote(request_url.path, unsafe='/')
 
         environ = {
             'wsgi.version':         (1, 0),

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -548,7 +548,7 @@ class EnvironBuilder(object):
             result.update(self.environ_base)
 
         def _path_encode(x):
-            return wsgi_encoding_dance(url_unquote(x, self.charset), self.charset)
+            return wsgi_encoding_dance(url_unquote(x, self.charset, unsafe='/'), self.charset)
 
         qs = wsgi_encoding_dance(self.query_string)
 


### PR DESCRIPTION
The unquoting of slashes is done before routing and this is creating an unexpected behavior.
See the following related issue in the repo for flask:
https://github.com/mitsuhiko/flask/issues/900
