### PR TITLE
check for a NoneType iterable

### DIFF
--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -78,11 +78,12 @@ def _assert_not_shallow(request):
 
 
 def _iter_encoded(iterable, charset):
-    for item in iterable:
-        if isinstance(item, text_type):
-            yield item.encode(charset)
-        else:
-            yield item
+    if iterable is not None:
+        for item in iterable:
+            if isinstance(item, text_type):
+                yield item.encode(charset)
+            else:
+                yield item
 
 
 class BaseRequest(object):


### PR DESCRIPTION
While working on a Flask application, I ran into the following backtrace:

> Traceback (most recent call last):
> File "/path/to/venv/lib/python2.7/site-packages/werkzeug/wsgi.py", line 682, in **next**
>     return self._next()
> File "/path/to/venv/lib/python2.7/site-packages/werkzeug/wrappers.py", line 82, in _iter_encoded
>     for item in iterable:
> TypeError: 'NoneType' object is not iterable

This was hit when the "request.method == 'OPTIONS'" (which apparently does not have anything to encode?).
