### PR TITLE
Enable unix domain socket binding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,13 +59,17 @@ Unreleased
     :meth:`Map.bind() <routing.Map.bind>`. (`#740`_, `#768`_, `#1316`_)
 -   Triggering a reload while using a tool such as PDB no longer hides
     input. (`#1318`_)
+-   The dev server can bind to a Unix socket by passing a hostname like
+    ``unix://app.socket``. (`#209`_, `#1019`_)
 
+.. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
 .. _`#693`: https://github.com/pallets/werkzeug/pull/693
 .. _`#718`: https://github.com/pallets/werkzeug/pull/718
 .. _`#724`: https://github.com/pallets/werkzeug/pull/724
 .. _`#740`: https://github.com/pallets/werkzeug/issues/740
 .. _`#768`: https://github.com/pallets/werkzeug/pull/768
+.. _`#1019`: https://github.com/pallets/werkzeug/issues/1019
 .. _`#1023`: https://github.com/pallets/werkzeug/issues/1023
 .. _`#1231`: https://github.com/pallets/werkzeug/issues/1231
 .. _`#1233`: https://github.com/pallets/werkzeug/pull/1233

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -225,3 +225,15 @@ discouraged because modern browsers do a bad job at supporting them for
 security reasons.
 
 This feature requires the pyOpenSSL library to be installed.
+
+Unix Sockets
+------------
+The builtin server supports Unix socket binding. This means that it is
+possible to start the server in a way that it will listen to a unix
+socket instead of a TCP socket.
+
+In order to use a unix socket the `hostname` parameter of :func:`run_simple`
+method must start with `'unix://'`::
+
+  from werkzeug.serving import run_simple
+  run_simple('unix://example.sock', 0, app)

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -76,7 +76,7 @@ Colored Logging
 ---------------
 Werkzeug is able to color the output of request logs when ran from a terminal, just install the `termcolor
 <https://pypi.python.org/pypi/termcolor>`_ package. Windows users need to install `colorama
-<https://pypi.python.org/pypi/colorama>`_ in addition to termcolor for this to work. 
+<https://pypi.python.org/pypi/colorama>`_ in addition to termcolor for this to work.
 
 Virtual Hosts
 -------------
@@ -226,14 +226,13 @@ security reasons.
 
 This feature requires the pyOpenSSL library to be installed.
 
+
 Unix Sockets
 ------------
-The builtin server supports Unix socket binding. This means that it is
-possible to start the server in a way that it will listen to a unix
-socket instead of a TCP socket.
 
-In order to use a unix socket the `hostname` parameter of :func:`run_simple`
-method must start with `'unix://'`::
+The dev server can bind to a Unix socket instead of a TCP socket.
+:func:`run_simple` will bind to a Unix socket if the ``hostname``
+parameter starts with ``'unix://'``. ::
 
-  from werkzeug.serving import run_simple
-  run_simple('unix://example.sock', 0, app)
+    from werkzeug.serving import run_simple
+    run_simple('unix://example.sock', 0, app)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,8 @@ def dev_server(tmpdir, xprocess, request, monkeypatch):
         appfile = app_pkg.join('__init__.py')
         port = next(port_generator)
         appfile.write('\n\n'.join((
-            'kwargs = dict(port=%d)' % port,
+            "kwargs = {{'hostname': 'localhost', 'port': {port:d}}}".format(
+                port=port),
             textwrap.dedent(application)
         )))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,22 +6,21 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import with_statement, print_function
+from __future__ import print_function, with_statement
 
+from itertools import count
 import os
 import signal
 import sys
 import textwrap
 import time
 
-import requests
 import pytest
 
 from werkzeug import serving
-from werkzeug.utils import cached_property
 from werkzeug._compat import to_bytes
-from itertools import count
-
+from werkzeug.urls import url_quote
+from werkzeug.utils import cached_property
 
 try:
     __import__('pytest_xprocess')
@@ -61,8 +60,7 @@ def _dev_server():
     sys.path.insert(0, sys.argv[1])
     import testsuite_app
     app = _get_pid_middleware(testsuite_app.app)
