### PR TITLE
Add license_file to setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,9 @@ norecursedirs = .* env* _build *.egg
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [flake8]
 ignore = E126,E241,E272,E402,E731,W503
 exclude=.tox,examples,docs


### PR DESCRIPTION
Without this, the LICENSE file is never included in the built wheels: this makes it harder for users to comply with the license.
With this addition a file LICENSE.txt will be created in the `xxx.dist-info` directory with the content of the `license_file` file, e.g. the top level LICENSE.
