### PR TITLE
Routing - try next rule without redirect.

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1488,6 +1488,10 @@ class MapAdapter(object):
 
         have_match_for = set()
         for rule in self.map._rules:
+            if rule.methods is not None and method not in rule.methods:
+                # Not our rule methods - try next rule
+                continue
+
             try:
                 rv = rule.match(path)
             except RequestSlash:


### PR DESCRIPTION
Try the next rule without redirect if the current request method is not match for the current rule methods.
For POST, PUT and PATCH methods redirect is not allowed.

Sample source code:

``` python
@app.route('/path/', methods=['GET'])
@app.route('/path',  methods=['GET'])
def get():
    return make_response(do_get())

@app.route('/path/', methods=['POST'])
@app.route('/path',  methods=['POST'])
def create():
    return make_response(do_create(request))

@app.route('/path/', methods=['DELETE'])
@app.route('/path',  methods=['DELETE'])
def delete():
    return make_response(do_delete(request))

@app.route('/path/', methods=['PATCH'])
@app.route('/path',  methods=['PATCH'])
def edit():
    id = request.args.get('id')
    return make_response(do_edit(id, request))
```

Sample error mesage without fix for PATCH method:
FormDataRoutingRedirect: A request was sent to this URL (http://localhost:9000/path?id=12345) but a redirect was issued automatically by the routing system to "http://localhost:9000/path/?id=12345".  The URL was defined with a trailing slash so Flask will automatically redirect to the URL with the trailing slash if it was accessed without one.  Make sure to directly send your PATCH-request to this URL since we can't make browsers or HTTP clients redirect with form data reliably or without user interaction.
