### PR TITLE
Fixed IPython 5.x shell support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ Unreleased.
   parameter.
 - Color run_simple's terminal output based on HTTP codes ``#1013``.
 - Fix self-XSS in debugger console, see ``#1031``.
+- Fix IPython 5.x shell support, see ``#1033``.
 
 Version 0.11.12
 ---------------

--- a/werkzeug/script.py
+++ b/werkzeug/script.py
@@ -279,14 +279,14 @@ def make_shell(init_func=None, banner=None, use_ipython=True):
             try:
                 try:
                     from IPython.frontend.terminal.embed import InteractiveShellEmbed
-                    sh = InteractiveShellEmbed(banner1=banner)
+                    sh = InteractiveShellEmbed.instance(banner1=banner)
                 except ImportError:
                     from IPython.Shell import IPShellEmbed
                     sh = IPShellEmbed(banner=banner)
             except ImportError:
                 pass
             else:
-                sh(global_ns={}, local_ns=namespace)
+                sh(local_ns=namespace)
                 return
         from code import interact
         interact(banner, local=namespace)


### PR DESCRIPTION
This PR closes #1012.

* `global_ns` was deprecated in IPython 4.x, and was removed in IPython 5.x.
* According to the discussion in https://github.com/ipython/ipython/issues/9798, `InteractiveShellEmbed.instance` should be used over `InteractiveShellEmbed` as it sets the shell as a default one automatically

I have tested this change in Python 3.5 using IPython 3.2.3, 4.2.1, and 5.1.0.

/cc @untitaker @sansculotte