### PR TITLE
Passes charset from url_fix() to to_native()

### DIFF
--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -494,7 +494,7 @@ def url_fix(s, charset='utf-8'):
     scheme, netloc, path, qs, anchor = url_parse(to_unicode(s, charset, 'replace'))
     path = url_quote(path, charset, safe='/%+$!*\'(),')
     qs = url_quote_plus(qs, charset, safe=':&%=+$!*\'(),')
-    return to_native(url_unparse((scheme, netloc, path, qs, anchor)))
+    return to_native(url_unparse((scheme, netloc, path, qs, anchor)), charset)
 
 
 def uri_to_iri(uri, charset='utf-8', errors='replace'):


### PR DESCRIPTION
Fixes Issue #582.

`url_fix` function defaults to a charset of utf-8 (which in my opinion is the way to go) but wasn't passing this charset argument to `to_native()` function, whose charset defaults to `sys.getdefaultencoding()` (problematic in python2 since essentially will fail with all non-ascii chars).

This fix simple passes the charset to to_native and the problem seems to be solved.
