### PR TITLE
check file size

### DIFF
--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -20,7 +20,7 @@ from functools import partial, update_wrapper
 
 from werkzeug._compat import iteritems, text_type, string_types, \
     implements_iterator, make_literal_wrapper, to_unicode, to_bytes, \
-    wsgi_get_bytes, try_coerce_native, PY2
+    wsgi_get_bytes, try_coerce_native, PY2, BytesIO
 from werkzeug._internal import _empty_stream, _encode_idna
 from werkzeug.http import is_resource_modified, http_date
 from werkzeug.urls import uri_to_iri, url_quote, url_parse, url_join
@@ -545,10 +545,11 @@ class SharedDataMiddleware(object):
             if filesystem_bound:
                 return basename, self._opener(
                     provider.get_resource_filename(manager, path))
+            s = provider.get_resource_string(manager, path)
             return basename, lambda: (
-                provider.get_resource_stream(manager, path),
+                BytesIO(s),
                 loadtime,
-                0
+                len(s)
             )
         return loader
 
@@ -620,10 +621,9 @@ class SharedDataMiddleware(object):
 
         headers.extend((
             ('Content-Type', mime_type),
+            ('Content-Length', str(file_size)),
             ('Last-Modified', http_date(mtime))
         ))
-        if file_size:
-            headers.append(('Content-Length', str(file_size)))
         start_response('200 OK', headers)
         return wrap_file(environ, f)
 

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -620,9 +620,10 @@ class SharedDataMiddleware(object):
 
         headers.extend((
             ('Content-Type', mime_type),
-            ('Content-Length', str(file_size)),
             ('Last-Modified', http_date(mtime))
         ))
+        if file_size:
+            headers.append(('Content-Length', str(file_size)))
         start_response('200 OK', headers)
         return wrap_file(environ, f)
 


### PR DESCRIPTION
In a frozen app, using 'pkg_resources' the file size returned is zero, and with development server the files/images are not shown. With cherrypy wsigserver, throw a exception with ValueError about content-length. With this patch, all is fine.
With this patch, exclusively when content-length is zero, this information isn't passed and firefox and chrome accept the image/scripts/etc and show all.