### PR TITLE
check file size

### DIFF
--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -620,9 +620,10 @@ class SharedDataMiddleware(object):
 
         headers.extend((
             ('Content-Type', mime_type),
-            ('Content-Length', str(file_size)),
             ('Last-Modified', http_date(mtime))
         ))
+        if file_size:
+            headers.append(('Content-Length', str(file_size)))
         start_response('200 OK', headers)
         return wrap_file(environ, f)
 


### PR DESCRIPTION
Using 'pkg_resources' the file size returned is zero, and with development server the files/images are not shown. With cherrypywsigserver, throw a exception with ValueError about content-length. With this patch, all is fine.