### PR TITLE
Don't redirect to slash route when method does not match

### DIFF
--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -745,9 +745,9 @@ class Rule(RuleFactory):
         )
         self._regex = re.compile(regex, re.UNICODE)
 
-    def match(self, path):
+    def match(self, path, method=None):
         """Check if the rule matches a given path. Path is a string in the
-        form ``"subdomain|/path(method)"`` and is assembled by the map.  If
+        form ``"subdomain|/path"`` and is assembled by the map.  If
         the map is doing host matching the subdomain part will be the host
         instead.
 
@@ -765,7 +765,9 @@ class Rule(RuleFactory):
                 # tells the map to redirect to the same url but with a
                 # trailing slash
                 if self.strict_slashes and not self.is_leaf and \
-                   not groups.pop('__suffix__'):
+                        not groups.pop('__suffix__') and \
+                        (method is None or self.methods is None or
+                         method in self.methods):
                     raise RequestSlash()
                 # if we are not in strict slashes mode we have to remove
                 # a __suffix__
@@ -1521,7 +1523,7 @@ class MapAdapter(object):
         have_match_for = set()
         for rule in self.map._rules:
             try:
-                rv = rule.match(path)
+                rv = rule.match(path, method)
             except RequestSlash:
                 raise RequestRedirect(self.make_redirect_url(
                     url_quote(path_info, self.map.charset,


### PR DESCRIPTION
This is a very simple fix for https://github.com/pallets/flask/issues/1783, it simply only redirects to slash when the method matches as well. I think this would qualify as backwards compatible as it only changes behaviour for routes that previously returned a 405 where there were actual routes matching the route exactly.