### PR TITLE
Fix for handling multiple request headers with same name in run_simple

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -104,10 +104,13 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             'SERVER_PROTOCOL':      self.request_version
         }
 
-        for key, value in self.headers.items():
-            key = 'HTTP_' + key.upper().replace('-', '_')
+        for header in self.headers.keys():
+            key = 'HTTP_' + header.upper().replace('-', '_')
             if key not in ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
-                environ[key] = value
+                if hasattr(self.headers, 'getheaders'):
+                    environ[key] = ', '.join(self.headers.getheaders(header))
+                else:
+                    environ[key] = ', '.join(self.headers.get_all(header))
 
         if request_url.netloc:
             environ['HTTP_HOST'] = request_url.netloc


### PR DESCRIPTION
Werkzeug didn't properly translate headers from HTTP to WSGI environ, having multiple headers with the same name. It would only keep the value of the last occurrence. Fixes https://github.com/mitsuhiko/flask/issues/850
