### PR TITLE
Fix bug in try_coerce_native

### DIFF
--- a/werkzeug/_compat.py
+++ b/werkzeug/_compat.py
@@ -82,7 +82,7 @@ if PY2:
         leave it as unicode.
         """
         try:
-            return str(s)
+            return to_native(s)
         except UnicodeError:
             return s
 


### PR DESCRIPTION
In Python 3:

```
str(b'foo')
```

will return the repr instead of a decoded string.
