### PR TITLE
Fix import_string masking of AttributeError

### DIFF
--- a/werkzeug/testsuite/__init__.py
+++ b/werkzeug/testsuite/__init__.py
@@ -36,9 +36,10 @@ def get_temporary_directory():
 def iter_suites(package):
     """Yields all testsuites."""
     for module in find_modules(package, include_packages=True):
-        mod = __import__(module, fromlist=['*'])
-        if hasattr(mod, 'suite'):
-            yield mod.suite()
+        if module != 'werkzeug.testsuite.foo':
+            mod = __import__(module, fromlist=['*'])
+            if hasattr(mod, 'suite'):
+                yield mod.suite()
 
 
 def find_all_tests(suite):

--- a/werkzeug/testsuite/foo/__init__.py
+++ b/werkzeug/testsuite/foo/__init__.py
@@ -1,0 +1,6 @@
+from . import bar
+if bar.first_import:
+    bar.first_import = False
+    raise AttributeError("Test")
+else:
+    pass

--- a/werkzeug/testsuite/foo/bar.py
+++ b/werkzeug/testsuite/foo/bar.py
@@ -1,0 +1,1 @@
+first_import = True

--- a/werkzeug/testsuite/utils.py
+++ b/werkzeug/testsuite/utils.py
@@ -183,6 +183,7 @@ class GeneralUtilityTestCase(WerkzeugTestCase):
         self.assert_is(utils.import_string(u'werkzeug.debug.DebuggedApplication'), DebuggedApplication)
         self.assert_raises(ImportError, utils.import_string, 'XXXXXXXXXXXXXXXX')
         self.assert_raises(ImportError, utils.import_string, 'cgi.XXXXXXXXXX')
+        self.assert_raises(AttributeError, utils.import_string, 'werkzeug.testsuite.foo:foo')
 
     def test_find_modules(self):
         self.assert_equal(list(utils.find_modules('werkzeug.debug')), \

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -408,14 +408,24 @@ def import_string(import_name, silent=False):
         # if the module is a package
         if PY2 and isinstance(obj, unicode):
             obj = obj.encode('utf-8')
+
+        # Don't mask out AttributeErrors during import
         try:
-            return getattr(__import__(module, None, None, [obj]), obj)
-        except (ImportError, AttributeError):
-            # support importing modules not yet set up by the parent module
-            # (or package for that matter)
-            modname = module + '.' + obj
-            __import__(modname)
-            return sys.modules[modname]
+            mod = __import__(module, None, None, [obj])
+        except ImportError:
+            mod = None
+
+        if mod:
+            try:
+                return getattr(mod, obj)
+            except AttributeError:
+                pass
+
+        # support importing modules not yet set up by the parent module
+        # (or package for that matter)
+        modname = module + '.' + obj
+        __import__(modname)
+        return sys.modules[modname]
     except ImportError as e:
         if not silent:
             reraise(


### PR DESCRIPTION
- Fixes edge case where import_string hides AttributeErrors happening
  inside the module being imported, and instead raises them wrongly as
  ImportErrors. The included test case may look very sought, but in
  large applications this may happen. In our case it was during replacement
  of warnings.showwarnings (closes #182).
