### PR TITLE
set_cookie cleanup in wrappers.py

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -229,7 +229,8 @@ def test_base_response():
 
     # set cookie
     response = wrappers.BaseResponse()
-    response.set_cookie('foo', 'bar', 60, 0, '/blub', 'example.org')
+    response.set_cookie('foo', value='bar', max_age=60, expires=0,
+                        path='/blub', domain='example.org')
     strict_eq(response.headers.to_wsgi_list(), [
         ('Content-Type', 'text/plain; charset=utf-8'),
         ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -968,3 +968,40 @@ def test_modified_url_encoding():
 def test_request_method_case_sensitivity():
     req = wrappers.Request({'REQUEST_METHOD': 'get'})
     assert req.method == 'GET'
+
+
+class TestSetCookie(object):
+    """Tests for :meth:`werkzeug.wrappers.BaseResponse.set_cookie`."""
+
+    def test_secure(self):
+        response = wrappers.BaseResponse()
+        response.set_cookie('foo', value='bar', max_age=60, expires=0,
+                            path='/blub', domain='example.org', secure=True)
+        strict_eq(response.headers.to_wsgi_list(), [
+            ('Content-Type', 'text/plain; charset=utf-8'),
+            ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
+             '01-Jan-1970 00:00:00 GMT; Max-Age=60; Secure; Path=/blub')
+        ])
+
+    def test_httponly(self):
+        response = wrappers.BaseResponse()
+        response.set_cookie('foo', value='bar', max_age=60, expires=0,
+                            path='/blub', domain='example.org', secure=False,
+                            httponly=True)
+        strict_eq(response.headers.to_wsgi_list(), [
+            ('Content-Type', 'text/plain; charset=utf-8'),
+            ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
+             '01-Jan-1970 00:00:00 GMT; Max-Age=60; HttpOnly; Path=/blub')
+        ])
+
+    def test_secure_and_httponly(self):
+        response = wrappers.BaseResponse()
+        response.set_cookie('foo', value='bar', max_age=60, expires=0,
+                            path='/blub', domain='example.org', secure=True,
+                            httponly=True)
+        strict_eq(response.headers.to_wsgi_list(), [
+            ('Content-Type', 'text/plain; charset=utf-8'),
+            ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
+             '01-Jan-1970 00:00:00 GMT; Max-Age=60; Secure; HttpOnly; '
+             'Path=/blub')
+        ])

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1011,9 +1011,15 @@ class BaseResponse(object):
         :param path: limits the cookie to a given path, per default it will
                      span the whole domain.
         """
-        self.headers.add('Set-Cookie', dump_cookie(key, value, max_age,
-                                                   expires, path, domain, secure, httponly,
-                                                   self.charset))
+        self.headers.add('Set-Cookie', dump_cookie(key,
+                                                   value=value,
+                                                   max_age=max_age,
+                                                   expires=expires,
+                                                   path=path,
+                                                   domain=domain,
+                                                   secure=secure,
+                                                   httponly=httponly,
+                                                   charset=self.charset))
 
     def delete_cookie(self, key, path='/', domain=None):
         """Delete a cookie.  Fails silently if key doesn't exist.

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -993,7 +993,7 @@ class BaseResponse(object):
         return _iter_encoded(self.response, self.charset)
 
     def set_cookie(self, key, value='', max_age=None, expires=None,
-                   path='/', domain=None, secure=None, httponly=False):
+                   path='/', domain=None, secure=False, httponly=False):
         """Sets a cookie. The parameters are the same as in the cookie `Morsel`
         object in the Python standard library but it accepts unicode data, too.
 

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1003,13 +1003,13 @@ class BaseResponse(object):
                         the cookie should last only as long as the client's
                         browser session.
         :param expires: should be a `datetime` object or UNIX timestamp.
+        :param path: limits the cookie to a given path, per default it will
+                     span the whole domain.
         :param domain: if you want to set a cross-domain cookie.  For example,
                        ``domain=".example.com"`` will set a cookie that is
                        readable by the domain ``www.example.com``,
                        ``foo.example.com`` etc.  Otherwise, a cookie will only
                        be readable by the domain that set it.
-        :param path: limits the cookie to a given path, per default it will
-                     span the whole domain.
         :param secure: If `True`, the cookie will only be available via HTTPS
         :param httponly: disallow JavaScript to access the cookie.  This is an
                          extension to the cookie standard and probably not

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1010,6 +1010,10 @@ class BaseResponse(object):
                        be readable by the domain that set it.
         :param path: limits the cookie to a given path, per default it will
                      span the whole domain.
+        :param secure: If `True`, the cookie will only be available via HTTPS
+        :param httponly: disallow JavaScript to access the cookie.  This is an
+                         extension to the cookie standard and probably not
+                         supported by all browsers.
         """
         self.headers.add('Set-Cookie', dump_cookie(key,
                                                    value=value,


### PR DESCRIPTION
This changes includes a handful of small patches to `BaseResponse.set_cookie`. It's intended to address https://github.com/pallets/werkzeug/issues/888, which I just created.

I intentionally put each small change in a separate commit so that they could be modified or discarded as needed. Let me know if this is okay or if I should just squash them all into one.