### PR TITLE
Fix string representation when debugging

### DIFF
--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -30,6 +30,16 @@ class TestDebugRepr(object):
         assert debug_repr([None]) == \
             u'[<span class="object">None</span>]'
 
+    def test_string_repr(self):
+        assert debug_repr('') == u'<span class="string">\'\'</span>'
+        assert debug_repr('foo') == u'<span class="string">\'foo\'</span>'
+        assert debug_repr('s' * 80) == u'<span class="string">\''\
+            + 's' * 70 + '<span class="extended">'\
+            + 's' * 10 + '\'</span></span>'
+        assert debug_repr('<' * 80) == u'<span class="string">\''\
+            + '&lt;' * 70 + '<span class="extended">'\
+            + '&lt;' * 10 + '\'</span></span>'
+
     def test_sequence_repr(self):
         assert debug_repr(list(range(20))) == (
             u'[<span class="number">0</span>, <span class="number">1</span>, '

--- a/werkzeug/debug/repr.py
+++ b/werkzeug/debug/repr.py
@@ -154,17 +154,16 @@ class DebugReprGenerator(object):
 
     def string_repr(self, obj, limit=70):
         buf = ['<span class="string">']
-        escaped = escape(obj)
-        a = repr(escaped[:limit])
-        b = repr(escaped[limit:])
+        a = repr(obj[:limit])
+        b = repr(obj[limit:])
         if isinstance(obj, text_type) and PY2:
             buf.append('u')
             a = a[1:]
             b = b[1:]
         if b != "''":
-            buf.extend((a[:-1], '<span class="extended">', b[1:], '</span>'))
+            buf.extend((escape(a[:-1]), '<span class="extended">', escape(b[1:]), '</span>'))
         else:
-            buf.append(a)
+            buf.append(escape(a))
         buf.append('</span>')
         return _add_subclass_info(u''.join(buf), obj, (bytes, text_type))
 


### PR DESCRIPTION
Long strings were HTML-escaped before being split. The HTML entities
threw off character counting, and were ocasionally split themselves.