### PR TITLE
uuid converter now accept strings without hyphens

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -443,6 +443,9 @@ def test_uuid_converter():
     rooute, kwargs = a.match('/a/a8098c1a-f86e-11da-bd1a-00112444be1e')
     assert type(kwargs['a_uuid']) == uuid.UUID
 
+    rooute, kwargs = a.match('/a/a8098c1af86e11dabd1a00112444be1e')
+    assert type(kwargs['a_uuid']) == uuid.UUID
+
 
 def test_converter_with_tuples():
     '''

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1075,7 +1075,7 @@ class UUIDConverter(BaseConverter):
     :param map: the :class:`Map`.
     """
     regex = r'[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-' \
-            r'[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}'
+            r'[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}|[A-Fa-f0-9]{32}'
 
     def to_python(self, value):
         return uuid.UUID(value)


### PR DESCRIPTION
Python accepts uuid strings with and without hyphens.
Currently, the converter enforce hyphens existence although it's not mandatory.
I've changed the regex to allow strings without hyphens and added a test for that. 