### PR TITLE
Fixed infinite loop FileStorage iter in python 3

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -900,3 +900,15 @@ class TestFileStorage(object):
     def test_mimetype_always_lowercase(self):
         file_storage = self.storage_class(content_type='APPLICATION/JSON')
         assert file_storage.mimetype == 'application/json'
+
+    def test_bytes_proper_sentinel(self):
+        # ensure we iterate over new lines and don't enter into an infinite loop
+        import io
+        unicode_storage = self.storage_class(io.StringIO(u"one\ntwo"))
+        for idx, line in enumerate(unicode_storage):
+            assert idx < 2
+        assert idx == 1
+        binary_storage = self.storage_class(io.BytesIO(b"one\ntwo"))
+        for idx, line in enumerate(binary_storage):
+            assert idx < 2
+        assert idx == 1

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2671,7 +2671,7 @@ class FileStorage(object):
         return getattr(self.stream, name)
 
     def __iter__(self):
-        return iter(self.readline, '')
+        return iter(self.stream)
 
     def __repr__(self):
         return '<%s: %r (%r)>' % (


### PR DESCRIPTION
In python 3 if you would iterate over FileStorage and the underlying stream returned bytes arrays the existing sentinel, being the empty string, would never equate to an empty bytes array and an infinite loop would occur. To fix this, I query if the underlying stream inherits from TextIOBase and set the sentinel to an empty string otherwise I set it to an empty bytes array so StopIteration will be called at the end of the file correctly. This is backwards compatible with python 2 as '' == b'' and it does not matter which of these the sentinel is set to.