### PR TITLE
Disable OS-level autocorrect in debugger

### DIFF
--- a/werkzeug/debug/shared/debugger.js
+++ b/werkzeug/debug/shared/debugger.js
@@ -182,7 +182,7 @@ function openShell(consoleNode, target, frameID) {
     }).
     appendTo(consoleNode);
 
-  var command = $('<input type="text">')
+  var command = $('<input type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">')
     .appendTo(form)
     .keydown(function(e) {
       if (e.charCode == 100 && e.ctrlKey) {


### PR DESCRIPTION
This is supposed to fix https://github.com/pallets/flask/issues/1989. Specifically, on operating systems that use autocorrect, the OS would attempt to “fix” code that was typed into the `<input>` field, which is annoying and breaks programs.

Tested (lightly) on OS X Sierra and El Capitan – where previously Sierra would attempt to be “helpful” and “correct” my code, now it stays quiet and doesn’t try to change anything.