### PR TITLE
Removed unnecessary double-check for cache length value

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -281,8 +281,7 @@ class SimpleCache(BaseCache):
     def add(self, key, value, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
-        if len(self._cache) > self._threshold:
-            self._prune()
+        self._prune()
         item = (time() + timeout, pickle.dumps(value,
             pickle.HIGHEST_PROTOCOL))
         if key in self._cache:


### PR DESCRIPTION
Cache length check upon calling _prune() is unnecessary as that method performs the same check.
