### PR TITLE
Allow logging before run_wsgi is called.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@ Werkzeug Changelog
 Version 0.11.6
 --------------
 
+- werkzeug.serving: Still show the client address on bad requests.
+
 Version 0.11.5
 --------------
 

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -211,4 +211,6 @@ def test_wrong_protocol(dev_server):
     with pytest.raises(requests.exceptions.ConnectionError):
         requests.get('https://%s/' % server.addr)
 
-    assert 'Traceback' not in server.logfile.read()
+    log = server.logfile.read()
+    assert 'Traceback' not in log
+    assert '\n127.0.0.1' in log

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -113,8 +113,8 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             'QUERY_STRING':         wsgi_encoding_dance(request_url.query),
             'CONTENT_TYPE':         self.headers.get('Content-Type', ''),
             'CONTENT_LENGTH':       self.headers.get('Content-Length', ''),
-            'REMOTE_ADDR':          self.client_address[0],
-            'REMOTE_PORT':          self.client_address[1],
+            'REMOTE_ADDR':          self.address_string(),
+            'REMOTE_PORT':          self.port_integer(),
             'SERVER_NAME':          self.server.server_address[0],
             'SERVER_PORT':          str(self.server.server_address[1]),
             'SERVER_PROTOCOL':      self.request_version
@@ -263,10 +263,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return BaseHTTPRequestHandler.version_string(self).strip()
 
     def address_string(self):
-        if getattr(self, 'environ', None):
-            return self.environ['REMOTE_ADDR']
-        else:
-            return ''
+        return self.client_address[0]
+
+    def port_integer(self):
+        return self.client_address[1]
 
     def log_request(self, code='-', size='-'):
         self.log('info', '"%s" %s %s', self.requestline, code, size)


### PR DESCRIPTION
WSGIRequestHandler.log used to require self.environ to be set before it's called as
WSGIRequestHandler.address_string looked self.environ up.

Continuation of #833