### PR TITLE
Inherit relevant collections base classes

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -13,6 +13,7 @@ import codecs
 import mimetypes
 from copy import deepcopy
 from itertools import repeat
+from collections import Container, Iterable, Mapping, MutableSet
 
 from werkzeug._internal import _missing, _empty_stream
 from werkzeug._compat import iterkeys, itervalues, iteritems, iterlists, \
@@ -866,7 +867,7 @@ def _unicodify_header_value(value):
 
 
 @native_itermethods(['keys', 'values', 'items'])
-class Headers(object):
+class Headers(Mapping):
 
     """An object that stores some headers.  It has a dict-like interface
     but is ordered and can store the same keys multiple times.
@@ -1955,7 +1956,7 @@ class CallbackDict(UpdateDictMixin, dict):
         )
 
 
-class HeaderSet(object):
+class HeaderSet(MutableSet):
 
     """Similar to the :class:`ETags` class this implements a set-like structure.
     Unlike :class:`ETags` this is case insensitive and used for vary, allow, and
@@ -2109,7 +2110,7 @@ class HeaderSet(object):
         )
 
 
-class ETags(object):
+class ETags(Container, Iterable):
 
     """A set that can be used to check if one etag is present in a collection
     of etags.


### PR DESCRIPTION
Some datastructures inherit from `object` but match some of the base classes from the `collections` module. 