### PR TITLE
Always quote qop parameter.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,8 @@ Version 0.9.7
   anymore (pull request ``#466``).
 - Fix bug in ``cache.RedisCache`` when combined with ``redis.StrictRedis``
   object (pull request ``#583``).
+- The ``qop`` parameter for ``WWW-Authenticate`` headers is now always quoted,
+  as required by RFC 2617 (issue ``#633``).
 
 Version 0.9.6
 -------------

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2357,7 +2357,7 @@ class WWWAuthenticate(UpdateDictMixin, dict):
     """Provides simple access to `WWW-Authenticate` headers."""
 
     #: list of keys that require quoting in the generated header
-    _require_quoting = frozenset(['domain', 'nonce', 'opaque', 'realm'])
+    _require_quoting = frozenset(['domain', 'nonce', 'opaque', 'realm', 'qop'])
 
     def __init__(self, auth_type=None, values=None, on_update=None):
         dict.__init__(self, values or ())

--- a/werkzeug/testsuite/wrappers.py
+++ b/werkzeug/testsuite/wrappers.py
@@ -489,6 +489,21 @@ class WrappersTestCase(WerkzeugTestCase):
         resp.www_authenticate.type = None
         assert 'WWW-Authenticate' not in resp.headers
 
+    def test_authenticate_mixin_quoted_qop(self):
+        # Example taken from https://github.com/mitsuhiko/werkzeug/issues/633
+        resp = wrappers.Response()
+        resp.www_authenticate.set_digest('REALM','NONCE',qop=("auth","auth-int"))
+
+        actual = set((resp.headers['WWW-Authenticate'] + ',').split())
+        expected = set('Digest nonce="NONCE", realm="REALM", qop="auth, auth-int",'.split())
+        self.assert_equal(actual, expected)
+
+        resp.www_authenticate.set_digest('REALM','NONCE',qop=("auth",))
+
+        actual = set((resp.headers['WWW-Authenticate'] + ',').split())
+        expected = set('Digest nonce="NONCE", realm="REALM", qop="auth",'.split())
+        self.assert_equal(actual, expected)
+
     def test_response_stream_mixin(self):
         response = wrappers.Response()
         response.stream.write('Hello ')


### PR DESCRIPTION
> According to http://tools.ietf.org/html/rfc2617#section-3.2.1 the qop
> attribute of the www-authenticate header is always enquoted even when a
> single token.

Fix #633
