### PR TITLE
Fix Python 3 compatibility with Lint Middleware (urlparse module)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Project Leader / Developer:
 - immerrr <immerrr@gmail.com>
 - Cédric Krier
 - Phil Jones
+- Ryan Lahfa <ryan@mangaki.fr>
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,7 @@ Unreleased.
   ``#933``.
 - ``test.Client`` now properly handles Location headers with relative URLs, see
   pull request ``#879``.
+- Fix the import of `urlparse` for Python 3 in the contribution module for LintMiddleware.
 
 Version 0.11.11
 ---------------

--- a/tests/contrib/test_lint.py
+++ b/tests/contrib/test_lint.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+    tests.contrib.lint
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    Added tests for the lint middleware.
+
+    :copyright: (c) 2016 by Ryan Lahfa.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from werkzeug.contrib import lint
+
+def test_working_module():
+    assert True

--- a/werkzeug/contrib/lint.py
+++ b/werkzeug/contrib/lint.py
@@ -19,7 +19,7 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from urlparse import urlparse
+from werkzeug.urls import url_parse
 from warnings import warn
 
 from werkzeug.datastructures import Headers
@@ -286,7 +286,7 @@ class LintMiddleware(object):
 
         location = headers.get('location')
         if location is not None:
-            if not urlparse(location).netloc:
+            if not url_parse(location).netloc:
                 warn(HTTPWarning('absolute URLs required for location header'),
                      stacklevel=4)
 


### PR DESCRIPTION
Currently, the Lint Middleware module is using `from urlparse import urlparse` to import `urlparse` module.
The problem is that, in Python 3, this module has been moved into `urllib.parse`, so in Python 3, you should do: `from urllib.parse import urlparse`.

As we are already using the Six module, we can just do `from six.moves.urllib.parse import urlparse`.

That is exactly what I propose in this pull request. On the other hand, I have added a test to ensure that module can be imported using the current Python interpreter (with your CI, it should test over all versions of Python which are supported).

Let me know if I have missed something in the guideline that I should have done and I'll happily correct the PR for it.
