### PR TITLE
Update specification URL for RoutingArgsRequestMixin

### DIFF
--- a/werkzeug/contrib/wrappers.py
+++ b/werkzeug/contrib/wrappers.py
@@ -101,7 +101,7 @@ class RoutingArgsRequestMixin(object):
     """This request mixin adds support for the wsgiorg routing args
     `specification`_.
 
-    .. _specification: http://www.wsgi.org/wsgi/Specifications/routing_args
+    .. _specification: http://wsgi.readthedocs.io/en/latest/specifications/routing_args.html
     """
 
     def _get_routing_args(self):

--- a/werkzeug/contrib/wrappers.py
+++ b/werkzeug/contrib/wrappers.py
@@ -101,7 +101,7 @@ class RoutingArgsRequestMixin(object):
     """This request mixin adds support for the wsgiorg routing args
     `specification`_.
 
-    .. _specification: http://wsgi.readthedocs.io/en/latest/specifications/routing_args.html
+    .. _specification: https://wsgi.readthedocs.io/en/latest/specifications/routing_args.html
     """
 
     def _get_routing_args(self):


### PR DESCRIPTION
*Wsgi.org* has moved their specifications to *Read The Docs* but does not set proper redirects from old URLs. This patch changes spec URL to new location.

(According to CONTRIBUTING file I should add myself to AUTHORS and CHANGES but this is just a minor fix so I don't feel it would be proper :smiley: )