### PR TITLE
Fix XSS in debugger

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -350,6 +350,7 @@ class Traceback(object):
                     evalex_trusted=True):
         """Render the Full HTML page with the traceback info."""
         exc = escape(self.exception)
+        ptext = escape(self.plaintext)
         return PAGE_HTML % {
             'evalex':           evalex and 'true' or 'false',
             'evalex_trusted':   evalex_trusted and 'true' or 'false',
@@ -358,7 +359,7 @@ class Traceback(object):
             'exception':        exc,
             'exception_type':   escape(self.exception_type),
             'summary':          self.render_summary(include_title=False),
-            'plaintext':        self.plaintext,
+            'plaintext':        ptext,
             'plaintext_cs':     re.sub('-{2,}', '-', self.plaintext),
             'traceback_id':     self.id,
             'secret':           secret


### PR DESCRIPTION

The `exc` and `plaintext_cs` variable, XSS has been the defense. But the `plaintext` didn't do that.

```python
def render_full(self, evalex=False, secret=None,
                    evalex_trusted=True):
        """Render the Full HTML page with the traceback info."""
        exc = escape(self.exception) # the exception info use the escape method
        return PAGE_HTML % {
            'evalex':           evalex and 'true' or 'false',
            'evalex_trusted':   evalex_trusted and 'true' or 'false',
            'console':          'false',
            'title':            exc,
            'exception':        exc,
            'exception_type':   escape(self.exception_type),
            'summary':          self.render_summary(include_title=False),
            'plaintext':        self.plaintext, # the plaintext did not use the escape method
            'plaintext_cs':     re.sub('-{2,}', '-', self.plaintext),
            'traceback_id':     self.id,
            'secret':           secret
        }
```

it make the debug page can be XSS.

For example:

![](http://ww4.sinaimg.cn/large/005y7Ba5jw1f7d0wibpdsj30ur0b6diu.jpg)