### PR TITLE
fix for Jython flask reload subprocess issue https://gist.github.com/pao...

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -649,8 +649,6 @@ def detect_executable():
 
         args = [java_exe] + classpath + input_args + ['org.python.util.jython'] + sys.argv 
         
-        print "args: {0}".format(args)
-        
         return args, (is_windows and is_jython)
 
 def run_with_reloader(main_func, extra_files=None, interval=1):

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -637,9 +637,10 @@ def detect_executable():
         bean = mgmt.ManagementFactory.getRuntimeMXBean()
         
         input_args = bean.getInputArguments()
-        classpath = [bean.getClassPath()]
-        if len(classpath) > 0:
-            classpath.insert(0, '-cp')
+        cp_string = bean.getClassPath()
+        classpath = []
+        if cp_string:
+            classpath += ['-cp', cp_string]
             
         #Check if we're on Windows
         os_bean = mgmt.ManagementFactory.getOperatingSystemMXBean()

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -610,6 +610,9 @@ def restart_with_reloader():
             return exit_code
 
 def detect_executable():
+    '''When sys.executable is None, try to detect how Python was started.
+    Currently only supports Jython.
+    '''
     #Standalone Jython won't refresh properly
     #https://gist.github.com/paolodina/b98c3f3a159024584e13
     import platform
@@ -649,6 +652,7 @@ def detect_executable():
 
         args = [java_exe] + classpath + input_args + ['org.python.util.jython'] + sys.argv 
         
+        #Return args and whether shell is required
         return args, (is_windows and is_jython)
 
 def run_with_reloader(main_func, extra_files=None, interval=1):

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -587,47 +587,12 @@ def restart_with_reloader():
     while 1:
         _log('info', ' * Restarting with reloader')
 
-        is_jython = False
-        is_windows = False
+        requires_shell = False
 
         if sys.executable:
             args = [sys.executable] + sys.argv
         else:
-            #Standalone Jython won't refresh properly
-            #https://gist.github.com/paolodina/b98c3f3a159024584e13
-            import platform
-
-            #Check if platform is jython
-            if platform.python_implementation().lower() == 'jython':
-                import java
-                
-                #when running Jython with -jar, rt.jar doesn't get imported
-                try:
-                    import java.lang.management as mgmt
-                except ImportError:
-                    _log('info', "ERROR: java.lang.management namespace is broken. Please make sure your CLASSPATH includes rt.jar.")
-                    raise ImportError
-
-                is_jython = True
-                
-                #get the args passed to the java exe and the classpath
-                bean = mgmt.ManagementFactory.getRuntimeMXBean()
-                
-                input_args = bean.getInputArguments()
-                classpath = [bean.getClassPath()]
-                if len(classpath) > 0:
-                    classpath.insert(0, '-cp')
-                    
-                #check if we're on Windows
-                os_bean = mgmt.ManagementFactory.getOperatingSystemMXBean()
-                os_name = os_bean.getName().lower()
-                
-                is_windows = os_name.startswith('windows')
-                
-                #get the Java exe name
-                java_exe = os.path.join(java.lang.System.getProperty('java.home'), 'bin', 'java')
-
-                args = [java_exe] + classpath + input_args + ['org.python.util.jython'] + sys.argv 
+            args, requires_shell = detect_executable()
 
         new_environ = os.environ.copy()
         new_environ['WERKZEUG_RUN_MAIN'] = 'true'
@@ -640,10 +605,53 @@ def restart_with_reloader():
                 if isinstance(value, text_type):
                     new_environ[key] = value.encode('iso-8859-1')
 
-        exit_code = subprocess.call(args, env=new_environ, shell=(is_jython and is_windows))
+        exit_code = subprocess.call(args, env=new_environ, shell=requires_shell)
         if exit_code != 3:
             return exit_code
 
+def detect_executable():
+    #Standalone Jython won't refresh properly
+    #https://gist.github.com/paolodina/b98c3f3a159024584e13
+    import platform
+
+    is_jython = False
+    is_windows = False
+
+    #Check if platform is jython
+    if platform.python_implementation().lower() == 'jython':
+        import java
+        
+        #when running Jython with -jar, rt.jar doesn't get imported
+        try:
+            import java.lang.management as mgmt
+        except ImportError:
+            _log('error', "ERROR: java.lang.management namespace is broken. Please make sure your CLASSPATH includes rt.jar.")
+            raise ImportError
+
+        is_jython = True
+        
+        #get the args passed to the java exe and the classpath
+        bean = mgmt.ManagementFactory.getRuntimeMXBean()
+        
+        input_args = bean.getInputArguments()
+        classpath = [bean.getClassPath()]
+        if len(classpath) > 0:
+            classpath.insert(0, '-cp')
+            
+        #check if we're on Windows
+        os_bean = mgmt.ManagementFactory.getOperatingSystemMXBean()
+        os_name = os_bean.getName().lower()
+        
+        is_windows = os_name.startswith('windows')
+        
+        #get the Java exe name
+        java_exe = os.path.join(java.lang.System.getProperty('java.home'), 'bin', 'java')
+
+        args = [java_exe] + classpath + input_args + ['org.python.util.jython'] + sys.argv 
+        
+        print "args: {0}".format(args)
+        
+        return args, (is_windows and is_jython)
 
 def run_with_reloader(main_func, extra_files=None, interval=1):
     """Run the given function in an independent python interpreter."""

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -621,7 +621,7 @@ def detect_executable():
     if platform.python_implementation().lower() == 'jython':
         import java
         
-        #when running Jython with -jar, rt.jar doesn't get imported
+        #When running Jython with -jar, rt.jar doesn't get imported
         try:
             import java.lang.management as mgmt
         except ImportError:
@@ -630,7 +630,7 @@ def detect_executable():
 
         is_jython = True
         
-        #get the args passed to the java exe and the classpath
+        #Get the args passed to the java exe and the classpath
         bean = mgmt.ManagementFactory.getRuntimeMXBean()
         
         input_args = bean.getInputArguments()
@@ -638,13 +638,13 @@ def detect_executable():
         if len(classpath) > 0:
             classpath.insert(0, '-cp')
             
-        #check if we're on Windows
+        #Check if we're on Windows
         os_bean = mgmt.ManagementFactory.getOperatingSystemMXBean()
         os_name = os_bean.getName().lower()
         
         is_windows = os_name.startswith('windows')
         
-        #get the Java exe name
+        #Get the Java exe name
         java_exe = os.path.join(java.lang.System.getProperty('java.home'), 'bin', 'java')
 
         args = [java_exe] + classpath + input_args + ['org.python.util.jython'] + sys.argv 


### PR DESCRIPTION
This is a fix for the Jython reload issue here: https://gist.github.com/paolodina/b98c3f3a159024584e13

If sys.executable is blank in restart_with_reloader(), it checks if the platform is Jython and then gets the java executable information, and whether we are on Windows or not.

I apologize in advance if I've messed up on any protocol in this pull request - it's the first one I've done.  Not sure if I needed to put the work in a new branch or not.

This works on both Linux (tried both icedtea 2.4.7, and Oracle jre 1.8.0_05) and on Windows Server 2003 (1.6.0_45)
