### PR TITLE
HTTPException displays description when raised, fixing #728

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Project Leader / Developer:
 - immerrr <immerrr@gmail.com>
 - Cédric Krier
 - Phil Jones
+- Michael Hunsinger
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,8 @@ Unreleased.
   ``#933``.
 - ``test.Client`` now properly handles Location headers with relative URLs, see
   pull request ``#879``.
+- When `HTTPException` is raised, it now prints the description, for easier
+  debugging.
 
 Version 0.11.11
 ---------------

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -70,12 +70,19 @@ def test_aborter_custom():
 
 def test_exception_repr():
     exc = exceptions.NotFound()
-    assert text_type(exc) == '404: Not Found'
+    assert text_type(exc) == (
+        '404 Not Found: The requested URL was not found '
+        'on the server.  If you entered the URL manually please check your '
+        'spelling and try again.')
     assert repr(exc) == "<NotFound '404: Not Found'>"
 
     exc = exceptions.NotFound('Not There')
-    assert text_type(exc) == '404: Not Found'
+    assert text_type(exc) == '404 Not Found: Not There'
     assert repr(exc) == "<NotFound '404: Not Found'>"
+
+    exc = exceptions.HTTPException('An error message')
+    assert text_type(exc) == 'None Unknown Error: An error message'
+    assert repr(exc) == "<HTTPException 'None: Unknown Error'>"
 
 
 def test_special_exceptions():

--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -156,10 +156,10 @@ class HTTPException(Exception):
         return response(environ, start_response)
 
     def __str__(self):
-        return '%d: %s' % (self.code, self.name)
+        return '%r %s: %s' % (self.code, self.name, self.description)
 
     def __repr__(self):
-        return '<%s \'%s\'>' % (self.__class__.__name__, self)
+        return "<%s '%r: %s'>" % (self.__class__.__name__, self.code, self.name)
 
 
 class BadRequest(HTTPException):


### PR DESCRIPTION
Changed the string representation of `HTTPException` to include the description, for easier debugging (as requested in #728).

The `code` attribute was also causing `__str__` to blow up, since it's default value is `None` and it was expecting a digit in the formatting.