### PR TITLE
test: accept fd for post() data parameter

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -44,6 +44,8 @@ Unreleased.
 - `Range` header parsing function fixed for invalid values ``#974``.
 - Add support for byte Range Requests, see pull request ``#978``.
 - Use modern cryptographic defaults in the dev servers ``#1004``.
+- the post() method of the test client now accept file object through the data
+  parameter.
 
 Version 0.11.12
 ---------------

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -637,3 +637,15 @@ def test_delete_requests_with_form():
     client = Client(test_app, Response)
     resp = client.delete('/', data={'x': 42})
     strict_eq(resp.data, b'42')
+
+
+def test_post_with_file_descriptor(tmpdir):
+    c = Client(Response(), response_wrapper=Response)
+    f = tmpdir.join('some-file.txt')
+    f.write('foo')
+    with open(f.strpath, mode='rt') as data:
+        resp = c.post('/', data=data)
+    strict_eq(resp.status_code, 200)
+    with open(f.strpath, mode='rb') as data:
+        resp = c.post('/', data=data)
+    strict_eq(resp.status_code, 200)

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -240,6 +240,8 @@ class EnvironBuilder(object):
             with the key and the unpacked `tuple` items as positional
             arguments.
         -   a `str`:  The string is set as form data for the associated key.
+    -   a file-like object: The object content is loaded in memory and then
+        handled like a regular `str` or a `bytes`.
 
     .. versionadded:: 0.6
        `path` and `base_url` can now be unicode strings that are encoded using
@@ -270,7 +272,8 @@ class EnvironBuilder(object):
     :param multiprocess: controls `wsgi.multiprocess`.  Defaults to `False`.
     :param run_once: controls `wsgi.run_once`.  Defaults to `False`.
     :param headers: an optional list or :class:`Headers` object of headers.
-    :param data: a string or dict of form data.  See explanation above.
+    :param data: a string or dict of form data or a file-object.
+                 See explanation above.
     :param environ_base: an optional dict of environment defaults.
     :param environ_overrides: an optional dict of environment overrides.
     :param charset: the charset used to encode unicode data.
@@ -329,6 +332,8 @@ class EnvironBuilder(object):
         if data:
             if input_stream is not None:
                 raise TypeError('can\'t provide input stream and data')
+            if hasattr(data, 'read'):
+                data = data.read()
             if isinstance(data, text_type):
                 data = data.encode(self.charset)
             if isinstance(data, bytes):


### PR DESCRIPTION
It's possible to pass an open file descriptor to the post() method
of requests. This patch ensures the test client also accepts the
parameter instead of this error message:

    E   AttributeError: 'file' object has no attribute 'iteritems'

See: http://docs.python-requests.org/en/master/api/#requests.post