### PR TITLE
Ability to use a callable timeout

### DIFF
--- a/tests/contrib/test_cache.py
+++ b/tests/contrib/test_cache.py
@@ -140,14 +140,20 @@ class CacheTests(object):
         assert c.get('foo') is None
 
     def test_generic_timeout_callable(self, c, fast_sleep):
+        # if the config is loaded at runtime, we need to fetch the
+        # value only then
+        config = {
+            'cache_timeout': 5
+        }
+
         def timeout():
-            return random.randint(1, 5)
+            return config.get('cache_timeout')
 
         c.set('foo', 'bar', timeout)
         assert c.get('foo') == 'bar'
         # sleep a bit longer than max timeout to ensure there are no
         # race conditions
-        fast_sleep(11)
+        fast_sleep(10)
         assert c.get('foo') is None
 
     def test_generic_has(self, c):

--- a/tests/contrib/test_cache.py
+++ b/tests/contrib/test_cache.py
@@ -139,6 +139,17 @@ class CacheTests(object):
         fast_sleep(timeout + 5)
         assert c.get('foo') is None
 
+    def test_generic_timeout_callable(self, c, fast_sleep):
+        def timeout():
+            return random.randint(1, 5)
+
+        c.set('foo', 'bar', timeout)
+        assert c.get('foo') == 'bar'
+        # sleep a bit longer than max timeout to ensure there are no
+        # race conditions
+        fast_sleep(11)
+        assert c.get('foo') is None
+
     def test_generic_has(self, c):
         assert c.has('foo') in (False, 0)
         assert c.has('spam') in (False, 0)

--- a/tests/contrib/test_cache.py
+++ b/tests/contrib/test_cache.py
@@ -146,10 +146,10 @@ class CacheTests(object):
             'cache_timeout': 5
         }
 
-        def timeout():
-            return config.get('cache_timeout')
+        def timeout(cache_timeout):
+            return config.get(cache_timeout)
 
-        c.set('foo', 'bar', timeout)
+        c.set('foo', 'bar', lambda: timeout('cache_timeout'))
         assert c.get('foo') == 'bar'
         # sleep a bit longer than max timeout to ensure there are no
         # race conditions

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -152,7 +152,8 @@ class BaseCache(object):
         :param value: the value for the key
         :param timeout: the cache timeout for the key in seconds (if not
                         specified, it uses the default timeout). A timeout of
-                        0 idicates that the cache never expires.
+                        0 idicates that the cache never expires. A callable
+                        that returns an int in seconds is also acceptable.
         :returns: ``True`` if key has been updated, ``False`` for backend
                   errors. Pickling errors, however, will raise a subclass of
                   ``pickle.PickleError``.
@@ -168,7 +169,8 @@ class BaseCache(object):
         :param value: the value for the key
         :param timeout: the cache timeout for the key in seconds (if not
                         specified, it uses the default timeout). A timeout of
-                        0 idicates that the cache never expires.
+                        0 idicates that the cache never expires. A callable
+                        that returns an int in seconds is also acceptable.
         :returns: Same as :meth:`set`, but also ``False`` for already
                   existing keys.
         :rtype: boolean
@@ -181,7 +183,8 @@ class BaseCache(object):
         :param mapping: a mapping with the keys/values to set.
         :param timeout: the cache timeout for the key in seconds (if not
                         specified, it uses the default timeout). A timeout of
-                        0 idicates that the cache never expires.
+                        0 idicates that the cache never expires. A callable
+                        that returns an int in seconds is also acceptable.
         :returns: Whether all given keys have been set.
         :rtype: boolean
         """

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -293,6 +293,8 @@ class SimpleCache(BaseCache):
     def _get_expiration(self, timeout):
         if timeout is None:
             timeout = self.default_timeout
+        if callable(timeout):
+            timeout = timeout()
         if timeout > 0:
             timeout = time() + timeout
         return timeout
@@ -394,6 +396,8 @@ class MemcachedCache(BaseCache):
     def _normalize_timeout(self, timeout):
         if timeout is None:
             timeout = self.default_timeout
+        if callable(timeout):
+            timeout = timeout()
         if timeout > 0:
             timeout = int(time()) + timeout
         return timeout
@@ -565,6 +569,8 @@ class RedisCache(BaseCache):
     def _get_expiration(self, timeout):
         if timeout is None:
             timeout = self.default_timeout
+        if callable(timeout):
+            timeout = timeout()
         if timeout == 0:
             timeout = -1
         return timeout
@@ -757,8 +763,11 @@ class FileSystemCache(BaseCache):
     def set(self, key, value, timeout=None):
         if timeout is None:
             timeout = int(time() + self.default_timeout)
-        elif timeout != 0:
-            timeout = int(time() + timeout)
+        else:
+            if callable(timeout):
+                timeout = timeout()
+            if timeout != 0:
+                timeout = int(time() + timeout)
         filename = self._get_filename(key)
         self._prune()
         try:
@@ -829,6 +838,8 @@ class UWSGICache(BaseCache):
     def _get_expiration(self, timeout):
         if timeout is None:
             timeout = self.default_timeout
+        if callable(timeout):
+            timeout = timeout()
         return timeout
 
     def get(self, key):


### PR DESCRIPTION
When caching, you can now pass a callable as the value for timeout