### PR TITLE
Converting parameter types in get_content_type() for Python3 compatibility

### DIFF
--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -216,6 +216,11 @@ def get_content_type(mimetype, charset):
     :param charset: the charset to be appended in case it was a text mimetype.
     :return: the content type.
     """
+    if not isinstance(mimetype, text_type):
+        mimetype = mimetype.decode('utf-8')
+    if not isinstance(charset, text_type):
+        charset = charset.decode('utf-8')
+
     if mimetype.startswith('text/') or \
        mimetype == 'application/xml' or \
        (mimetype.startswith('application/') and


### PR DESCRIPTION
When mimetype and charset input parameters are passed with inconsistent types (sometimes bytes and sometimes string/unicode), string comparison would sometimes fail in Python3 since it requires same data-types for string comparison

```
>>> b''.startswith('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```

addresses #636
