### PR TITLE
Add Accept-Ranges: bytes support for movie file seeking

### DIFF
--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -618,7 +618,6 @@ class SharedDataMiddleware(object):
         else:
             headers.append(('Cache-Control', 'public'))
 
-
         byterange = 0
         if 'HTTP_RANGE' in environ:
             byterangeval = environ['HTTP_RANGE']
@@ -633,6 +632,7 @@ class SharedDataMiddleware(object):
                 ('Content-Range', 'bytes ' + str(byterange)
                     + '-' + str(file_size))
             ))
+            start_response('206 Partial Content', headers)
         else:
             headers.extend((
                 ('Content-Type', mime_type),
@@ -640,11 +640,8 @@ class SharedDataMiddleware(object):
                 ('Last-Modified', http_date(mtime)),
                 ('Accept-Ranges', 'bytes')
             ))
-
-        if byterange > 0:
-            start_response('206 Partial Content', headers)
-        else:
             start_response('200 OK', headers)
+
         return wrap_file(environ, f, 8192, byterange)
 
 


### PR DESCRIPTION
(Second attempt, first attempt failed continuous integration check due to extra blank lines.)
This modifies the werkzeug SharedDataMiddleware code so that a person serving movies (e.g. WebM/VP8) can click to the middle of the movie and have a HTTP range request to the server and get a 206 Partial Content result.