### PR TITLE
Fix type check in EnvironHeaders.__getitem__

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1334,6 +1334,8 @@ class EnvironHeaders(ImmutableHeadersMixin, Headers):
     def __getitem__(self, key, _get_mode=False):
         # _get_mode is a no-op for this class as there is no index but
         # used because get() calls it.
+        if not isinstance(key, string_types):
+            raise KeyError(key)
         key = key.upper().replace('-', '_')
         if key in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
             return _unicodify_header_value(self.environ[key])


### PR DESCRIPTION
`__getitem__` in `EnvironHeaders` does not check for whether the key type is a string or a unicode (Python 2). The first line in the function raises an `AttributeError` instead of a `KeyError`.

In other words, `EnvironHeaders.get(key, default)` is going to raise an error instead of returning the default value.
