### PR TITLE
Change the way to detect native pbdkf2 support.

### DIFF
--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -65,8 +65,7 @@ def pbkdf2_hex(data, salt, iterations=DEFAULT_PBKDF2_ITERATIONS,
     return to_native(codecs.encode(rv, 'hex_codec'))
 
 
-_has_native_pbdkf2 = hasattr(hashlib, 'pbkdf2_hmac') and \
-        hasattr(hashlib, 'algorithms_available')
+_has_native_pbdkf2 = hasattr(hashlib, 'pbkdf2_hmac')
 
 
 def pbkdf2_bin(data, salt, iterations=DEFAULT_PBKDF2_ITERATIONS,
@@ -99,7 +98,7 @@ def pbkdf2_bin(data, salt, iterations=DEFAULT_PBKDF2_ITERATIONS,
     if _has_native_pbdkf2:
         _test_hash = hashfunc()
         if hasattr(_test_hash, 'name') and \
-           _test_hash.name in hashlib.algorithms_available:
+           _test_hash.name in _hash_funcs:
             return hashlib.pbkdf2_hmac(_test_hash.name,
                                        data, salt, iterations,
                                        keylen)


### PR DESCRIPTION
`hashlib.pbdkf2_hmac` was introduced in version 2.7.8.

The built-in `hashlib.pbdkf2_hmac` is much faster.

Here is the benchmark result for 1000 times `generate_password_hash`:
1. werkzeug way: 9.906912s
2. native way: 4.98566s
