### PR TITLE
Fixes regex for determining charset in traceback

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -479,7 +479,7 @@ class Frame(object):
             source = source[3:]
         else:
             for idx, match in enumerate(_line_re.finditer(source)):
-                match = _line_re.search(match.group())
+                match = _coding_re.search(match.group())
                 if match is not None:
                     charset = match.group(1)
                     break


### PR DESCRIPTION
`_coding_re` was defined to match the magic comment as described in [PEP 0263](http://legacy.python.org/dev/peps/pep-0263/), but tbtools was incorrectly using `_line_re`. This results in using `codecs.lookup` on the first line of a file, which can often match an undesired codec, e.g. 'symbol'
