### PR TITLE
Make websockets a bit nicer.

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -141,7 +141,11 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                     header_keys.add(key)
                 if 'content-length' not in header_keys:
                     self.close_connection = True
-                    self.send_header('Connection', 'close')
+                    if "connection" not in header_keys:
+                        # Connection should never be in header_keys it's banned by
+                        # the WSGI spec. However setting connection is very usefull
+                        # for creating websockets.
+                        self.send_header('Connection', 'close')
                 if 'server' not in header_keys:
                     self.send_header('Server', self.version_string())
                 if 'date' not in header_keys:


### PR DESCRIPTION
I'd be interested to hear what you think of this. I was trying to get a pure python implementation of websockets working with Flask (no gevent, no uwsgi, no twisted, no autobahn) and I failed. But on the way I did get a version working with werkzeug and wsgiref (some monkeypatching of wsgiref required). There was however an ugly in the result with werkzeug. This pull request fixes that. In case anyone is interested my websocket implementation is at https://github.com/mbirtwell/simple-websockets and at the time very incomplete.

To create a websocket it is necessary to set the connection and upgrade
headers and not set the content-length header. At the moment werkzeug
will set a second connection header for close in this situation, this as it
happens doesn't seem to bother the couple of browser I've tried this with
(Chrome and IE) but it's not pretty.
