### PR TITLE
Issue file system cache data increase

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -717,8 +717,8 @@ class FileSystemCache(BaseCache):
         entries = self._list_dir()
         if len(entries) > self._threshold:
             now = time()
-            try:
-                for idx, fname in enumerate(entries):
+            for idx, fname in enumerate(entries):
+                try:
                     remove = False
                     with open(fname, 'rb') as f:
                         expires = pickle.load(f)
@@ -726,8 +726,8 @@ class FileSystemCache(BaseCache):
 
                     if remove:
                         os.remove(fname)
-            except (IOError, OSError):
-                pass
+                except (IOError, OSError):
+                    pass
 
     def clear(self):
         for fname in self._list_dir():


### PR DESCRIPTION
If at least one file in cache directory has some kind of problem (for example, can't delete the file because of permission error),
there is a possibility that the cache data continue to increase forever without being deleted.