### PR TITLE
Log the actual listen port, not the configured one

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -469,8 +469,9 @@ class BaseWSGIServer(HTTPServer, object):
                 if ':' in display_hostname:
                     display_hostname = '[%s]' % display_hostname
                 quit_msg = '(Press CTRL+C to quit)'
+                real_port = self.socket.getsockname()[1]
                 _log('info', ' * Running on %s://%s:%d/ %s', self.ssl_context is None
-                     and 'http' or 'https', display_hostname, self.port, quit_msg)
+                     and 'http' or 'https', display_hostname, real_port, quit_msg)
             HTTPServer.serve_forever(self)
         except KeyboardInterrupt:
             pass

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -445,7 +445,7 @@ class BaseWSGIServer(HTTPServer, object):
         self.passthrough_errors = passthrough_errors
         self.shutdown_signal = False
         self.host = host
-        self.port = port
+        self.port = self.socket.getsockname()[1]
 
         if ssl_context is not None:
             if isinstance(ssl_context, tuple):
@@ -469,9 +469,8 @@ class BaseWSGIServer(HTTPServer, object):
                 if ':' in display_hostname:
                     display_hostname = '[%s]' % display_hostname
                 quit_msg = '(Press CTRL+C to quit)'
-                real_port = self.socket.getsockname()[1]
                 _log('info', ' * Running on %s://%s:%d/ %s', self.ssl_context is None
-                     and 'http' or 'https', display_hostname, real_port, quit_msg)
+                     and 'http' or 'https', display_hostname, self.port, quit_msg)
             HTTPServer.serve_forever(self)
         except KeyboardInterrupt:
             pass


### PR DESCRIPTION
When the listen port is configured to "0", the kernel randomly assigns a free TCP port to the server. This is the port we should log, because the server is only reachable there, not on port 0.

Setting the port to 0 is useful when you start a web server to run integration tests with/against it, e.g. on a developers desktop or on a build server. You don't want to rely on any specific port being available for that server. Instead you start the server on some port that is available, read the logs to figure out which port was assigned to it, then run the tests with that server.