### PR TITLE
hmac.compare_digest does not accept mixed string/unicode arguments.

### DIFF
--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -130,7 +130,11 @@ def safe_str_cmp(a, b):
     .. versionadded:: 0.7
     """
     if _builtin_safe_str_cmp is not None:
-        return _builtin_safe_str_cmp(a, b)
+        # Comparing buffers and strings does not work
+        if type(a) is type(b):
+            return _builtin_safe_str_cmp(a, b)
+        else:
+            return _builtin_safe_str_cmp(to_bytes(a), to_bytes(b))
     if len(a) != len(b):
         return False
     rv = 0


### PR DESCRIPTION
hmac.compare_digest has been backported to Python 2.7.7. It does not like comparisons between Unicode and String. At all. This is by design: http://bugs.python.org/issue21306

```
DEBUG:pybble.manager.main:Serving requests.
ERROR:pybble:Exception on /admin/login [POST]
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1836, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1491, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1395, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1489, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1475, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/srv/www/pybble/pybble/blueprint/_root/login.py", line 64, in do_login
    if not u.check_password(form.password.data):
  File "/srv/www/pybble/pybble/core/models/user.py", line 77, in check_password
    return security.check_password_hash(self.password,password)
  File "/usr/lib/python2.7/dist-packages/werkzeug/security.py", line 240, in check_password_hash
    return safe_str_cmp(_hash_internal(method, salt, password)[0], hashval)
  File "/usr/lib/python2.7/dist-packages/werkzeug/security.py", line 133, in safe_str_cmp
return _builtin_safe_str_cmp(a, b)
```