-    serving.run_simple(hostname='localhost', application=app,
-                       **testsuite_app.kwargs)
+    serving.run_simple(application=app, **testsuite_app.kwargs)
 
 
 class _ServerInfo(object):
@@ -83,11 +81,16 @@ class _ServerInfo(object):
         return self.xprocess.getinfo('dev_server').logpath.open()
 
     def request_pid(self):
-        for i in range(20):
+        if self.url.startswith('http+unix://'):
+            from requests_unixsocket import get as rget
+        else:
+            from requests import get as rget
+
+        for i in range(10):
             time.sleep(0.1 * i)
             try:
-                self.last_pid = int(requests.get(self.url + '/_getpid',
-                                                 verify=False).text)
+                response = rget(self.url + '/_getpid', verify=False)
+                self.last_pid = int(response.text)
                 return self.last_pid
             except Exception as e:  # urllib also raises socketerrors
                 print(self.url)
@@ -133,19 +136,19 @@ def dev_server(tmpdir, xprocess, request, monkeypatch):
         monkeypatch.delitem(sys.modules, 'testsuite_app', raising=False)
         monkeypatch.syspath_prepend(str(tmpdir))
         import testsuite_app
+        hostname = testsuite_app.kwargs['hostname']
         port = testsuite_app.kwargs['port']
+        addr = '{}:{}'.format(hostname, port)
 
-        if testsuite_app.kwargs.get('ssl_context', None):
-            url_base = 'https://localhost:{0}'.format(port)
+        if hostname.startswith('unix://'):
+            addr = hostname.split('unix://', 1)[1]
+            requests_url = 'http+unix://' + url_quote(addr, safe='')
+        elif testsuite_app.kwargs.get('ssl_context', None):
+            requests_url = 'https://localhost:{0}'.format(port)
         else:
-            url_base = 'http://localhost:{0}'.format(port)
+            requests_url = 'http://localhost:{0}'.format(port)
 
-        info = _ServerInfo(
-            xprocess,
-            'localhost:{0}'.format(port),
-            url_base,
-            port
-        )
+        info = _ServerInfo(xprocess, addr, requests_url, port)
 
         def preparefunc(cwd):
             args = [sys.executable, __file__, str(tmpdir)]
@@ -153,6 +156,7 @@ def dev_server(tmpdir, xprocess, request, monkeypatch):
 
         xprocess.ensure('dev_server', preparefunc, restart=True)
 
+        @request.addfinalizer
         def teardown():
             # Killing the process group that runs the server, not just the
             # parent process attached. xprocess is confused about Werkzeug's
@@ -160,7 +164,6 @@ def dev_server(tmpdir, xprocess, request, monkeypatch):
             pid = info.request_pid()
             if pid:
                 os.killpg(os.getpgid(pid), signal.SIGTERM)
-        request.addfinalizer(teardown)
 
         return info
 

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -9,12 +9,12 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
+import socket
 import ssl
+import subprocess
 import sys
 import textwrap
 import time
-import subprocess
-
 
 try:
     import OpenSSL
@@ -450,7 +450,6 @@ def test_multiple_headers_concatenated_per_rfc_3875_section_4_1_18(dev_server):
         from httplib import HTTPConnection
     else:
         from http.client import HTTPConnection
-
     conn = HTTPConnection('127.0.0.1', server.port)
     conn.connect()
     conn.putrequest('GET', '/')
@@ -470,3 +469,31 @@ def test_multiple_headers_concatenated_per_rfc_3875_section_4_1_18(dev_server):
     assert res.read() == b'a ,b,c ,d'
 
     conn.close()
+
+
+@pytest.mark.skipif(
+    not hasattr(socket, 'AF_UNIX'), reason='Only works on UNIX')
+def test_unix_socket(tmpdir, dev_server):
+    socket_f = str(tmpdir.join('socket'))
+    dev_server('''
+    def app(environ, start_response):
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return [b'hello']
+    kwargs['hostname'] = {socket!r}
+    '''.format(socket='unix://' + socket_f))
+
+    for i in reversed(range(10)):
+        try:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(socket_f)
+            s.send(b'GET / HTTP/1.0\n\n\n')
+            data = s.recv(1024)
+            assert b'hello' in data
+            s.shutdown(1)
+            s.close()
+        except socket.error:
+            if i == 0:
+                raise
+            time.sleep(0.1)
+        else:
+            break

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     pytest-xprocess
     coverage
     requests
