### PR TITLE
RFC2231 filename continuations of Content-Disposition header.

### DIFF
--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -406,6 +406,26 @@ class MultiPartParser(object):
             name = extra.get('name')
             filename = extra.get('filename')
 
+            # we can deal with continuation lines for filename
+            # according to RFC 2231.
+            # See <a href="http://tools.ietf.org/html/rfc2231">RFC 2231</a>
+            # for details.
+            if filename is None:
+                rfc2231_filename_continuations = [('form-data', '')]
+                # deal with up to 10 filename continuations.
+                for x in range(10):
+                    filename_part = extra.get('filename*%d*' % x)
+                    if filename_part is not None:
+                        rfc2231_filename_continuations.append(
+                            ('filename*%d*' % x, filename_part))
+                if len(rfc2231_filename_continuations) > 1:
+                    from email.utils import decode_params
+                    # 'decode_params' returns a list of tuples like,
+                    # [('form-data', ''),
+                    #  ('filename', ('us-ascii', '', '"foo.txt"'))]
+                    params = decode_params(rfc2231_filename_continuations)
+                    filename = params[1][1][2]
+
             # if no content type is given we stream into memory.  A list is
             # used as a temporary container.
             if filename is None:

--- a/werkzeug/testsuite/formparser.py
+++ b/werkzeug/testsuite/formparser.py
@@ -384,6 +384,28 @@ class MultiPartTestCase(WerkzeugTestCase):
         self.assert_equal(form, MultiDict())
         self.assert_equal(files, MultiDict())
 
+    def test_file_rfc2231_filename_continuations(self):
+        data = (
+            b'--foo\r\n'
+            b'Content-Type: text/plain; charset=utf-8\r\n'
+            b'Content-Disposition: form-data; name="rfc2231_filename";\r\n'
+            b"	filename*0*=us-ascii'en'word01%20word02%20word03%20;\r\n"
+            b"	filename*1*=word04%20word05%20word06%20word07%20word08%20;\r\n"
+            b"	filename*2*=word09%20word10%20word11%20word12%20word13%20;\r\n"
+            b"	filename*3*=word14%20word15%20word16%20word17.txt\r\n\r\n"
+            b'file contents\r\n--foo--'
+        )
+
+        data = Request.from_values(input_stream=BytesIO(data),
+                                   content_length=len(data),
+                                   content_type='multipart/form-data; boundary=foo',
+                                   method='POST')
+        self.assert_equal(data.files['rfc2231_filename'].filename, '"word01'
+                          + ' word02 word03 word04 word05 word06 word07 word08'
+                          + ' word09 word10 word11 word12 word13 word14 word15'
+                          + ' word16 word17.txt"')
+        self.assert_strict_equal(data.files['rfc2231_filename'].read(),
+                                 b'file contents')
 
 class InternalFunctionsTestCase(WerkzeugTestCase):
 


### PR DESCRIPTION
This patch allows you to appropriately deal with filename continuations in Content-Disposition header.
The params continualtion is defined in RFC 2231(http://tools.ietf.org/html/rfc2231).
When specifying a long filename as a attachment file, a string of the filename will be sometimes splitted into several pieces, like 'filename_0_=' and  'filename_1_='.

Requirements: email.utils
