### PR TITLE
Fix timestamp given as string

### DIFF
--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -368,7 +368,7 @@ class DebuggedApplication(object):
             return False
         if pin_hash != hash_pin(self.pin):
             return None
-        return (time.time() - PIN_TIME) < ts
+        return (time.time() - PIN_TIME) < float(ts)
 
     def _fail_pin_auth(self):
         time.sleep(self._failed_pin_auth > 5 and 5.0 or 0.5)


### PR DESCRIPTION
Fix TypeError: unorderable types: float() < str()

found with python 3.6dev