### PR TITLE
Fix stream_encode_multipart

### DIFF
--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -272,6 +272,15 @@ def test_environ_builder_unicode_file_mix():
         stream.close()
 
 
+def test_environ_builder_mix_files_and_non_strings():
+    d = MultiDict(dict(
+        f=(BytesIO(u'hello world'.encode('utf-8')), 'hello.txt'),
+        t=42,
+    ))
+    # this should not fail
+    stream_encode_multipart(d)
+
+
 def test_create_environ():
     env = create_environ('/foo?bar=baz', 'http://example.org/')
     expected = {

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -99,8 +99,7 @@ def stream_encode_multipart(values, use_tempfile=True, threshold=1024 * 500,
             else:
                 if not isinstance(value, string_types):
                     value = str(value)
-                else:
-                    value = to_bytes(value, charset)
+                value = to_bytes(value, charset)
                 write('\r\n\r\n')
                 write_binary(value)
             write('\r\n')


### PR DESCRIPTION
There was an error. How to reproduce it:
Try to create a request having both plain and file-like objects in it,
like this:

myfile = open('/dev/null')
EnvironBuilder(data=dict(
    id=123,
    somefile=(myfile, 'empty_file.txt'),
))

Expected result: request is built
Actual result: we get an error:

(...)
env/lib/python3.5/site-packages/werkzeug/test.py:106: in stream_encode_multipart
    write_binary(value)
env/lib/python3.5/site-packages/werkzeug/test.py:59: in write_binary
(string = '123')
                stream.write(string)
TypeError: a bytes-like object is required, not 'str'

As you can see, without this fix non-string values are converted to string,
but then are passed to method which expects only bytes.
