### PR TITLE
LocalProxy: add __wrapped__ attribute to refer to wrapped function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Project Leader / Developer:
 - Markus Unterwaditzer
 - Joe Esposito <joe@joeyespo.com>
 - Abhinav Upadhyay <er.abhinav.upadhyay@gmail.com>
+- immerrr <immerrr@gmail.com>
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Unreleased.
   in the user agent string.
 - Recognize SeaMonkey browser name and version correctly
 - Recognize Baiduspider, and bingbot user agents
+- If `LocalProxy`'s wrapped object is a function, refer to it with __wrapped__
+  attribute.
 
 Version 0.11.10
 ---------------

--- a/werkzeug/local.py
+++ b/werkzeug/local.py
@@ -287,11 +287,15 @@ class LocalProxy(object):
     .. versionchanged:: 0.6.1
        The class can be instanciated with a callable as well now.
     """
-    __slots__ = ('__local', '__dict__', '__name__')
+    __slots__ = ('__local', '__dict__', '__name__', '__wrapped__')
 
     def __init__(self, local, name=None):
         object.__setattr__(self, '_LocalProxy__local', local)
         object.__setattr__(self, '__name__', name)
+        if callable(local) and not hasattr(local, '__release_local__'):
+            # "local" is a callable that is not an instance of Local or
+            # LocalManager: mark it as a wrapped function.
+            object.__setattr__(self, '__wrapped__', local)
 
     def _get_current_object(self):
         """Return the current object.  This is useful if you want the real


### PR DESCRIPTION
This is an attempt to fix https://github.com/pallets/flask/issues/1680.

`__wrapped__` attribute is a somewhat unofficial dunder-attribute used in `functools` and `inspect` to refer to an underlying function of a decorator. Technically, `LocalProxy` can wrap callables, so using `__wrapped__` attribute does not seem much of a "workaround".

If "local" is not a callable, `__wrapped__` slot is not initialized, and thus the `proxy.__wrapped__` request will  be forwarded to current object as previously.