### PR TITLE
Properly parse cookies with blank keys

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,8 @@ Unreleased.
   see pull request ``#968``.
 - Fix a bug in ``MultiPartParser`` when no ``stream_factory`` was provided
   during initialization, see pull request ``#973``.
+- Cookies without equals signs are now parsed as having an empty key, see pull
+  request ``#989``.
 
 Version 0.11.11
 ---------------

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -321,13 +321,14 @@ class TestHTTPUtility(object):
     def test_cookies(self):
         strict_eq(
             dict(http.parse_cookie('dismiss-top=6; CP=null*; PHPSESSID=0a539d42abc001cd'
-                                   'c762809248d4beed; a=42; b="\\\";"')),
+                                   'c762809248d4beed; a=42; b="\\\";"; BLANKKEY')),
             {
                 'CP':           u'null*',
                 'PHPSESSID':    u'0a539d42abc001cdc762809248d4beed',
                 'a':            u'42',
                 'dismiss-top':  u'6',
-                'b':            u'\";'
+                'b':            u'\";',
+                '':             u'BLANKKEY',
             }
         )
         rv = http.dump_cookie('foo', 'bar baz blub', 360, httponly=True,

--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -44,8 +44,10 @@ _octal_re = re.compile(b'\\\\[0-3][0-7][0-7]')
 _quote_re = re.compile(b'[\\\\].')
 _legal_cookie_chars_re = b'[\w\d!#%&\'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\=]'
 _cookie_re = re.compile(b"""(?x)
-    (?P<key>[^=]+)
-    \s*=\s*
+    (
+        (?P<key>[^=]+)
+        \s*=\s*
+    )? # Without equals sign, the key is empty - see http://stackoverflow.com/a/1969339/4455114
     (?P<val>
         "(?:[^\\\\"]|\\\\.)*" |
          (?:.*?)
@@ -282,8 +284,8 @@ def _cookie_parse_impl(b):
         if not match:
             break
 
-        key = match.group('key').strip()
-        value = match.group('val')
+        key = (match.group('key') or '').strip()
+        value = match.group('val').strip()
         i = match.end(0)
 
         # Ignore parameters.  We have no interest in them.


### PR DESCRIPTION
Fixes #841
