### PR TITLE
routing: Transparently convert a MultiDict containing parameters.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,8 @@ Version 0.10.5
 
 - Reloader: Correctly detect file changes made by moving temporary files over
   the original, which is e.g. the case with PyCharm (pull request ``#722``).
+- Reintroduce `MultiDict` values for building URLs. We actually can eat our
+  cake and have it too.
 
 Version 0.10.4
 --------------

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -100,8 +100,6 @@ def test_basic_building():
     assert adapter.build('bar', {'baz': 'blub'}) == \
         'http://example.org/bar/blub'
     assert adapter.build('bari', {'bazi': 50}) == 'http://example.org/bar/50'
-    multivalues = MultiDict([('bazi', 50), ('bazi', None)])
-    assert adapter.build('bari', multivalues) == 'http://example.org/bar/50'
     assert adapter.build('barf', {'bazf': 0.815}) == \
         'http://example.org/bar/0.815'
     assert adapter.build('barp', {'bazp': 'la/di'}) == \
@@ -482,13 +480,25 @@ def test_build_append_unknown():
 
 def test_build_append_multiple():
     map = r.Map([
-        r.Rule('/bar/<float:bazf>', endpoint='barf')
+        r.Rule('/bar/<float:foo>', endpoint='endp')
     ])
-    adapter = map.bind('example.org', '/', subdomain='blah')
-    params = {'bazf': 0.815, 'bif': [1.0, 3.0], 'pof': 2.0}
-    a, b = adapter.build('barf', params).split('?')
+    adapter = map.bind('example.org', '/', subdomain='subd')
+    params = {'foo': 0.815, 'x': [1.0, 3.0], 'y': 2.0}
+    a, b = adapter.build('endp', params).split('?')
     assert a == 'http://example.org/bar/0.815'
-    assert set(b.split('&')) == set('pof=2.0&bif=1.0&bif=3.0'.split('&'))
+    assert set(b.split('&')) == set('y=2.0&x=1.0&x=3.0'.split('&'))
+
+
+def test_build_append_multidict():
+    map = r.Map([
+        r.Rule('/bar/<float:foo>', endpoint='endp')
+    ])
+    adapter = map.bind('example.org', '/', subdomain='subd')
+    params = MultiDict(
+        (('foo', 0.815), ('x', 1.0), ('x', 3.0), ('y', 2.0)))
+    a, b = adapter.build('endp', params).split('?')
+    assert a == 'http://example.org/bar/0.815'
+    assert set(b.split('&')) == set('y=2.0&x=1.0&x=3.0'.split('&'))
 
 
 def test_method_fallback():

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -109,7 +109,7 @@ from werkzeug.exceptions import HTTPException, NotFound, MethodNotAllowed
 from werkzeug._internal import _get_environ, _encode_idna
 from werkzeug._compat import itervalues, iteritems, to_unicode, to_bytes, \
     text_type, string_types, native_string_result, \
-    implements_to_string, wsgi_decoding_dance
+    implements_to_string, wsgi_decoding_dance, iterlists
 from werkzeug.datastructures import ImmutableDict, MultiDict
 
 
@@ -1748,11 +1748,12 @@ class MapAdapter(object):
         self.map.update()
         if values:
             if isinstance(values, MultiDict):
-                temp = dict(
-                    (k, (values.getlist(k)
-                         if len(values.getlist(k)) > 1
-                         else values[k]))
-                    for k in values)
+                temp = {}
+                for key, list_value in iterlists(values):
+                    if len(list_value) == 1:
+                        temp[key] = list_value[0]
+                    else:
+                        temp[key] = list_value
             else:
                 temp = values
             values = dict((k, v) for k, v in iteritems(temp) if v is not None)

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1748,11 +1748,11 @@ class MapAdapter(object):
         self.map.update()
         if values:
             if isinstance(values, MultiDict):
-                temp = {
-                    k: (values.getlist(k)
-                        if len(values.getlist(k)) > 1
-                        else values[k])
-                    for k in values}
+                temp = dict(
+                    (k, (values.getlist(k)
+                         if len(values.getlist(k)) > 1
+                         else values[k]))
+                    for k in values)
             else:
                 temp = values
             values = dict((k, v) for k, v in iteritems(temp) if v is not None)

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1717,6 +1717,12 @@ class MapAdapter(object):
         >>> urls.build("index", {'q': ['a', 'b', 'c']})
         '/?q=a&q=b&q=c'
 
+        If an actual :py:class:`werkzeug.datastructures.MultiDict` is passed
+        in it is automatically expanded to do the correct thing:
+
+        >>> urls.build("index", MultiDict((('p', 'z'), ('q', 'a'), ('q', 'b'))))
+        '/?p=z&q=a&q=b'
+
         If a rule does not exist when building a `BuildError` exception is
         raised.
 
@@ -1742,10 +1748,14 @@ class MapAdapter(object):
         self.map.update()
         if values:
             if isinstance(values, MultiDict):
-                valueiter = iteritems(values, multi=True)
+                temp = {
+                    k: (values.getlist(k)
+                        if len(values.getlist(k)) > 1
+                        else values[k])
+                    for k in values}
             else:
-                valueiter = iteritems(values)
-            values = dict((k, v) for k, v in valueiter if v is not None)
+                temp = values
+            values = dict((k, v) for k, v in iteritems(temp) if v is not None)
         else:
             values = {}
 


### PR DESCRIPTION
Sorry to nag once more w.r.t. the multiple values for URL building, but I think I found a way to make everybody happy. The following should allow passing in MultiDicts and receiving the desired behaviour without getting any regressions.
This should be ready to merge (as in there is test and documentation).

This allows to pass a MultiDict and get the intuitively expected result
(that is multiple parameters, where multiple values are present). This
allows to recreate a URL as follows:
- create a URL with multiple values for a parameter
- use Map.match() to extract them into a MultiDict
- recreate the URL with Map.build() handing in the MultiDict

The last step would fail before this commit (in that it would reproduce only
one of the values for each parameter). Also this avoids the collateral
damage introduced by the last attempt at allowing MultiDicts.

This zaps one of the test cases in test_basic_building to reflect the
changed behaviour.
