### PR TITLE
Refactor Accept.best_match and fix test

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -52,7 +52,7 @@ class TestHTTPUtility(object):
         assert a.best_match(['text/html']) == 'text/html'
         assert a.best_match(['foo/bar']) is None
         assert a.best_match(['foo/bar', 'bar/foo'], default='foo/bar') == 'foo/bar'
-        assert a.best_match(['application/xml', 'text/xml']) == 'application/xml'
+        assert a.best_match(['application/xml', 'text/xml']) == 'text/xml'
 
     def test_charset_accept(self):
         a = http.parse_accept_header('ISO-8859-1,utf-8;q=0.7,*;q=0.7',

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1728,17 +1728,12 @@ class Accept(ImmutableList):
         :param matches: a list of matches to check for
         :param default: the value that is returned if none match
         """
-        best_quality = -1
-        result = default
-        for server_item in matches:
-            for client_item, quality in self:
-                if quality <= best_quality:
-                    break
-                if self._value_matches(server_item, client_item) \
-                   and quality > 0:
-                    best_quality = quality
-                    result = server_item
-        return result
+        for client_item, quality in self:
+            if quality > 0:
+                for server_item in matches:
+                    if self._value_matches(server_item, client_item):
+                        return server_item
+        return default
 
     @property
     def best(self):


### PR DESCRIPTION
`Accept.best_match` is now simpler and more performant (less assignments and earlier return).

`test_accept_matches` has been fixed according to [the doc](https://github.com/arthurwhite/werkzeug/blob/2f610f2d5f510a9ace14cdc26dbc6cecc9ca64a6/werkzeug/datastructures.py#L1723):

> If two items have the same quality, the one is returned that comes first.
