### PR TITLE
Allow DELETE to send content in tests

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,8 @@ Release date and codename to be decided
   ``#611``).
 - Added support for specifying a ``Response`` subclass to use when calling
   :func:`~werkzeug.utils.redirect`\ .
+- Make testing Content-Type independent of HTTP method used.  Instead, depend
+  only on provided data and/or input stream (issue ``#620``).
 
 Version 0.9.7
 -------------

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -379,9 +379,9 @@ class EnvironBuilder(object):
     def _get_content_type(self):
         ct = self.headers.get('Content-Type')
         if ct is None and not self._input_stream:
-            if self.method in ('POST', 'PUT', 'PATCH'):
-                if self._files:
-                    return 'multipart/form-data'
+            if self._files:
+                return 'multipart/form-data'
+            elif self._form:
                 return 'application/x-www-form-urlencoded'
             return None
         return ct


### PR DESCRIPTION
Werkzeug (and in turn, Flask) doesn't support sending `data` content with a `DELETE` request.

I just ran into this issue in my own tests, and found someone on Stack Overflow with a similar question: http://stackoverflow.com/q/24073488/1309238

Following the debugger through the request, it looks like the issue is here in this pull request, where the `_get_content_type` returns `None` for DELETE requests.  As I mention in my answer to that Stack Overflow question, this is inconsistent with how HTTP libraries (like curl) can be used to send DELETE requests with content.

I wasn't able to successfully run the tests on my local machine, so I'm not sure if this method is exercised or checked by anything.  I'm happy to add a test that covers this, if it's needed to merge into the repo.
