### PR TITLE
Fix some Python 3 issues flagged by the -3 flag and Pylint

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -526,6 +526,12 @@ class TestOrderedMultiDict(_MutableMultiDictTests):
         with pytest.raises(BadRequestKeyError):
             d.popitemlist()
 
+        # Unhashable
+        d = self.storage_class()
+        d.add('foo', 23)
+        with pytest.raises(TypeError):
+            some_set = set(d)
+
     def test_iterables(self):
         a = datastructures.MultiDict((("key_a", "value_a"),))
         b = datastructures.MultiDict((("key_b", "value_b"),))

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -529,8 +529,7 @@ class TestOrderedMultiDict(_MutableMultiDictTests):
         # Unhashable
         d = self.storage_class()
         d.add('foo', 23)
-        with pytest.raises(TypeError):
-            some_set = set(d)
+        pytest.raises(TypeError, hash, d)
 
     def test_iterables(self):
         a = datastructures.MultiDict((("key_a", "value_a"),))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -358,6 +358,12 @@ def test_rule_emptying():
     assert rule.__dict__ != rule2.__dict__
 
 
+def test_rule_unhashable():
+    rule = r.Rule('/foo', {'meh': 'muh'}, 'x', ['POST'],
+                  False, 'x', True, None)
+    with pytest.raises(TypeError):
+        some_set = set(rule)
+
 def test_rule_templates():
     testcase = r.RuleTemplate([
         r.Submount(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -361,8 +361,8 @@ def test_rule_emptying():
 def test_rule_unhashable():
     rule = r.Rule('/foo', {'meh': 'muh'}, 'x', ['POST'],
                   False, 'x', True, None)
-    with pytest.raises(TypeError):
-        some_set = set(rule)
+    pytest.raises(TypeError, hash, rule)
+
 
 def test_rule_templates():
     testcase = r.RuleTemplate([

--- a/werkzeug/contrib/atom.py
+++ b/werkzeug/contrib/atom.py
@@ -159,7 +159,7 @@ class AtomFeed(object):
         """Return a generator that yields pieces of XML."""
         # atom demands either an author element in every entry or a global one
         if not self.author:
-            if False in map(lambda e: bool(e.author), self.entries):
+            if any(not bool(e.author) for e in self.entries):
                 self.author = ({'name': 'Unknown author'},)
 
         if not self.updated:

--- a/werkzeug/contrib/atom.py
+++ b/werkzeug/contrib/atom.py
@@ -159,7 +159,7 @@ class AtomFeed(object):
         """Return a generator that yields pieces of XML."""
         # atom demands either an author element in every entry or a global one
         if not self.author:
-            if any(not bool(e.author) for e in self.entries):
+            if any(not e.author for e in self.entries):
                 self.author = ({'name': 'Unknown author'},)
 
         if not self.updated:

--- a/werkzeug/contrib/iterio.py
+++ b/werkzeug/contrib/iterio.py
@@ -260,7 +260,7 @@ class IterO(IterIO):
         try:
             tmp_end_pos = len(self._buf)
             while pos > tmp_end_pos:
-                item = self._gen.next()
+                item = next(self._gen)
                 tmp_end_pos += len(item)
                 buf.append(item)
         except StopIteration:

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -98,17 +98,11 @@ class ImmutableListMixin(object):
     def __delitem__(self, key):
         is_immutable(self)
 
-    def __delslice__(self, i, j):
-        is_immutable(self)
-
     def __iadd__(self, other):
         is_immutable(self)
     __imul__ = __iadd__
 
     def __setitem__(self, key, value):
-        is_immutable(self)
-
-    def __setslice__(self, i, j, value):
         is_immutable(self)
 
     def append(self, item):
@@ -765,6 +759,8 @@ class OrderedMultiDict(MultiDict):
                 return False
         return True
 
+    __hash__ = None
+
     def __ne__(self, other):
         return not self.__eq__(other)
 
@@ -971,6 +967,8 @@ class Headers(Mapping):
     def __eq__(self, other):
         return other.__class__ is self.__class__ and \
             set(other._list) == set(self._list)
+
+    __hash__ = None
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -1339,6 +1337,8 @@ class EnvironHeaders(ImmutableHeadersMixin, Headers):
 
     def __eq__(self, other):
         return self.environ is other.environ
+
+    __hash__ = None
 
     def __getitem__(self, key, _get_mode=False):
         # _get_mode is a no-op for this class as there is no index but

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -889,6 +889,8 @@ class Rule(RuleFactory):
         return self.__class__ is other.__class__ and \
             self._trace == other._trace
 
+    __hash__ = None
+
     def __ne__(self, other):
         return not self.__eq__(other)
 


### PR DESCRIPTION
I've been working through looking at adopting Python 3, and I've been utilizing the `-3` flag to help idenitfy issues with Python 3.

Here's a quick write up I did last week:

https://gist.github.com/rowillia/c0feed97c1863b2d8e5a3ed73712df65

The `-3` flagged a few issues in `werkzeug` worth fixing, namely around `__eq__` shadowing `__hash__` in PY3.

Fixing these issues will help make the `-3` flag less noisey for folks running Werkzeug in production.