### PR TITLE
Simplifies Accept header constructor.

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1596,10 +1596,8 @@ class Accept(ImmutableList):
             list.__init__(self, values)
         else:
             self.provided = True
-            values = [(a, b) for b, a in values]
-            values.sort()
-            values.reverse()
-            list.__init__(self, [(a, b) for b, a in values])
+            values = sorted(values, key=lambda x: (x[1], x[0]), reverse=True)
+            list.__init__(self, values)
 
     def _value_matches(self, value, item):
         """Check if a value matches a given accept item."""


### PR DESCRIPTION
This commit removes the function calls and in-place sorting in favor of
using the built-in `sorted` method with the appropriate `key` and
`reverse` keyword arguments.

As justification,
- this reduces the number of lists in memory by one,
- this uses the `reverse` keyword argument to the built-in `sorted` function instead of manually calling `sort()` and `reverse()`,
- the number of function calls is reduced (though some of the work is offloaded to the `sorted()` function):

   ```python
>>> from dis import dis
>>> def f(values):
...     return sorted(values, key=lambda x: (x[1], x[0]), reverse=True)
... 
>>> dis(f)
  2           0 LOAD_GLOBAL              0 (sorted)
              3 LOAD_FAST                0 (values)
              6 LOAD_CONST               1 ('key')
              9 LOAD_CONST               2 (<code object <lambda> at 0x7fb389fa4c90, file "<stdin>", line 2>)
             12 LOAD_CONST               3 ('f.<locals>.<lambda>')
             15 MAKE_FUNCTION            0
             18 LOAD_CONST               4 ('reverse')
             21 LOAD_CONST               5 (True)
             24 CALL_FUNCTION          513 (1 positional, 2 keyword pair)
             27 RETURN_VALUE

>>> def g(values):
...             values = [(a, b) for b, a in values]
...             values.sort()
...             values.reverse()
...             return values
... 
>>> dis(g)
  2           0 LOAD_CONST               1 (<code object <listcomp> at 0x7fb38a0580c0, file "<stdin>", line 2>)
              3 LOAD_CONST               2 ('g.<locals>.<listcomp>')
              6 MAKE_FUNCTION            0
              9 LOAD_FAST                0 (values)
             12 GET_ITER
             13 CALL_FUNCTION            1 (1 positional, 0 keyword pair)
             16 STORE_FAST               0 (values)

  3          19 LOAD_FAST                0 (values)
             22 LOAD_ATTR                0 (sort)
             25 CALL_FUNCTION            0 (0 positional, 0 keyword pair)
             28 POP_TOP

  4          29 LOAD_FAST                0 (values)
             32 LOAD_ATTR                1 (reverse)
             35 CALL_FUNCTION            0 (0 positional, 0 keyword pair)
             38 POP_TOP

  5          39 LOAD_FAST                0 (values)
             42 RETURN_VALUE
   ```