### PR TITLE
Add the OS environment variables to the request headers

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -112,7 +112,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         if request_url.netloc:
             environ['HTTP_HOST'] = request_url.netloc
 
-        for key, value in os.environ.iteritems():
+        for key, value in os.environ.items():
             if key not in environ:
                 environ[key] = value
 


### PR DESCRIPTION
Werkzeug does not add the OS environment variables to the request headers, however this can sometimes be helpful (eg, specifying the REMOTE_USER when developing with Django). This patch adds the OS environment variables to the request headers.
