### PR TITLE
Fix a Python 2.6 formatter bug

### DIFF
--- a/werkzeug/filesystem.py
+++ b/werkzeug/filesystem.py
@@ -59,7 +59,7 @@ def get_filesystem_encoding():
         if not _warned_about_filesystem_encoding:
             warnings.warn(
                 'Detected a misconfigured UNIX filesystem: Will use UTF-8 as '
-                'filesystem encoding instead of {!r}'.format(rv),
+                'filesystem encoding instead of {0!r}'.format(rv),
                 BrokenFilesystemWarning)
             _warned_about_filesystem_encoding = True
         return 'utf-8'


### PR DESCRIPTION
There are already tests that cover this, but apparently the system they run on matters.
I hit this running with Python 2.6.6 in the Docker base image for CentOS 6.7 (see the Dockerfile below).
* Note: There is an extra failure I'm not sure how best to fix. I have opened [an issue](https://github.com/pallets/werkzeug/issues/914) for this.
``` Dockerfile
FROM centos:6.7

# Get pip.
RUN yum install -y epel-release
RUN yum install -y python-pip
RUN pip install --upgrade pip

RUN pip install pytest requests
WORKDIR /src
COPY . .
RUN py.test
```
```
============================= test session starts ==============================
platform linux2 -- Python 2.6.6, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /src, inifile: setup.cfg
collected 459 items

tests/test_compat.py ..
tests/test_datastructures.py .............................................s..
tests/test_debug.py .............FFF.ss
tests/test_exceptions.py ......................
tests/test_formparser.py ...................
tests/test_http.py .................................
tests/test_internal.py ...
tests/test_local.py .........
tests/test_routing.py ..................................................
tests/test_security.py ....
tests/test_serving.py sssssssssFs
tests/test_test.py ...................................
tests/test_urls.py .........................................
tests/test_utils.py ...................
tests/test_wrappers.py ...................................................
tests/test_wsgi.py .F.....................
tests/contrib/test_atom.py .
tests/contrib/test_cache.py ...............................ssssssssssssss
tests/contrib/test_fixers.py .......
tests/contrib/test_iterio.py ....ss
tests/contrib/test_securecookie.py ..
tests/contrib/test_sessions.py .....
tests/contrib/test_wrappers.py ...
tests/res/test.txt s

=================================== FAILURES ===================================
____________________________ TestTraceback.test_log ____________________________

self = <tests.test_debug.TestTraceback object at 0x2283590>

    def test_log(self):
        try:
            1 / 0
        except ZeroDivisionError:
>           traceback = Traceback(*sys.exc_info())

tests/test_debug.py:193: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
werkzeug/debug/tbtools.py:235: in __init__
    self.frames.append(Frame(exc_type, exc_value, tb))
werkzeug/debug/tbtools.py:402: in __init__
    self.filename = to_unicode(fn, get_filesystem_encoding())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def get_filesystem_encoding():
        """
        Returns the filesystem encoding that should be used. Note that this is
        different from the Python understanding of the filesystem encoding which
        might be deeply flawed. Do not use this value against Python's unicode APIs
        because it might be different. See :ref:`filesystem-encoding` for the exact
        behavior.
    
        The concept of a filesystem encoding in generally is not something you
        should rely on. As such if you ever need to use this function except for
        writing wrapper code reconsider.
        """
        global _warned_about_filesystem_encoding
        rv = sys.getfilesystemencoding()
        if has_likely_buggy_unicode_filesystem and not rv \
           or _is_ascii_encoding(rv):
            if not _warned_about_filesystem_encoding:
                warnings.warn(
                    'Detected a misconfigured UNIX filesystem: Will use UTF-8 as '
>                   'filesystem encoding instead of {!r}'.format(rv),
                    BrokenFilesystemWarning)
E               ValueError: zero length field name in format

werkzeug/filesystem.py:62: ValueError
___________________ TestTraceback.test_sourcelines_encoding ____________________

self = <tests.test_debug.TestTraceback object at 0x22ac250>

    def test_sourcelines_encoding(self):
        source = (u'# -*- coding: latin1 -*-\n\n'
                  u'def foo():\n'
                  u'    """höhö"""\n'
                  u'    1 / 0\n'
                  u'foo()').encode('latin1')
        code = compile(source, filename='lol.py', mode='exec')
        try:
            eval(code)
        except ZeroDivisionError:
>           traceback = Traceback(*sys.exc_info())

tests/test_debug.py:209: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
werkzeug/debug/tbtools.py:235: in __init__
    self.frames.append(Frame(exc_type, exc_value, tb))
werkzeug/debug/tbtools.py:402: in __init__
    self.filename = to_unicode(fn, get_filesystem_encoding())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def get_filesystem_encoding():
        """
        Returns the filesystem encoding that should be used. Note that this is
        different from the Python understanding of the filesystem encoding which
        might be deeply flawed. Do not use this value against Python's unicode APIs
        because it might be different. See :ref:`filesystem-encoding` for the exact
        behavior.
    
        The concept of a filesystem encoding in generally is not something you
        should rely on. As such if you ever need to use this function except for
        writing wrapper code reconsider.
        """
        global _warned_about_filesystem_encoding
        rv = sys.getfilesystemencoding()
        if has_likely_buggy_unicode_filesystem and not rv \
           or _is_ascii_encoding(rv):
            if not _warned_about_filesystem_encoding:
                warnings.warn(
                    'Detected a misconfigured UNIX filesystem: Will use UTF-8 as '
>                   'filesystem encoding instead of {!r}'.format(rv),
                    BrokenFilesystemWarning)
E               ValueError: zero length field name in format

werkzeug/filesystem.py:62: ValueError
_____________________ TestTraceback.test_filename_encoding _____________________

self = <tests.test_debug.TestTraceback object at 0x1ea7bd0>
tmpdir = local('/tmp/pytest-of-root/pytest-0/test_filename_encoding0')
monkeypatch = <_pytest.monkeypatch.monkeypatch instance at 0x201d9e0>

    def test_filename_encoding(self, tmpdir, monkeypatch):
        moduledir = tmpdir.mkdir('föö')
        moduledir.join('bar.py').write('def foo():\n    1/0\n')
        monkeypatch.syspath_prepend(str(moduledir))
    
        import bar
    
        try:
            bar.foo()
        except ZeroDivisionError:
>           traceback = Traceback(*sys.exc_info())

tests/test_debug.py:237: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
werkzeug/debug/tbtools.py:235: in __init__
    self.frames.append(Frame(exc_type, exc_value, tb))
werkzeug/debug/tbtools.py:402: in __init__
    self.filename = to_unicode(fn, get_filesystem_encoding())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def get_filesystem_encoding():
        """
        Returns the filesystem encoding that should be used. Note that this is
        different from the Python understanding of the filesystem encoding which
        might be deeply flawed. Do not use this value against Python's unicode APIs
        because it might be different. See :ref:`filesystem-encoding` for the exact
        behavior.
    
        The concept of a filesystem encoding in generally is not something you
        should rely on. As such if you ever need to use this function except for
        writing wrapper code reconsider.
        """
        global _warned_about_filesystem_encoding
        rv = sys.getfilesystemencoding()
        if has_likely_buggy_unicode_filesystem and not rv \
           or _is_ascii_encoding(rv):
            if not _warned_about_filesystem_encoding:
                warnings.warn(
                    'Detected a misconfigured UNIX filesystem: Will use UTF-8 as '
>                   'filesystem encoding instead of {!r}'.format(rv),
                    BrokenFilesystemWarning)
E               ValueError: zero length field name in format

werkzeug/filesystem.py:62: ValueError
___________________________ test_monkeypached_sleep ____________________________

tmpdir = local('/tmp/pytest-of-root/pytest-0/test_monkeypached_sleep0')

    def test_monkeypached_sleep(tmpdir):
        # removing the staticmethod wrapper in the definition of
        # ReloaderLoop._sleep works most of the time, since `sleep` is a c
        # function, and unlike python functions which are descriptors, doesn't
        # become a method when attached to a class. however, if the user has called
        # `eventlet.monkey_patch` before importing `_reloader`, `time.sleep` is a
        # python function, and subsequently calling `ReloaderLoop._sleep` fails
        # with a TypeError. This test checks that _sleep is attached correctly.
        script = tmpdir.mkdir('app').join('test.py')
        script.write(textwrap.dedent('''
        import time
    
        def sleep(secs):
            pass
    
        # simulate eventlet.monkey_patch by replacing the builtin sleep
        # with a regular function before _reloader is imported
        time.sleep = sleep
    
        from werkzeug._reloader import ReloaderLoop
        ReloaderLoop()._sleep(0)
        '''))
>       subprocess.check_call(['python', str(script)])

tests/test_serving.py:233: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

popenargs = (['python', '/tmp/pytest-of-root/pytest-0/test_monkeypached_sleep0/app/test.py'],)
kwargs = {}, retcode = 1
cmd = ['python', '/tmp/pytest-of-root/pytest-0/test_monkeypached_sleep0/app/test.py']

    def check_call(*popenargs, **kwargs):
        """Run command with arguments.  Wait for command to complete.  If
        the exit code was zero then return, otherwise raise
        CalledProcessError.  The CalledProcessError object will have the
        return code in the returncode attribute.
    
        The arguments are the same as for the Popen constructor.  Example:
    
        check_call(["ls", "-l"])
        """
        retcode = call(*popenargs, **kwargs)
        cmd = kwargs.get("args")
        if cmd is None:
            cmd = popenargs[0]
        if retcode:
>           raise CalledProcessError(retcode, cmd)
E           CalledProcessError: Command '['python', '/tmp/pytest-of-root/pytest-0/test_monkeypached_sleep0/app/test.py']' returned non-zero exit status 1

/usr/lib64/python2.6/subprocess.py:505: CalledProcessError
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/tmp/pytest-of-root/pytest-0/test_monkeypached_sleep0/app/test.py", line 11, in <module>
    from werkzeug._reloader import ReloaderLoop
ImportError: No module named werkzeug._reloader
_________________________ test_shared_data_middleware __________________________

tmpdir = local('/tmp/pytest-of-root/pytest-0/test_shared_data_middleware0')

    def test_shared_data_middleware(tmpdir):
        def null_application(environ, start_response):
            start_response('404 NOT FOUND', [('Content-Type', 'text/plain')])
            yield b'NOT FOUND'
    
        test_dir = str(tmpdir)
        with open(path.join(test_dir, to_native(u'äöü', 'utf-8')), 'w') as test_file:
            test_file.write(u'FOUND')
    
        app = wsgi.SharedDataMiddleware(null_application, {
            '/':        path.join(path.dirname(__file__), 'res'),
            '/sources': path.join(path.dirname(__file__), 'res'),
            '/pkg':     ('werkzeug.debug', 'shared'),
            '/foo':     test_dir
        })
    
        for p in '/test.txt', '/sources/test.txt', '/foo/äöü':
>           app_iter, status, headers = run_wsgi_app(app, create_environ(p))

tests/test_wsgi.py:48: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
werkzeug/test.py:871: in run_wsgi_app
    app_rv = app(environ, start_response)
werkzeug/wsgi.py:578: in __call__
    cleaned_path = cleaned_path.encode(get_filesystem_encoding())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def get_filesystem_encoding():
        """
        Returns the filesystem encoding that should be used. Note that this is
        different from the Python understanding of the filesystem encoding which
        might be deeply flawed. Do not use this value against Python's unicode APIs
        because it might be different. See :ref:`filesystem-encoding` for the exact
        behavior.
    
        The concept of a filesystem encoding in generally is not something you
        should rely on. As such if you ever need to use this function except for
        writing wrapper code reconsider.
        """
        global _warned_about_filesystem_encoding
        rv = sys.getfilesystemencoding()
        if has_likely_buggy_unicode_filesystem and not rv \
           or _is_ascii_encoding(rv):
            if not _warned_about_filesystem_encoding:
                warnings.warn(
                    'Detected a misconfigured UNIX filesystem: Will use UTF-8 as '
>                   'filesystem encoding instead of {!r}'.format(rv),
                    BrokenFilesystemWarning)
E               ValueError: zero length field name in format

werkzeug/filesystem.py:62: ValueError
=============== 5 failed, 424 passed, 30 skipped in 3.72 seconds ===============
```