### PR TITLE
Don't send response reason-phrase in all caps.

### DIFF
--- a/werkzeug/testsuite/wrappers.py
+++ b/werkzeug/testsuite/wrappers.py
@@ -253,14 +253,14 @@ class WrappersTestCase(WerkzeugTestCase):
     def test_response_status_codes(self):
         response = wrappers.BaseResponse()
         response.status_code = 404
-        self.assert_strict_equal(response.status, '404 NOT FOUND')
+        self.assert_strict_equal(response.status, '404 Not Found')
         response.status = '200 OK'
         self.assert_strict_equal(response.status_code, 200)
         response.status = '999 WTF'
         self.assert_strict_equal(response.status_code, 999)
         response.status_code = 588
         self.assert_strict_equal(response.status_code, 588)
-        self.assert_strict_equal(response.status, '588 UNKNOWN')
+        self.assert_strict_equal(response.status, '588 Unknown')
         response.status = 'wtf'
         self.assert_strict_equal(response.status_code, 0)
         self.assert_strict_equal(response.status, '0 wtf')

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -847,9 +847,9 @@ class BaseResponse(object):
     def _set_status_code(self, code):
         self._status_code = code
         try:
-            self._status = '%d %s' % (code, HTTP_STATUS_CODES[code].upper())
+            self._status = '%d %s' % (code, HTTP_STATUS_CODES[code])
         except KeyError:
-            self._status = '%d UNKNOWN' % code
+            self._status = '%d Unknown' % code
     status_code = property(_get_status_code, _set_status_code,
                            doc='The HTTP Status code as number')
     del _get_status_code, _set_status_code


### PR DESCRIPTION
Can't see a good reason to capitalize the reason phrase, as discussed in issue #522. Request to change?
