### PR TITLE
Add an extras_require entry for the optional watchdog dependency

### DIFF
--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -56,7 +56,8 @@ Since version 0.10, there are two backends the reloader supports: ``stat`` and
 
 - The ``watchdog`` backend uses filesystem events, and is much faster than
   ``stat``. It requires the `watchdog <https://pypi.python.org/pypi/watchdog>`_
-  module to be installed.
+  module to be installed. The recommended way to achieve this is to add
+  ``Werkzeug[watchdog]`` to your requirements file.
 
 If ``watchdog`` is installed and available it will automatically be used
 instead of the builtin ``stat`` reloader.

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     packages=['werkzeug', 'werkzeug.debug', 'werkzeug.contrib'],
+    extras_require={
+        'watchdog': ['watchdog'],
+    },
     cmdclass=dict(test=TestCommand),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
The reloader feature has an optional dependency on watchdog:
http://werkzeug.pocoo.org/docs/0.11/serving/#reloader

This change allows the use of `Werkzeug[watchdog]` in requirements files, which makes the reason behind the dependency clearer, and also allows for version specifiers to be more easily introduced in the future, should there be incompatibilities with certain versions of watchdog.

Fixes #929.