### PR TITLE
Remove IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,3 @@ branches:
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "chat.freenode.net#pocoo"
-    on_success: change
-    on_failure: always
-    use_notice: true
-    skip_join: true


### PR DESCRIPTION
It is not the right approach to keep track of broken builds. Trying to
embrace @homu for this.