### PR TITLE
Fix doc warnings and errors. Includes a import fix to handle py2.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,5 +210,5 @@ latex_use_modindex = False
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'http://docs.python.org/dev': None,
-    'http://www.sqlalchemy.org/docs/05': None
+    'http://docs.sqlalchemy.org/en/latest/': None
 }

--- a/docs/contrib/lint.rst
+++ b/docs/contrib/lint.rst
@@ -2,6 +2,8 @@
 Lint Validation Middleware
 ==========================
 
+.. currentmodule:: werkzeug.contrib.lint
+
 .. automodule:: werkzeug.contrib.lint
 
 .. autoclass:: LintMiddleware

--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -81,8 +81,9 @@ Pasting Errors
 ==============
 
 If you click on the `Traceback` title, the traceback switches over to a text
-based one.  The text based one can be pasted to `gist.github.com`_ with one
+based one.  The text based one can be pasted to `gist.github.com <https://gist.github.com>`_ with one
 click.
 
 
-.. _paste.pocoo.org: https://gist.github.com/
+.. _paste.pocoo.org: https://gist.github.com
+

--- a/werkzeug/contrib/lint.py
+++ b/werkzeug/contrib/lint.py
@@ -19,7 +19,12 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from urlparse import urlparse
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
 from warnings import warn
 
 from werkzeug.datastructures import Headers
@@ -126,7 +131,7 @@ class GuardedIterator(object):
 
     def __init__(self, iterator, headers_set, chunks):
         self._iterator = iterator
-        self._next = iter(iterator).next
+        self._next = iter(iterator).__next__
         self.closed = False
         self.headers_set = headers_set
         self.chunks = chunks
@@ -134,7 +139,7 @@ class GuardedIterator(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         if self.closed:
             warn(WSGIWarning('iterated over closed app_iter'),
                  stacklevel=2)

--- a/werkzeug/contrib/lint.py
+++ b/werkzeug/contrib/lint.py
@@ -19,7 +19,6 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -131,7 +130,7 @@ class GuardedIterator(object):
 
     def __init__(self, iterator, headers_set, chunks):
         self._iterator = iterator
-        self._next = iter(iterator).__next__
+        self._next = iter(iterator).next
         self.closed = False
         self.headers_set = headers_set
         self.chunks = chunks
@@ -139,7 +138,7 @@ class GuardedIterator(object):
     def __iter__(self):
         return self
 
-    def __next__(self):
+    def next(self):
         if self.closed:
             warn(WSGIWarning('iterated over closed app_iter'),
                  stacklevel=2)

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -902,6 +902,9 @@ def make_line_iter(stream, limit=None, buffer_size=10 * 1024,
     .. versionadded:: 0.9
        added support for iterators as input stream.
 
+    .. versionadded:: 0.11.10
+       added support for the `cap_at_buffer` parameter.
+
     :param stream: the stream or iterate to iterate over.
     :param limit: the limit in bytes for the stream.  (Usually
                   content length.  Not necessary if the `stream`
@@ -911,8 +914,6 @@ def make_line_iter(stream, limit=None, buffer_size=10 * 1024,
                           than the buffer size.  Internally this is implemented
                           that the buffer size might be exhausted by a factor
                           of two however.
-    .. versionadded:: 0.11.10
-       added support for the `cap_at_buffer` parameter.
     """
     _iter = _make_chunk_iter(stream, limit, buffer_size)
 


### PR DESCRIPTION
The lint.py changes are a result of two things. The import fix was seen when building the docs and the next -> __next__ were seen from 2to3.