### PR TITLE
Recognize NetBSD and OpenBSD platforms in the useragent string.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Project Leader / Developer:
 - Daniel Neuhäuser
 - Markus Unterwaditzer
 - Joe Esposito <joe@joeyespo.com>
+- Abhinav Upadhyay <er.abhinav.upadhyay@gmail.com>
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,8 @@ Unreleased.
   loop.
 - Datastructures now inherit from the relevant baseclasses from the
   `collections` module in the stdlib. See #794.
+- Add support for recognizing NetBSD and OpenBSD platforms in the user agent
+  string.
 
 Version 0.11.5
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -17,8 +17,9 @@ Unreleased.
   loop.
 - Datastructures now inherit from the relevant baseclasses from the
   `collections` module in the stdlib. See #794.
-- Add support for recognizing NetBSD and OpenBSD platforms in the user agent
-  string.
+- Add support for recognizing NetBSD, OpenBSD, and FreeBSD platforms in the
+  user agent string.
+- Recognize SeaMonkey browser name and version correctly
 
 Version 0.11.5
 --------------

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -384,8 +384,23 @@ def test_user_agent_mixin():
         ('Mozilla/5.0 (SymbianOS/9.3; Series60/3.2 NokiaE5-00/101.003; '
          'Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) '
          'NokiaBrowser/7.3.1.35 Mobile Safari/533.4 3gpp-gba',
-         'safari', 'symbian', '533.4', None)
-
+         'safari', 'symbian', '533.4', None),
+        ('Mozilla/5.0 (X11; OpenBSD amd64; rv:45.0) Gecko/20100101 Firefox/45.0',
+         'firefox', 'openbsd', '45.0', None),
+        ('Mozilla/5.0 (X11; NetBSD amd64; rv:45.0) Gecko/20100101 Firefox/45.0',
+         'firefox', 'netbsd', '45.0', None),
+        ('Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/537.36 (KHTML, like Gecko) '
+         'Chrome/48.0.2564.103 Safari/537.36',
+         'chrome', 'freebsd', '48.0.2564.103', None),
+        ('Mozilla/5.0 (X11; FreeBSD amd64; rv:45.0) Gecko/20100101 Firefox/45.0',
+         'firefox', 'freebsd', '45.0', None),
+        ('Mozilla/5.0 (X11; U; NetBSD amd64; en-US; rv:) Gecko/20150921 SeaMonkey/1.1.18',
+         'seamonkey', 'netbsd', '1.1.18', 'en-US'),
+        ('Mozilla/5.0 (Windows; U; Windows NT 6.2; WOW64; rv:1.8.0.7) '
+         'Gecko/20110321 MultiZilla/4.33.2.6a SeaMonkey/8.6.55',
+         'seamonkey', 'windows', '8.6.55', None),
+        ('Mozilla/5.0 (X11; Linux x86_64; rv:12.0) Gecko/20120427 Firefox/12.0 SeaMonkey/2.9',
+         'seamonkey', 'linux', '2.9', None)
     ]
     for ua, browser, platform, version, lang in user_agents:
         request = wrappers.Request({'HTTP_USER_AGENT': ua})

--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -25,6 +25,8 @@ class UserAgentParser(object):
         (r'darwin|mac|os\s*x', 'macos'),
         ('win', 'windows'),
         (r'android', 'android'),
+        ('netbsd', 'netbsd'),
+        ('openbsd', 'openbsd'),
         (r'x11|lin(\b|ux)?', 'linux'),
         ('(sun|i86)os', 'solaris'),
         (r'nintendo\s+wii', 'wii'),

--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -27,6 +27,7 @@ class UserAgentParser(object):
         (r'android', 'android'),
         ('netbsd', 'netbsd'),
         ('openbsd', 'openbsd'),
+        ('freebsd', 'freebsd'),
         (r'x11|lin(\b|ux)?', 'linux'),
         ('(sun|i86)os', 'solaris'),
         (r'nintendo\s+wii', 'wii'),
@@ -47,6 +48,7 @@ class UserAgentParser(object):
         (r'aol|america\s+online\s+browser', 'aol'),
         ('opera', 'opera'),
         ('chrome', 'chrome'),
+        ('seamonkey', 'seamonkey'),
         ('firefox|firebird|phoenix|iceweasel', 'firefox'),
         ('galeon', 'galeon'),
         ('safari|version', 'safari'),
@@ -57,8 +59,7 @@ class UserAgentParser(object):
         ('netscape', 'netscape'),
         (r'msie|microsoft\s+internet\s+explorer|trident/.+? rv:', 'msie'),
         ('lynx', 'lynx'),
-        ('links', 'links'),
-        ('seamonkey|mozilla', 'seamonkey')
+        ('links', 'links')
     )
 
     _browser_version_re = r'(?:%s)[/\sa-z(]*(\d+[.\da-z]+)?(?i)'


### PR DESCRIPTION
I noticed that the platform in the useragent was being reported as linux for user agent strings which had NetBSD and OpenBSD as platforms. A sample user agent string is below. The proposed change helps recognize the correct platform for these strings.

```Mozilla/5.0 (X11; OpenBSD amd64; rv:45.0) Gecko/20100101 Firefox/45.0```
 ```Mozilla/5.0 (X11; NetBSD amd64; rv:45.0) Gecko/20100101 Firefox/45.0```

