### PR TITLE
Add json method to Response object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Project Leader / Developer:
 - Abhinav Upadhyay <er.abhinav.upadhyay@gmail.com>
 - immerrr <immerrr@gmail.com>
 - Cédric Krier
+- Joeseph Rodrigues <dowhilegeek@gmail.com>
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,8 @@ Unreleased.
   ``#933``.
 - ``test.Client`` now properly handles Location headers with relative URLs, see
   pull request ``#879``.
+- Add Response.json() method, for convenient json parsing of response bodies, see
+  pull request ``#949``.
 
 Version 0.11.11
 ---------------

--- a/tests/contrib/test_wrappers.py
+++ b/tests/contrib/test_wrappers.py
@@ -11,8 +11,6 @@
 
 from __future__ import with_statement
 
-import pytest
-
 from werkzeug.contrib import wrappers
 from werkzeug import routing
 from werkzeug.wrappers import Request, Response
@@ -97,4 +95,3 @@ def test_dynamic_charset_response_mixin():
         pass
     else:
         assert False, 'expected type error on charset setting without ct'
-

--- a/tests/contrib/test_wrappers.py
+++ b/tests/contrib/test_wrappers.py
@@ -10,7 +10,6 @@
 """
 
 from __future__ import with_statement
-import json
 
 import pytest
 
@@ -99,17 +98,3 @@ def test_dynamic_charset_response_mixin():
     else:
         assert False, 'expected type error on charset setting without ct'
 
-
-def test_json_mixin_happy_path():
-    payload = {"hello": "world"}
-
-    resp = Response(response=json.dumps(payload))
-
-    assert resp.json() == payload
-
-
-@pytest.mark.xfail(raises=json.JSONDecodeError)
-def test_json_mixin_invalid_json():
-    resp = Response(response="this is not valid json")
-
-    resp.json()

--- a/tests/contrib/test_wrappers.py
+++ b/tests/contrib/test_wrappers.py
@@ -10,6 +10,9 @@
 """
 
 from __future__ import with_statement
+import json
+
+import pytest
 
 from werkzeug.contrib import wrappers
 from werkzeug import routing
@@ -95,3 +98,18 @@ def test_dynamic_charset_response_mixin():
         pass
     else:
         assert False, 'expected type error on charset setting without ct'
+
+
+def test_json_mixin_happy_path():
+    payload = {"hello": "world"}
+
+    resp = Response(response=json.dumps(payload))
+
+    assert resp.json() == payload
+
+
+@pytest.mark.xfail(raises=json.JSONDecodeError)
+def test_json_mixin_invalid_json():
+    resp = Response(response="this is not valid json")
+
+    resp.json()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2014 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
+import json
 import pytest
 
 import pickle
@@ -1000,6 +1001,28 @@ def test_request_method_case_sensitivity():
     req = wrappers.Request({'REQUEST_METHOD': 'get'})
     assert req.method == 'GET'
 
+
+def test_json_mixin_happy_path():
+    payload = {"hello": "world"}
+
+    resp = wrappers.Response(response=json.dumps(payload))
+
+    assert resp.json() == payload
+
+
+def test_json_mixin_invalid_json():
+    resp = wrappers.Response(response="this is not valid json")
+
+    # this convoluted logic is because json module in python2 doesnt have
+    # json.decoder.JSONDecodeError, which leads to an attribute error. This way
+    # we can test python2 and python3.
+    try:
+        resp.json()
+    except Exception as e:
+        if isinstance(e, ValueError):
+            pass
+        elif isinstance(e, json.decoder.JSONDecodeError):
+            pass
 
 class TestSetCookie(object):
     """Tests for :meth:`werkzeug.wrappers.BaseResponse.set_cookie`."""

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1024,6 +1024,7 @@ def test_json_mixin_invalid_json():
         elif isinstance(e, json.decoder.JSONDecodeError):
             pass
 
+
 class TestSetCookie(object):
     """Tests for :meth:`werkzeug.wrappers.BaseResponse.set_cookie`."""
 

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1830,6 +1830,7 @@ class JSONMixin(object):
     def json(self, **kwargs):
         return json.loads(self.response[0].decode(self.charset), **kwargs)
 
+
 class Request(BaseRequest, AcceptMixin, ETagRequestMixin,
               UserAgentMixin, AuthorizationMixin,
               CommonRequestDescriptorsMixin):

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -22,6 +22,7 @@
 """
 from functools import update_wrapper
 from datetime import datetime, timedelta
+import json
 
 from werkzeug.http import HTTP_STATUS_CODES, \
     parse_accept_header, parse_cache_control_header, parse_etags, \
@@ -1823,6 +1824,12 @@ class WWWAuthenticateMixin(object):
         return parse_www_authenticate_header(header, on_update)
 
 
+class JSONMixin(object):
+    """Adds a :method:`json` to parse response payloads"""
+
+    def json(self, **kwargs):
+        return json.loads(self.response[0].decode(self.charset), **kwargs)
+
 class Request(BaseRequest, AcceptMixin, ETagRequestMixin,
               UserAgentMixin, AuthorizationMixin,
               CommonRequestDescriptorsMixin):
@@ -1846,8 +1853,8 @@ class PlainRequest(StreamOnlyMixin, Request):
 
 
 class Response(BaseResponse, ETagResponseMixin, ResponseStreamMixin,
-               CommonResponseDescriptorsMixin,
-               WWWAuthenticateMixin):
+               CommonResponseDescriptorsMixin, WWWAuthenticateMixin,
+               JSONMixin):
 
     """Full featured response object implementing the following mixins:
 
@@ -1855,4 +1862,5 @@ class Response(BaseResponse, ETagResponseMixin, ResponseStreamMixin,
     - :class:`ResponseStreamMixin` to add support for the `stream` property
     - :class:`CommonResponseDescriptorsMixin` for various HTTP descriptors
     - :class:`WWWAuthenticateMixin` for HTTP authentication support
+    - :class:`JSONMixin` for parsing JSON payloads
     """


### PR DESCRIPTION
Method will parse response payloads, or throw `json.JSONDecodeError`
trying.

Method uses the charset specified by the Response object.

Method takes kwargs, and passes them onto `json.loads`.

This commit is a first pass at satisfying the needs of #948