### PR TITLE
fix issue #909

### DIFF
--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -69,6 +69,14 @@ class TestFormParser(object):
         req.max_form_memory_size = 400
         strict_eq(req.form['foo'], u'Hello World')
 
+        data = b'foo=Hello+World&bar=\xd6\xd0\xce\xc4'
+        req = Request.from_values(input_stream=BytesIO(data),
+                                  content_length=len(data),
+                                  content_type='application/x-www-form-urlencoded; charset=GBK',
+                                  method='POST')
+        req.max_content_length = 400
+        strict_eq(req.form['bar'], u'中文')
+
         data = (b'--foo\r\nContent-Disposition: form-field; name=foo\r\n\r\n'
                 b'Hello World\r\n'
                 b'--foo\r\nContent-Disposition: form-field; name=bar\r\n\r\n'

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -218,6 +218,8 @@ class FormDataParser(object):
            content_length is not None and \
            content_length > self.max_form_memory_size:
             raise exceptions.RequestEntityTooLarge()
+        if options:
+            self.charset = options.get('charset', self.charset)
         form = url_decode_stream(stream, self.charset,
                                  errors=self.errors, cls=self.cls)
         return stream, form, self.cls()


### PR DESCRIPTION
Fixed a bug:

When request content-type is application/x-www-form-urlencoded or application/x-url-encoded and charset is not utf-8, request data will be decoded by wrong charset(always utf-8).