### PR TITLE
try-except in inner() in run_simple() leaves exceptions grounds

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -643,10 +643,8 @@ def run_simple(hostname, port, application, use_reloader=False,
              display_hostname, port, quit_msg)
 
     def inner():
-        try:
-            fd = int(os.environ['WERKZEUG_SERVER_FD'])
-        except (LookupError, ValueError):
-            fd = None
+        fd = os.getenv('WERKZEUG_SERVER_FD')
+        fd = int(fd) if isinstance(fd, str) and fd.isdigit() else None
         srv = make_server(hostname, port, application, threaded,
                           processes, request_handler,
                           passthrough_errors, ssl_context,


### PR DESCRIPTION
`try-except` in `inner()` in `run_simple()` leaves exceptions grounds. When `use_reloader` is set to `True`, at that point `KeyError` is raised and in Flask environment, by mysterious reason the exception grounds shall be given to signal handlers, and it is seen as an exception. (Refer https://github.com/mitsuhiko/flask/issues/1694 / this patch may fixes this issue.)
