### PR TITLE
Add support for WWW-Authenticate challenges to Unauthorized

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,7 @@ def test_proxy_exception():
 
 @pytest.mark.parametrize('test', [
     (exceptions.BadRequest, 400),
-    (exceptions.Unauthorized, 401),
+    (exceptions.Unauthorized, 401, ['Basic "test realm"']),
     (exceptions.Forbidden, 403),
     (exceptions.NotFound, 404),
     (exceptions.MethodNotAllowed, 405, ['GET', 'HEAD']),
@@ -82,3 +82,8 @@ def test_special_exceptions():
     h = dict(exc.get_headers({}))
     assert h['Allow'] == 'GET, HEAD, POST'
     assert 'The method is not allowed' in exc.get_description()
+
+    exc = exceptions.Unauthorized(['Basic realm1', 'Digest realm=...'])
+    h = dict(exc.get_headers({}))
+    assert h['WWW-Authenticate'] == 'Basic realm1, Digest realm=...'
+    assert 'authorized' in exc.get_description()

--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -207,6 +207,10 @@ class Unauthorized(HTTPException):
 
     Raise if the user is not authorized.  Also used if you want to use HTTP
     basic auth.
+
+    The first argument for this exception should be a list of WWW-Authenticate
+    challenges.  Strictly speaking the response would be invalid if you don't 
+    provide at least one challenge.
     """
     code = 401
     description = (
@@ -215,6 +219,17 @@ class Unauthorized(HTTPException):
         'a bad password), or your browser doesn\'t understand how to supply '
         'the credentials required.'
     )
+    
+    def __init__(self, challenges=None, description=None):
+        """Takes an optional list of WWW-Authenticate challenges."""
+        HTTPException.__init__(self, description)
+        self.challenges = challenges
+
+    def get_headers(self, environ):
+        headers = HTTPException.get_headers(self, environ)
+        if self.challenges:
+            headers.append(('WWW-Authenticate', ', '.join(self.challenges)))
+        return headers
 
 
 class Forbidden(HTTPException):


### PR DESCRIPTION
In the HTTP spec, the Unauthorized response is required to provide at least one WWW-Authenticate challenge.  This makes it easier to comply with that spec with werkzeug exceptions.

closes #772 