+    requests_unixsocket
     pyopenssl
     greenlet
     redis

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -166,6 +166,12 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             self.server.shutdown_signal = True
 
         url_scheme = self.server.ssl_context is None and 'http' or 'https'
+        if not self.client_address:
+            self.client_address = '<local>'
+        if isinstance(self.client_address, str):
+            self.client_address = (self.client_address, 0)
+        else:
+            pass
         path_info = url_unquote(request_url.path)
 
         environ = {
@@ -344,6 +350,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
     def address_string(self):
         if getattr(self, 'environ', None):
             return self.environ['REMOTE_ADDR']
+        elif not self.client_address:
+            return '<local>'
+        elif isinstance(self.client_address, str):
+            return self.client_address
         else:
             return self.client_address[0]
 
@@ -556,7 +566,7 @@ def is_ssl_error(error=None):
     return isinstance(error, exc_types)
 
 
-def select_ip_version(host, port):
+def select_address_family(host, port):
     """Returns AF_INET4 or AF_INET6 depending on where to connect to."""
     # disabled due to problems with current ipv6 implementations
     # and various operating systems.  Probably this code also is
@@ -570,7 +580,9 @@ def select_ip_version(host, port):
     #         return info[0][0]
     # except socket.gaierror:
     #     pass
-    if ':' in host and hasattr(socket, 'AF_INET6'):
+    if host.startswith('unix://'):
+        return socket.AF_UNIX
+    elif ':' in host and hasattr(socket, 'AF_INET6'):
         return socket.AF_INET6
     return socket.AF_INET
 
@@ -578,11 +590,13 @@ def select_ip_version(host, port):
 def get_sockaddr(host, port, family):
     """Returns a fully qualified socket address, that can properly used by
     socket.bind"""
+    if family == socket.AF_UNIX:
+        return host.split('://', 1)[1]
     try:
-        res = socket.getaddrinfo(host, port, family,
-                                 socket.SOCK_STREAM, socket.SOL_TCP)
+        res = socket.getaddrinfo(
+            host, port, family, socket.SOCK_STREAM, socket.SOL_TCP)
     except socket.gaierror:
-        return (host, port)
+        return host, port
     return res[0][4]
 
 
@@ -593,19 +607,31 @@ class BaseWSGIServer(HTTPServer, object):
     multiprocess = False
     request_queue_size = LISTEN_QUEUE
 
-    def __init__(self, host, port, app, handler=None,
-                 passthrough_errors=False, ssl_context=None, fd=None):
+    def __init__(
+        self, host, port, app, handler=None, passthrough_errors=False,
+        ssl_context=None, fd=None
+    ):
         if handler is None:
             handler = WSGIRequestHandler
 
-        self.address_family = select_ip_version(host, port)
+        self.address_family = select_address_family(host, port)
 
         if fd is not None:
-            real_sock = socket.fromfd(fd, self.address_family,
-                                      socket.SOCK_STREAM)
+            real_sock = socket.fromfd(
+                fd, self.address_family, socket.SOCK_STREAM)
             port = 0
-        HTTPServer.__init__(self, get_sockaddr(host, int(port),
-                                               self.address_family), handler)
+
+        server_address = get_sockaddr(host, int(port), self.address_family)
+
+        # remove socket file if it already exists
+        if (
+            self.address_family == socket.AF_UNIX
+            and os.path.exists(server_address)
+        ):
+            os.unlink(server_address)
+
+        HTTPServer.__init__(self, server_address, handler)
+
         self.app = app
         self.passthrough_errors = passthrough_errors
         self.shutdown_signal = False
@@ -738,7 +764,9 @@ def run_simple(hostname, port, application, use_reloader=False,
        through the `reloader_type` parameter.  See :ref:`reloader`
        for more information.
 
-    :param hostname: The host for the application.  eg: ``'localhost'``
+    :param hostname: The host for the application.  eg: ``'localhost'``.
+                     In order to use an unix socket instead of a TCP socket
+                     ``hostname`` must start with ``'unix://'``.
     :param port: The port for the server.  eg: ``8080``
     :param application: the WSGI application to execute
     :param use_reloader: should the server automatically restart the python
@@ -786,13 +814,16 @@ def run_simple(hostname, port, application, use_reloader=False,
 
     def log_startup(sock):
         display_hostname = hostname not in ('', '*') and hostname or 'localhost'
-        if ':' in display_hostname:
-            display_hostname = '[%s]' % display_hostname
         quit_msg = '(Press CTRL+C to quit)'
-        port = sock.getsockname()[1]
-        _log('info', ' * Running on %s://%s:%d/ %s',
-             ssl_context is None and 'http' or 'https',
-             display_hostname, port, quit_msg)
+        if sock.family is socket.AF_UNIX:
+            _log('info', ' * Running on %s %s', display_hostname, quit_msg)
+        else:
+            if ':' in display_hostname:
+                display_hostname = '[%s]' % display_hostname
+            port = sock.getsockname()[1]
+            _log('info', ' * Running on %s://%s:%d/ %s',
+                 ssl_context is None and 'http' or 'https',
+                 display_hostname, port, quit_msg)
 
     def inner():
         try:
@@ -820,10 +851,11 @@ def run_simple(hostname, port, application, use_reloader=False,
             # Create and destroy a socket so that any exceptions are
             # raised before we spawn a separate Python interpreter and
             # lose this ability.
-            address_family = select_ip_version(hostname, port)
+            address_family = select_address_family(hostname, port)
+            server_address = get_sockaddr(hostname, port, address_family)
             s = socket.socket(address_family, socket.SOCK_STREAM)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind(get_sockaddr(hostname, port, address_family))
+            s.bind(server_address)
             if hasattr(s, 'set_inheritable'):
                 s.set_inheritable(True)
 
@@ -835,6 +867,9 @@ def run_simple(hostname, port, application, use_reloader=False,
                 log_startup(s)
             else:
                 s.close()
+                if address_family is socket.AF_UNIX:
+                    _log('info', "Unlinking %s" % server_address)
+                    os.unlink(server_address)
 
         # Do not use relative imports, otherwise "python -m werkzeug.serving"
         # breaks.

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -567,7 +567,8 @@ def is_ssl_error(error=None):
 
 
 def select_address_family(host, port):
-    """Returns AF_INET4 or AF_INET6 depending on where to connect to."""
+    """Return ``AF_INET4``, ``AF_INET6``, or ``AF_UNIX`` depending on
+    the host and port."""
     # disabled due to problems with current ipv6 implementations
     # and various operating systems.  Probably this code also is
     # not supposed to work, but I can't come up with any other
@@ -588,8 +589,8 @@ def select_address_family(host, port):
 
 
 def get_sockaddr(host, port, family):
-    """Returns a fully qualified socket address, that can properly used by
-    socket.bind"""
+    """Return a fully qualified socket address that can be passed to
+    :func:`socket.bind`."""
     if family == socket.AF_UNIX:
         return host.split('://', 1)[1]
     try:
@@ -764,9 +765,13 @@ def run_simple(hostname, port, application, use_reloader=False,
        through the `reloader_type` parameter.  See :ref:`reloader`
        for more information.
 
-    :param hostname: The host for the application.  eg: ``'localhost'``.
-                     In order to use an unix socket instead of a TCP socket
-                     ``hostname`` must start with ``'unix://'``.
+    .. versionchanged:: 0.15
+        Bind to a Unix socket by passing a path that starts with
+        ``unix://`` as the ``hostname``.
+
+    :param hostname: The host to bind to, for example ``'localhost'``.
+        If the value is a path that starts with ``unix://`` it will bind
+        to a Unix socket instead of a TCP socket..
     :param port: The port for the server.  eg: ``8080``
     :param application: the WSGI application to execute
     :param use_reloader: should the server automatically restart the python


### PR DESCRIPTION
If hostname starts with 'unix://', assume a
unix domain socket instead of a TCP socket.

I took the original solution from @runderwood PR #209 posted 4 years ago, and adjusted it to work in latest code.
