### PR TITLE
fixed deprecated pytest syntax in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [aliases]
 release = egg_info -RDb ''
 
-[pytest]
+[tool:pytest]
 norecursedirs = .* env* _build *.egg
 
 [bdist_wheel]


### PR DESCRIPTION
pytest complains in the form of a warning, that command in setup.cfg should be "[tool:pytest]" rather than "[pytest]".
http://doc.pytest.org/en/latest/example/pythoncollection.html#changing-naming-conventions