### PR TITLE
Allow non-cached/temporary redirects in werkzeug.routing.RequestRedirect

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -220,12 +220,12 @@ class RequestRedirect(HTTPException, RoutingException):
     `strict_slashes` are activated and an url that requires a trailing slash.
 
     The attribute `new_url` contains the absolute destination url.
+    The attribute `code` is returned status code.
     """
-    code = 301
-
-    def __init__(self, new_url):
+    def __init__(self, new_url, code=301):
         RoutingException.__init__(self, new_url)
         self.new_url = new_url
+        self.code = code
 
     def get_response(self, environ):
         return redirect(self.new_url, self.code)


### PR DESCRIPTION
> Unfortunately, RequestRedirect() exception returns 301 HTTP status code and it will be cached by the browser.
> http://stackoverflow.com/a/16371787/1364191

This pull request will make it possible to change the returned status code to 302. This is very necessary for Flask applications which need to return a redirect from within a helper function.

Here's a Gist example: https://gist.github.com/pawl/762876a1770e0d2593b6
