### PR TITLE
Use reprs of values in _CacheControl.

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1840,9 +1840,11 @@ class _CacheControl(UpdateDictMixin, dict):
         return self.to_header()
 
     def __repr__(self):
-        return '<%s %r>' % (
+        return '<%s %s>' % (
             self.__class__.__name__,
-            self.to_header()
+            " ".join(
+                "{0}={1!r}".format(k, v) for k, v in sorted(self.iteritems())
+            ),
         )
 
 

--- a/werkzeug/testsuite/datastructures.py
+++ b/werkzeug/testsuite/datastructures.py
@@ -803,6 +803,17 @@ class CallbackDictTestCase(WerkzeugTestCase):
             self.assert_raises(KeyError, lambda: dct.pop('x'))
 
 
+class CacheControlTestCase(WerkzeugTestCase):
+    def test_repr(self):
+        cc = datastructures.RequestCacheControl(
+            [("max-age", "0"), ("private", "True")],
+        )
+        self.assert_equal(
+            repr(cc),
+            "<RequestCacheControl max-age='0' private='True'>",
+        )
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(MultiDictTestCase))
@@ -817,4 +828,5 @@ def suite():
     suite.addTest(unittest.makeSuite(HeaderSetTestCase))
     suite.addTest(unittest.makeSuite(NativeItermethodsTestCase))
     suite.addTest(unittest.makeSuite(CallbackDictTestCase))
+    suite.addTest(unittest.makeSuite(CacheControlTestCase))
     return suite


### PR DESCRIPTION
Prevents things like:

```
exceptions.AssertionError: <ResponseCacheControl 'no-cache=True, no-store=True, private=True, max-age=0'> != <ResponseCacheControl 'no-cache=True, no-store=True, private=True, max-age=0'>
```

caused by using `to_header` in there.
