### PR TITLE
Use daemon threads for threaded test server

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -492,6 +492,7 @@ class ThreadedWSGIServer(ThreadingMixIn, BaseWSGIServer):
 
     """A WSGI server that does threading."""
     multithread = True
+    daemon_threads = True
 
 
 class ForkingWSGIServer(ForkingMixIn, BaseWSGIServer):


### PR DESCRIPTION
When using `werkzeug.serving.run_simle(..., threaded=True)` the worker threads still keep running after the main thread is terminated either by pressing `Ctrl-C` or when using the reloader. This can easily be reproduced with `ab -n 1000 -c 10 http://120.0.0.1:5000`.

That is because `ThreadingMixIn.daemon_threads`, in the [socketserver](https://docs.python.org/3/library/socketserver.html) module, defaults to `False`. When overriding this attribute with the value `True` in the `ThreadedWSGIServer` class, the program will terminate as soon as the main thread exits, which is the expected behavior for a test server.