### PR TITLE
Fixed stream multipart encoding for python3

### DIFF
--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -95,7 +95,7 @@ def stream_encode_multipart(values, use_tempfile=True, threshold=1024 * 500,
                     chunk = reader(16384)
                     if not chunk:
                         break
-                    write_binary(chunk)
+                    write(chunk)
             else:
                 if not isinstance(value, string_types):
                     value = str(value)


### PR DESCRIPTION
Fixes an error probably introduced in `6cde94ce`
