### PR TITLE
Cookie value of more than 4096 bytes should not fail silently

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -368,11 +368,11 @@ class TestHTTPUtility(object):
         strict_eq(val, 'foo=bar; Domain=.foo.com; Path=/')
 
     def test_cookie_maxsize(self):
-        val = http.dump_cookie('foo', ('bar'*1360)+'b')
+        val = http.dump_cookie('foo', ('bar' * 1360) + 'b')
         assert len(val) == http.COOKIE_MAXSIZE
 
         with pytest.raises(ValueError) as excinfo:
-            http.dump_cookie('foo', ('bar'*1360)+'ba')
+            http.dump_cookie('foo', ('bar' * 1360) + 'ba')
         assert ('Cookie too large' in excinfo.value.message)
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -373,7 +373,7 @@ class TestHTTPUtility(object):
 
         with pytest.raises(ValueError) as excinfo:
             http.dump_cookie('foo', ('bar' * 1360) + 'ba')
-        assert ('Cookie too large' in excinfo.value.message)
+        assert ('Cookie too large' in str(excinfo))
 
 
 class TestRange(object):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -367,6 +367,14 @@ class TestHTTPUtility(object):
         val = http.dump_cookie('foo', 'bar', domain=u'.foo.com')
         strict_eq(val, 'foo=bar; Domain=.foo.com; Path=/')
 
+    def test_cookie_maxsize(self):
+        val = http.dump_cookie('foo', ('bar'*1360)+'b')
+        assert len(val) == http.COOKIE_MAXSIZE
+
+        with pytest.raises(ValueError) as excinfo:
+            http.dump_cookie('foo', ('bar'*1360)+'ba')
+        assert ('Cookie too large' in excinfo.value.message)
+
 
 class TestRange(object):
 

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -999,8 +999,8 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
     cookie_size = len(rv)
     if cookie_size > COOKIE_MAXSIZE:
         raise ValueError((
-            'Cookie too large: size of {} is {} bytes, '
-            'standard limit in most browsers is {} bytes').format(
+            'Cookie too large: size of {0} is {1} bytes, '
+            'standard limit in most browsers is {2} bytes').format(
                 key, cookie_size, COOKIE_MAXSIZE))
 
     return rv

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -992,7 +992,7 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
     # the cookie is too large, then it will simply get lost, which can
     # be quite hard to debug.
     cookie_size = len(rv)
-    cookie_maxsize = 4096
+    cookie_maxsize = 4093
     if cookie_size > cookie_maxsize:
         raise ValueError((
             'Cookie too large: size of {} is {} bytes, '

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -986,6 +986,19 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
     rv = b'; '.join(buf)
     if not PY2:
         rv = rv.decode('latin1')
+
+    # Check that the final value of the cookie is less than the
+    # standard limit set by browsers. If no check is performed, and if
+    # the cookie is too large, then it will simply get lost, which can
+    # be quite hard to debug.
+    cookie_size = len(rv)
+    cookie_maxsize = 4096
+    if cookie_size > cookie_maxsize:
+        raise ValueError((
+            'Cookie too large: size of {} is {} bytes, '
+            'standard limit in most browsers is {} bytes').format(
+                key, cookie_size, cookie_maxsize))
+
     return rv
 
 

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -135,6 +135,11 @@ HTTP_STATUS_CODES = {
     510:    'Not Extended'
 }
 
+# For discussion of a safe (i.e. lowest common denominator) cookie
+# max size, see:
+# http://browsercookielimits.squawky.net/
+COOKIE_MAXSIZE = 4093
+
 
 def wsgi_to_bytes(data):
     """coerce wsgi unicode represented bytes to real ones
@@ -992,12 +997,11 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
     # the cookie is too large, then it will simply get lost, which can
     # be quite hard to debug.
     cookie_size = len(rv)
-    cookie_maxsize = 4093
-    if cookie_size > cookie_maxsize:
+    if cookie_size > COOKIE_MAXSIZE:
         raise ValueError((
             'Cookie too large: size of {} is {} bytes, '
             'standard limit in most browsers is {} bytes').format(
-                key, cookie_size, cookie_maxsize))
+                key, cookie_size, COOKIE_MAXSIZE))
 
     return rv
 


### PR DESCRIPTION
For more details on cookie size limits, see:

http://stackoverflow.com/questions/640938/what-is-the-maximum-size-of-a-web-browsers-cookies-key

A similar ticket was opened for Django - see:

https://code.djangoproject.com/ticket/22242

The Django folks decided not to raise an exception when this happens, because they're using Python's standard Cookie library, so they'd have to duplicate the code to build / output the cookie value. Although they did update their documentation.

This is not an issue for Werkzeug, because it implements the raw encoding of the cookie by itself in `dump_cookie()`, rather than relying on Python Cookie. So, checking the size and raising an exception is a trivial change for Werkzeug.
