### PR TITLE
Fix debugger source code view with python 3

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -411,7 +411,7 @@ class Frame(object):
         if hasattr(self.code, 'co_firstlineno'):
             lineno = self.code.co_firstlineno - 1
             while lineno > 0:
-                if _funcdef_re.match(lines[lineno].code):
+                if _funcdef_re.match(lines[lineno].code.encode('utf-8')):
                     break
                 lineno -= 1
             try:


### PR DESCRIPTION
```
File "werkzeug/werkzeug/debug/tbtools.py", line 414, in get_annotated_lines
    if _funcdef_re.match(lines[lineno].code):
TypeError: can't use a bytes pattern on a string-like object
```
