### PR TITLE
Add HTTP 423 status code exception

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Project Leader / Developer:
 - Abhinav Upadhyay <er.abhinav.upadhyay@gmail.com>
 - immerrr <immerrr@gmail.com>
 - Cédric Krier
+- Phil Jones
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,7 @@ Unreleased.
 - Spit out big deprecation warnings for werkzeug.script
 - Use `inspect.getfullargspec` internally when available as
   `inspect.getargspec` is gone in 3.6
-- Added support for status code 451.
+- Added support for status code 451 and 423
 - Improved the build error suggestions.  In particular only if
   someone stringifies the error will the suggestions be calculated.
 - Added support for uWSGI's caching backend.

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -43,6 +43,7 @@ def test_proxy_exception():
     (exceptions.RequestURITooLarge, 414),
     (exceptions.UnsupportedMediaType, 415),
     (exceptions.UnprocessableEntity, 422),
+    (exceptions.Locked, 423),
     (exceptions.InternalServerError, 500),
     (exceptions.NotImplemented, 501),
     (exceptions.BadGateway, 502),

--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -466,6 +466,18 @@ class UnprocessableEntity(HTTPException):
     )
 
 
+class Locked(HTTPException):
+
+    """*423* `Locked`
+
+    Used if the resource that is being accessed is locked.
+    """
+    code = 423
+    description = (
+        'The resource that is being accessed is locked.'
+    )
+
+
 class PreconditionRequired(HTTPException):
 
     """*428* `Precondition Required`


### PR DESCRIPTION
This adds the 423 Locked HTTP status code as an exception, thereby
allowing it to be used in abort methods.

I realise that @ffix has opened #855 which adds the same exception, however I'm assuming that hasn't been merged as it doesn't meet the contribution guidelines (notably testing, changelog and author changes). I've opened this as I hope by meeting the guidelines this functionality will be merged, if it isn't appropriate please close.