### PR TITLE
Fix get_machine_id on OS X

### DIFF
--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -67,7 +67,7 @@ def get_machine_id():
         try:
             dump = Popen(['ioreg', '-c', 'IOPlatformExpertDevice', '-d', '2'],
                          stdout=PIPE).communicate()[0]
-            match = re.match(r'"serial-number" = <([^>]+)', dump)
+            match = re.search(b'"serial-number" = <([^>]+)', dump)
             if match is not None:
                 return match.group(1)
         except OSError:


### PR DESCRIPTION
Fixes #895 where the call to ioreg gave a bytes result, which was then handed to a str (in Python 3) regex call and raised a TypeError.