### PR TITLE
install "redis-server", not "redis", in tutorial 

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -20,7 +20,7 @@ you are on OS X, you can use `brew` to install it::
 
 If you are on Ubuntu or Debian, you can use apt-get::
 
-    sudo apt-get install redis
+    sudo apt-get install redis-server
 
 Redis was developed for UNIX systems and was never really designed to
 work on Windows.  For development purposes, the unofficial ports however


### PR DESCRIPTION
Hi! The tutorial in werkzeug/docs/tutorial.rst suggests:

> If you are on Ubuntu or Debian, you can use apt-get::
>   sudo apt-get install redis

but, at least on my machine (Linux Mint Qiana and thus accessing .deb repositories), that gives me the error `Unable to locate package redis`. The current name [seems](https://packages.debian.org/wheezy/redis-server) to be `redis-server` so I'm suggesting a change. Let me know if I'm missing something!

Thank you for Werkzeug!
