### PR TITLE
MemcachedCache timeouts are now standardised.

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -343,7 +343,7 @@ class MemcachedCache(BaseCache):
         if self.key_prefix:
             key = self.key_prefix + key
         # memcached doesn't support keys longer than that.  Because often
-        # checks for so long keys can occour because it's tested from user
+        # checks for so long keys can occur because it's tested from user
         # submitted data etc we fail silently for getting.
         if _test_memcached_key(key):
             return self._client.get(key)
@@ -375,6 +375,7 @@ class MemcachedCache(BaseCache):
     def add(self, key, value, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
+        timeout += int(time())
         if isinstance(key, text_type):
             key = key.encode('utf-8')
         if self.key_prefix:
@@ -384,6 +385,7 @@ class MemcachedCache(BaseCache):
     def set(self, key, value, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
+        timeout += int(time())
         if isinstance(key, text_type):
             key = key.encode('utf-8')
         if self.key_prefix:
@@ -397,6 +399,7 @@ class MemcachedCache(BaseCache):
     def set_many(self, mapping, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
+        timeout += int(time())
         new_mapping = {}
         for key, value in _items(mapping):
             if isinstance(key, text_type):


### PR DESCRIPTION
MemcachedCache forwards its timeout parameter to the native Memcache client.
This has an unexpected behaviour of timeouts greater than 2592000 seconds
(30 days) are treated as unix timestamps. By appending the current unix time
to all timestamps, MemcachedCache's behaviour matches that of the other Caches
provided in cache.py.
