### PR TITLE
Fix IterO.readline

### DIFF
--- a/werkzeug/contrib/iterio.py
+++ b/werkzeug/contrib/iterio.py
@@ -305,7 +305,10 @@ class IterO(IterIO):
             nl_pos = self._buf.find(_newline(self._buf), self.pos)
         buf = []
         try:
-            pos = self.pos
+            if self._buf is None:
+                pos = self.pos
+            else:
+                pos = len(self._buf)
             while nl_pos < 0:
                 item = next(self._gen)
                 local_pos = item.find(_newline(item))

--- a/werkzeug/testsuite/contrib/iterio.py
+++ b/werkzeug/testsuite/contrib/iterio.py
@@ -42,6 +42,13 @@ class IterOTestSuite(WerkzeugTestCase):
         io.seek(0)
         self.assert_equal(io.readlines(), ['Hello\n', 'World!'])
 
+        io = IterIO(['Line one\nLine ', 'two\nLine three'])
+        self.assert_equal(list(io), ['Line one\n', 'Line two\n', 'Line three'])
+        io = IterIO(iter('Line one\nLine two\nLine three'))
+        self.assert_equal(list(io), ['Line one\n', 'Line two\n', 'Line three'])
+        io = IterIO(['Line one\nL', 'ine', ' two', '\nLine three'])
+        self.assert_equal(list(io), ['Line one\n', 'Line two\n', 'Line three'])
+
         io = IterIO(["foo\n", "bar"])
         io.seek(-4, 2)
         self.assert_equal(io.read(4), '\nbar')


### PR DESCRIPTION
The old version fails when the source iterator doesn't always emit complete lines.
