### PR TITLE
decode bytes to string for py3

### DIFF
--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -67,7 +67,7 @@ def get_machine_id():
         try:
             dump = Popen(['ioreg', '-c', 'IOPlatformExpertDevice', '-d', '2'],
                          stdout=PIPE).communicate()[0]
-            match = re.match(r'"serial-number" = <([^>]+)', dump)
+            match = re.match(r'"serial-number" = <([^>]+)', dump.decode())
             if match is not None:
                 return match.group(1)
         except OSError:


### PR DESCRIPTION
when i run flask in debug mode with py3, it crashes, here is the full error stack:

 * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
Traceback (most recent call last):
  File "app.py", line 16, in <module>
    app.run(debug=True)
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/flask/app.py", line 772, in run
    run_simple(host, port, self, **options)
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/werkzeug/serving.py", line 633, in run_simple
    application = DebuggedApplication(application, use_evalex)
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/werkzeug/debug/__init__.py", line 249, in __init__
    if self.pin is None:
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/werkzeug/debug/__init__.py", line 259, in _get_pin
    self._pin, self._pin_cookie = get_pin_and_cookie_name(self.app)
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/werkzeug/debug/__init__.py", line 159, in get_pin_and_cookie_name
    get_machine_id(),
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/werkzeug/debug/__init__.py", line 94, in get_machine_id
    _machine_id = rv = _generate()
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/site-packages/werkzeug/debug/__init__.py", line 70, in _generate
    match = re.match(r'"serial-number" = <([^>]+)', dump)
  File "/Users/pengfei/Code/mine/socketio/lib/python3.5/re.py", line 163, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object