### PR TITLE
Fix typo for setting doc for a property

### DIFF
--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -433,7 +433,7 @@ class EnvironBuilder(object):
         def setter(self, value):
             self._input_stream = None
             setattr(self, key, value)
-        return property(getter, setter, doc)
+        return property(getter, setter, doc=doc)
 
     form = form_property('form', MultiDict, doc='''
         A :class:`MultiDict` of form values.''')


### PR DESCRIPTION
Without this fix `doc` would be assigned to `property`'s `fdel` argument.