### PR TITLE
Allow logging before run_wsgi is called.

### DIFF
--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -24,6 +24,11 @@ try:
 except ImportError:
     watchdog = None
 
+try:
+    import urllib2  # python 2
+except:
+    import urllib.request as urllib2  # python 3
+
 import requests
 import requests.exceptions
 import pytest
@@ -196,3 +201,11 @@ def test_monkeypached_sleep(tmpdir):
     ReloaderLoop()._sleep(0)
     '''))
     subprocess.check_call(['python', str(script)])
+
+
+def test_bad_request(dev_server):
+    server = dev_server('from werkzeug.testapp import test_app as app')
+
+    req = urllib2.Request('http://localhost:5000/ a')
+    resp = urllib2.urlopen(req)
+    assert '<p>Error code 400.\n' in resp.readlines()

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -114,8 +114,8 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             'QUERY_STRING':         wsgi_encoding_dance(request_url.query),
             'CONTENT_TYPE':         self.headers.get('Content-Type', ''),
             'CONTENT_LENGTH':       self.headers.get('Content-Length', ''),
-            'REMOTE_ADDR':          self.client_address[0],
-            'REMOTE_PORT':          self.client_address[1],
+            'REMOTE_ADDR':          self.address_string(),
+            'REMOTE_PORT':          self.port_integer(),
             'SERVER_NAME':          self.server.server_address[0],
             'SERVER_PORT':          str(self.server.server_address[1]),
             'SERVER_PROTOCOL':      self.request_version
@@ -264,7 +264,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return BaseHTTPRequestHandler.version_string(self).strip()
 
     def address_string(self):
-        return self.environ['REMOTE_ADDR']
+        return self.client_address[0]
+
+    def port_integer(self):
+        return self.client_address[1]
 
     def log_request(self, code='-', size='-'):
         self.log('info', '"%s" %s %s', self.requestline, code, size)


### PR DESCRIPTION
A Bad Request (error 400) yields an exception in `BaseHTTPRequestHandler.parse_request`, which in turns prevent `WSGIRequestHandler.run_wsgi` to be called. The error is supposed to be logged. However the log function relies on `WSGIRequestHandler.environ` which is initialized in `WSGIRequestHandler.run_wsgi`. This fix removes the dependency with `environ`, allowing logging even if the request url cannot be parsed.

I discovered this bug by requesting  url with spaces with curl.

``` bash
$ curl 'http://localhost:5000/ a'
curl: (52) Empty reply from server
```

That would yield this error on the Werkzeug side:
``` bash
$ python examples/shortly/shortly.py 
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger pin code: 324-280-915
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 54110)
Traceback (most recent call last):
  File "/usr/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python2.7/SocketServer.py", line 655, in __init__
    self.handle()
  File "/home/charles/src/github/charles/werkzeug/werkzeug/serving.py", line 217, in handle
    rv = BaseHTTPRequestHandler.handle(self)
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 340, in handle
    self.handle_one_request()
  File "/home/charles/src/github/charles/werkzeug/werkzeug/serving.py", line 251, in handle_one_request
    elif self.parse_request():
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 286, in parse_request
    self.send_error(400, "Bad request syntax (%r)" % requestline)
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 364, in send_error
    self.log_error("code %d, message %s", code, message)
  File "/home/charles/src/github/charles/werkzeug/werkzeug/serving.py", line 273, in log_error
    self.log('error', *args)
  File "/home/charles/src/github/charles/werkzeug/werkzeug/serving.py", line 279, in log
    _log(type, '%s - - [%s] %s\n' % (self.address_string(),
  File "/home/charles/src/github/charles/werkzeug/werkzeug/serving.py", line 267, in address_string
    return self.environ['REMOTE_ADDR']
AttributeError: 'WSGIRequestHandler' object has no attribute 'environ'
```

With this patch neither curl nor Werkzeug fail anymore and the error is properly logged.

``` bash
$ curl 'http://localhost:5000/ a'
<head>
<title>Error response</title>
</head>
<body>
<h1>Error response</h1>
<p>Error code 400.
<p>Message: Bad request syntax ('GET / a HTTP/1.1').
<p>Error code explanation: 400 = Bad request syntax or unsupported method.
</body>
```

``` bash
$ python examples/shortly/shortly.py 
 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger pin code: 324-280-915
127.0.0.1 - - [20/Dec/2015 02:16:02] code 400, message Bad request syntax ('GET / a HTTP/1.1')
127.0.0.1 - - [20/Dec/2015 02:16:02] "GET / a HTTP/1.1" 400 -
```

The tests are run with the lower level `httplib2`: `requests` yields an exception before sending a bad request.