### PR TITLE
Added request.values_with_files

### DIFF
--- a/werkzeug/testsuite/wrappers.py
+++ b/werkzeug/testsuite/wrappers.py
@@ -581,6 +581,7 @@ class WrappersTestCase(WerkzeugTestCase):
             method='POST'
         )
         foo = req.files['foo']
+        self.assert_equal(req.values_with_files["foo"], foo)
         self.assert_equal(foo.mimetype, 'text/plain')
         self.assert_equal(foo.filename, 'foo.txt')
 

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -495,6 +495,16 @@ class BaseRequest(object):
         return CombinedMultiDict(args)
 
     @cached_property
+    def values_with_files(self):
+        """Combined multi dict for :attr:`values` and :attr:`files`."""
+        args = []
+        for d in self.values, self.files:
+            if not isinstance(d, MultiDict):
+                d = MultiDict(d)
+            args.append(d)
+        return CombinedMultiDict(args)
+
+    @cached_property
     def files(self):
         """:class:`~werkzeug.datastructures.MultiDict` object containing
         all uploaded files.  Each key in :attr:`files` is the name from the


### PR DESCRIPTION
Useful for wtforms integration.

For a form with FileField fields, you can create the form instance with: `form = MyForm(request.values_with_files)`
