### PR TITLE
Use keyword arguments for redis cache.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,8 @@ Release date and codename to be decided
 - Allow protocol-relative URLs when building external URLs.
 - Fixed Atom syndication to print time zone offset for tz-aware datetime
   objects (pull request ``#254``).
+- Fix bug in ``cache.RedisCache`` when combined with ``redis.StrictRedis``
+  object (pull request ``#583``).
 
 Version 0.9.7
 -------------

--- a/tests/contrib/test_cache.py
+++ b/tests/contrib/test_cache.py
@@ -157,13 +157,19 @@ if redis is not None:
     class TestRedisCache(CacheTests):
         _can_use_fast_sleep = False
 
-        @pytest.fixture
+        @pytest.fixture(params=[
+            ([], dict()),
+            ([redis.Redis()], dict()),
+            ([redis.StrictRedis()], dict())
+        ])
         def make_cache(self, xprocess, request):
             def preparefunc(cwd):
                 return 'server is now ready', ['redis-server']
 
             xprocess.ensure('redis_server', preparefunc)
-            c = cache.RedisCache(key_prefix='werkzeug-test-case:')
+            args, kwargs = request.param
+            c = cache.RedisCache(*args, key_prefix='werkzeug-test-case:',
+                                 **kwargs)
             request.addfinalizer(c.clear)
             return lambda: c
 

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -494,7 +494,8 @@ class RedisCache(BaseCache):
                 import redis
             except ImportError:
                 raise RuntimeError('no redis module found')
-            self._client = redis.Redis(host=host, port=port, password=password, db=db)
+            self._client = redis.Redis(host=host, port=port, password=password,
+                                       db=db)
         else:
             self._client = host
         self.key_prefix = key_prefix or ''
@@ -537,14 +538,16 @@ class RedisCache(BaseCache):
         if timeout is None:
             timeout = self.default_timeout
         dump = self.dump_object(value)
-        return self._client.setex(self.key_prefix + key, dump, timeout)
+        return self._client.setex(name=self.key_prefix + key,
+                                  value=dump, time=timeout)
 
     def add(self, key, value, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
         dump = self.dump_object(value)
-        added = self._client.setnx(self.key_prefix + key, dump)
-        return added and self._client.expire(self.key_prefix + key, timeout)
+        added = self._client.setnx(name=self.key_prefix + key, value=dump)
+        expire = self._client.expire(name=self.key_prefix + key, time=timeout)
+        return added and expire
 
     def set_many(self, mapping, timeout=None):
         if timeout is None:
@@ -552,7 +555,7 @@ class RedisCache(BaseCache):
         pipe = self._client.pipeline()
         for key, value in _items(mapping):
             dump = self.dump_object(value)
-            pipe.setex(self.key_prefix + key, dump, timeout)
+            pipe.setex(name=self.key_prefix + key, value=dump, time=timeout)
         return pipe.execute()
 
     def delete(self, key):
@@ -576,10 +579,10 @@ class RedisCache(BaseCache):
         return status
 
     def inc(self, key, delta=1):
-        return self._client.incr(self.key_prefix + key, delta)
+        return self._client.incr(name=self.key_prefix + key, amount=delta)
 
     def dec(self, key, delta=1):
-        return self._client.decr(self.key_prefix + key, delta)
+        return self._client.decr(name=self.key_prefix + key, amount=delta)
 
 
 class FileSystemCache(BaseCache):


### PR DESCRIPTION
StrictRedis has a different argument order for some reason.

Fix #406
