### PR TITLE
Tightened the ChromeOS User-Agent regex to avoid mislabelling some Microsoft browsers

### DIFF
--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -19,7 +19,7 @@ class UserAgentParser(object):
     """A simple user agent parser.  Used by the `UserAgent`."""
 
     platforms = (
-        ('cros', 'chromeos'),
+        ('cros ', 'chromeos'),
         ('iphone|ios', 'iphone'),
         ('ipad', 'ipad'),
         (r'darwin|mac|os\s*x', 'macos'),


### PR DESCRIPTION
The 'cros' User-Agent regex in useragents.py matches on the 'Microsoft' string in a variety of Microsoft User-Agent strings (see #818). 

Three possible solutions:

1. Reorder the `platforms` list so that the Windows regexes come first.
2. Make the match case-sensitive, in contrast to the current use of `re.I`.
3. Tighten the ChromeOS regex by adding a space into the regex (i.e. `('cros ', 'chromeos')`

We've gone with the third option, tightening the regex, as it's less invasive than reordering, or changing case matching.