### PR TITLE
make test Client follow relative redirects

### DIFF
--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -72,6 +72,19 @@ def external_redirect_demo_app(environ, start_response):
     return response(environ, start_response)
 
 
+class LocalResponse(BaseResponse):
+    autocorrect_location_header = False
+
+
+def local_redirect_app(environ, start_response):
+    req = Request(environ)
+    if '/from/location' in req.url:
+        response = redirect('/to/location', Response=LocalResponse)
+    else:
+        response = Response('current path: %s' % req.path)
+    return response(environ, start_response)
+
+
 def external_subdomain_redirect_demo_app(environ, start_response):
     if 'test.example.com' in environ['HTTP_HOST']:
         response = Response('redirected successfully to subdomain')
@@ -335,6 +348,13 @@ def test_follow_redirect():
     resp = c.get('/first/request', follow_redirects=True)
     strict_eq(resp.status_code, 200)
     strict_eq(resp.data, b'current url: http://localhost/some/redirect/')
+
+
+def test_follow_local_redirect():
+    c = Client(local_redirect_app, response_wrapper=BaseResponse)
+    resp = c.get('/from/location', follow_redirects=True)
+    strict_eq(resp.status_code, 200)
+    strict_eq(resp.data, b'current path: /to/location')
 
 
 def test_follow_redirect_with_post_307():

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -72,19 +72,6 @@ def external_redirect_demo_app(environ, start_response):
     return response(environ, start_response)
 
 
-class LocalResponse(BaseResponse):
-    autocorrect_location_header = False
-
-
-def local_redirect_app(environ, start_response):
-    req = Request(environ)
-    if '/from/location' in req.url:
-        response = redirect('/to/location', Response=LocalResponse)
-    else:
-        response = Response('current path: %s' % req.path)
-    return response(environ, start_response)
-
-
 def external_subdomain_redirect_demo_app(environ, start_response):
     if 'test.example.com' in environ['HTTP_HOST']:
         response = Response('redirected successfully to subdomain')
@@ -351,6 +338,17 @@ def test_follow_redirect():
 
 
 def test_follow_local_redirect():
+    class LocalResponse(BaseResponse):
+        autocorrect_location_header = False
+
+    def local_redirect_app(environ, start_response):
+        req = Request(environ)
+        if '/from/location' in req.url:
+            response = redirect('/to/location', Response=LocalResponse)
+        else:
+            response = Response('current path: %s' % req.path)
+        return response(environ, start_response)
+
     c = Client(local_redirect_app, response_wrapper=BaseResponse)
     resp = c.get('/from/location', follow_redirects=True)
     strict_eq(resp.status_code, 200)

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -679,6 +679,10 @@ class Client(object):
 
         cur_server_name = netloc.split(':', 1)[0].split('.')
         real_server_name = get_host(environ).rsplit(':', 1)[0].split('.')
+        if cur_server_name == ['']:
+            # this is a local redirect having autocorrect_location_header=False
+            cur_server_name = real_server_name
+            base_url = EnvironBuilder(environ).base_url
 
         if self.allow_subdomain_redirects:
             allowed = cur_server_name[-len(real_server_name):] == real_server_name


### PR DESCRIPTION
v 0.8 introduced BaseResponse attribute autocorrect_location_header allowing users to use relative URLs in Location header.

This PR makes testing Client recognize such locations in redirects.
