### PR TITLE
Avoid errors on platforms that cannot fork

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,8 @@ Unreleased.
 - Color run_simple's terminal output based on HTTP codes ``#1013``.
 - Fix self-XSS in debugger console, see ``#1031``.
 - Fix IPython 5.x shell support, see ``#1033``.
+- Check if platform can fork before importing ``ForkingMixIn``, raise exception
+  when creating ``ForkingWSGIServer`` on such a platform, see PR ``#999``.
 
 
 Version 0.11.13

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -42,6 +42,10 @@ import socket
 import sys
 import signal
 
+
+can_fork = hasattr(os, "fork")
+
+
 try:
     import termcolor
 except ImportError:
@@ -67,10 +71,16 @@ def _get_openssl_crypto_module():
 
 
 try:
-    from SocketServer import ThreadingMixIn, ForkingMixIn
+    if can_fork:
+        from SocketServer import ThreadingMixIn, ForkingMixIn
+    else:
+        from SocketServer import ThreadingMixIn
     from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 except ImportError:
-    from socketserver import ThreadingMixIn, ForkingMixIn
+    if can_fork:
+        from socketserver import ThreadingMixIn, ForkingMixIn
+    else:
+        from socketserver import ThreadingMixIn
     from http.server import HTTPServer, BaseHTTPRequestHandler
 
 # important: do not use relative imports here or python -m will break
@@ -569,7 +579,7 @@ def make_server(host=None, port=None, app=None, threaded=False, processes=1,
     elif threaded:
         return ThreadedWSGIServer(host, port, app, request_handler,
                                   passthrough_errors, ssl_context, fd=fd)
-    elif processes > 1:
+    elif processes > 1 and can_fork:
         return ForkingWSGIServer(host, port, app, processes, request_handler,
                                  passthrough_errors, ssl_context, fd=fd)
     else:


### PR DESCRIPTION
Check if OS can fork before importing `ForkingMixIn` since Python 3.6 will no longer define that when it is not available on the operating system (python/cpython@aadff9bea61a2fc9f4cf0f213f0ee50fc54d6574) and `ImportError: cannot import name 'ForkingMixIn'` will occur.

Let me know if there's a more elegant way you'd like to implement this, or if an exception should be raised when `make_server` would otherwise try to make a `ForkingWSGIServer` on platforms (like Windows) where that is impossible (instead of silently skipping over that to `BaseWSGIServer`).  Also, I didn't add my name to _AUTHORS_ since this change is so small, should I have?
