### PR TITLE
Add empty line in docstring of BaseCache.clear()

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -218,6 +218,7 @@ class BaseCache(object):
     def clear(self):
         """Clears the cache.  Keep in mind that not all caches support
         completely clearing the cache.
+
         :returns: Whether the cache has been cleared.
         :rtype: boolean
         """


### PR DESCRIPTION
Tags should be clearly separated from the method's summary,
otherwise they may not be parsed correctly:
http://werkzeug.pocoo.org/docs/0.11/contrib/cache/#werkzeug.contrib.cache.BaseCache.clear
