### PR TITLE
Update tbtools.py to handle non-ascii files

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -461,7 +461,7 @@ class Frame(object):
 
         if source is None:
             try:
-                f = open(self.filename, encoding='utf8', errors='replace')
+                f = open(self.filename, mode='rb')
             except IOError:
                 return []
             try:


### PR DESCRIPTION
When reading a non-ascii source file, a UnicodeDecodeError exception may occur. It's better to assume the file is UTF-8 instead of ASCII.
