### PR TITLE
Refactor tox.ini again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
-envlist = py{26,27,py,33,34,35}-{test,uwsgi,stylecheck}
+envlist = py{26,27,py,33,34,35}-{normal,uwsgi,stylecheck}
 
 [testenv]
 passenv = LANG
 deps=
 # General
-    pyopenssl
-    greenlet
-    pytest
-    pytest-xprocess
-    redis
-    requests
-    watchdog
-
-    uwsgi: uwsgi
+    normal: pyopenssl
+    normal: greenlet
+    normal: pytest
+    normal: pytest-xprocess
+    normal: redis
     normal: python-memcached
+    normal: requests
+    normal: watchdog
+    uwsgi: uwsgi
+    stylecheck: flake8
 
 whitelist_externals=
     redis-server


### PR DESCRIPTION
- Fix unused "test" env: It should be "normal".
- Don't install useless deps in stylecheck
- Actually install flake8 in stylecheck