### PR TITLE
routing methods type checking

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -522,11 +522,8 @@ def test_implicit_head():
 
 
 def test_pass_str_as_router_methods():
-    try:
+    with pytest.raises(TypeError):
         r.Rule('/get', methods='GET')
-        raise AssertionError
-    except Exception as e:
-        assert isinstance(e, TypeError)
 
 
 def test_protocol_joining_bug():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -522,10 +522,10 @@ def test_implicit_head():
 
 
 def test_pass_str_as_router_methods():
-    test_get = r.Rule('/get', methods='GET')
-    assert test_get.methods == set(['HEAD', 'GET'])
-    test_post = r.Rule('/post', methods='POST')
-    assert test_post.methods == set(['POST'])
+    try:
+        r.Rule('/get', methods='GET')
+    except Exception as e:
+        assert isinstance(e, TypeError)
 
 
 def test_protocol_joining_bug():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -524,6 +524,7 @@ def test_implicit_head():
 def test_pass_str_as_router_methods():
     try:
         r.Rule('/get', methods='GET')
+        raise AssertionError
     except Exception as e:
         assert isinstance(e, TypeError)
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -521,6 +521,13 @@ def test_implicit_head():
                   '/post', method='HEAD')
 
 
+def test_pass_str_as_router_methods():
+    test_get = r.Rule('/get', methods='GET')
+    assert test_get.methods == set(['HEAD', 'GET'])
+    test_post = r.Rule('/post', methods='POST')
+    assert test_post.methods == set(['POST'])
+
+
 def test_protocol_joining_bug():
     m = r.Map([r.Rule('/<foo>', endpoint='x')])
     a = m.bind('example.org')

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -615,7 +615,7 @@ class Rule(RuleFactory):
             self.methods = None
         else:
             if isinstance(methods, str):
-                methods = [methods]
+                raise TypeError('param `methods` should be `Iterable[str]`, not `str`')
             self.methods = set([x.upper() for x in methods])
             if 'HEAD' not in self.methods and 'GET' in self.methods:
                 self.methods.add('HEAD')

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -613,6 +613,8 @@ class Rule(RuleFactory):
         self.alias = alias
         if methods is None:
             self.methods = None
+        if isinstance(methods, str):
+            self.methods = [methods]
         else:
             self.methods = set([x.upper() for x in methods])
             if 'HEAD' not in self.methods and 'GET' in self.methods:

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -615,7 +615,7 @@ class Rule(RuleFactory):
             self.methods = None
         else:
             if isinstance(methods, str):
-                self.methods = [methods]
+                methods = [methods]
             self.methods = set([x.upper() for x in methods])
             if 'HEAD' not in self.methods and 'GET' in self.methods:
                 self.methods.add('HEAD')

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -613,9 +613,9 @@ class Rule(RuleFactory):
         self.alias = alias
         if methods is None:
             self.methods = None
-        if isinstance(methods, str):
-            self.methods = [methods]
         else:
+            if isinstance(methods, str):
+                self.methods = [methods]
             self.methods = set([x.upper() for x in methods])
             if 'HEAD' not in self.methods and 'GET' in self.methods:
                 self.methods.add('HEAD')


### PR DESCRIPTION
Do type checking when passing `methods`. 

I triggered a problem when tried passing a 'POST' as methods `prams` of routing function(actually flask.app.route), and the routing parse the string into ['P', 'O', 'S', 'T'], I think the best way is either ignore the wrong type or map it into the correct type, (to raise a exception is also a good choice) .

So there is the `pull request`: when passing a str type to `routing` as methods argument, try map it into a list type object : `str -> [str]`
