### PR TITLE
Remove duplicate test for utils.import_string.

### DIFF
--- a/werkzeug/testsuite/utils.py
+++ b/werkzeug/testsuite/utils.py
@@ -180,7 +180,6 @@ class GeneralUtilityTestCase(WerkzeugTestCase):
         self.assert_is(utils.import_string('cgi:escape'), cgi.escape)
         self.assert_is_none(utils.import_string('XXXXXXXXXXXX', True))
         self.assert_is_none(utils.import_string('cgi.XXXXXXXXXXXX', True))
-        self.assert_is(utils.import_string(u'cgi.escape'), cgi.escape)
         self.assert_is(utils.import_string(u'werkzeug.debug.DebuggedApplication'), DebuggedApplication)
         self.assert_raises(ImportError, utils.import_string, 'XXXXXXXXXXXXXXXX')
         self.assert_raises(ImportError, utils.import_string, 'cgi.XXXXXXXXXX')


### PR DESCRIPTION
Removes duplicate test of:

``` python

self.assert_is(utils.import_string(u'cgi.escape'), cgi.escape)
```

on https://github.com/tony/werkzeug/commit/c4429f245f9e51aefd1cc49ccac688b5d9f4ed16#diff-4af618d8be4053d1aaa0862448b1609cL179 and https://github.com/tony/werkzeug/commit/c4429f245f9e51aefd1cc49ccac688b5d9f4ed16#diff-4af618d8be4053d1aaa0862448b1609cL183.
