### PR TITLE
fix multidict behavior for pop for empty lists

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -362,6 +362,24 @@ class TestMultiDict(_MutableMultiDictTests):
         with pytest.raises(KeyError):
             d.pop('foos')
 
+    def test_multidict_pop_raise_badrequestkeyerror_for_empty_list_value(self):
+        mapping = [('a', 'b'), ('a', 'c')]
+        md = self.storage_class(mapping)
+
+        md.setlistdefault('empty', [])
+
+        with pytest.raises(KeyError):
+            md.pop('empty')
+
+    def test_multidict_popitem_raise_badrequestkeyerror_for_empty_list_value(self):
+        mapping = []
+        md = self.storage_class(mapping)
+
+        md.setlistdefault('empty', [])
+
+        with pytest.raises(KeyError):
+            md.popitem()
+
     def test_setlistdefault(self):
         md = self.storage_class()
         assert md.setlistdefault('u', [-1, -2]) == [-1, -2]

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -606,7 +606,12 @@ class MultiDict(TypeConversionDict):
                         not in the dictionary.
         """
         try:
-            return dict.pop(self, key)[0]
+            lst = dict.pop(self, key)
+
+            if len(lst) == 0:
+                raise exceptions.BadRequestKeyError()
+
+            return lst[0]
         except KeyError as e:
             if default is not _missing:
                 return default
@@ -616,6 +621,10 @@ class MultiDict(TypeConversionDict):
         """Pop an item from the dict."""
         try:
             item = dict.popitem(self)
+
+            if len(item[1]) == 0:
+                raise exceptions.BadRequestKeyError()
+
             return (item[0], item[1][0])
         except KeyError as e:
             raise exceptions.BadRequestKeyError(str(e))


### PR DESCRIPTION
I think that for `pop` functions the same behavior like in PR https://github.com/pallets/werkzeug/pull/991 is also suitable.