### PR TITLE
Join headers with same name by ','

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,8 @@ Unreleased.
 - the post() method of the test client now accept file object through the data
   parameter.
 - Color run_simple's terminal output based on HTTP codes ``#1013``.
+- Headers with the same name (other than set-cookie) are combined into a single
+  header by joining with a comma ``#1034``.
 
 Version 0.11.12
 ---------------

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -613,13 +613,17 @@ class TestHeaders(object):
         assert len(headers.getlist('Content-Type')) == 1
 
         # list conversion
-        assert headers.to_wsgi_list() == [
+        assert sorted(headers.to_wsgi_list()) == [
             ('Content-Type', 'foo/bar'),
             ('X-Foo', 'bar')
         ]
         assert str(headers) == (
             "Content-Type: foo/bar\r\n"
             "X-Foo: bar\r\n"
+            "\r\n"
+        ) or str(headers) == (
+            "X-Foo: bar\r\n"
+            "Content-Type: foo/bar\r\n"
             "\r\n"
         )
         assert str(self.storage_class()) == "\r\n"

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -720,13 +720,14 @@ class TestHeaders(object):
     def test_to_wsgi_list(self):
         h = self.storage_class()
         h.set(u'Key', u'Value')
+        h.add(u'Key', u'Value2')
         for key, value in h.to_wsgi_list():
             if PY2:
                 strict_eq(key, b'Key')
-                strict_eq(value, b'Value')
+                strict_eq(value, b'Value,Value2')
             else:
                 strict_eq(key, u'Key')
-                strict_eq(value, u'Value')
+                strict_eq(value, u'Value,Value2')
 
 
 class TestEnvironHeaders(object):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -613,17 +613,13 @@ class TestHeaders(object):
         assert len(headers.getlist('Content-Type')) == 1
 
         # list conversion
-        assert sorted(headers.to_wsgi_list()) == [
+        assert headers.to_wsgi_list() == [
             ('Content-Type', 'foo/bar'),
             ('X-Foo', 'bar')
         ]
         assert str(headers) == (
             "Content-Type: foo/bar\r\n"
             "X-Foo: bar\r\n"
-            "\r\n"
-        ) or str(headers) == (
-            "X-Foo: bar\r\n"
-            "Content-Type: foo/bar\r\n"
             "\r\n"
         )
         assert str(self.storage_class()) == "\r\n"
@@ -725,6 +721,7 @@ class TestHeaders(object):
         h = self.storage_class()
         h.set(u'Key', u'Value')
         h.add(u'Key', u'Value2')
+        assert len(h.to_wsgi_list()) == 1
         for key, value in h.to_wsgi_list():
             if PY2:
                 strict_eq(key, b'Key')
@@ -732,6 +729,19 @@ class TestHeaders(object):
             else:
                 strict_eq(key, u'Key')
                 strict_eq(value, u'Value,Value2')
+
+    def test_to_wsgi_list_cookie(self):
+        h = self.storage_class()
+        h.set(u'Set-Cookie', u'key1=value1')
+        h.add(u'Set-Cookie', u'key2=value2')
+        l = h.to_wsgi_list()
+
+        assert len(l) == 2
+        assert l[0][0] == 'Set-Cookie'
+        assert l[1][0] == 'Set-Cookie'
+
+        assert l[0][1] == 'key1=value1'
+        assert l[1][1] == 'key2=value2'
 
 
 class TestEnvironHeaders(object):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1117,7 +1117,6 @@ class TestSetCookie(object):
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=True,
                             httponly=True)
-        print 'test headers: {}'.format(response.headers.to_wsgi_list())
         strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -233,19 +233,19 @@ def test_base_response():
     response = wrappers.BaseResponse()
     response.set_cookie('foo', value='bar', max_age=60, expires=0,
                         path='/blub', domain='example.org')
-    strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
+    strict_eq(response.headers.to_wsgi_list(), [
         ('Content-Type', 'text/plain; charset=utf-8'),
         ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
          '01-Jan-1970 00:00:00 GMT; Max-Age=60; Path=/blub')
-    ]))
+    ])
 
     # delete cookie
     response = wrappers.BaseResponse()
     response.delete_cookie('foo')
-    strict_eq(sorted(response.headers.to_wsgi_list()), ([
+    strict_eq(response.headers.to_wsgi_list(), [
         ('Content-Type', 'text/plain; charset=utf-8'),
         ('Set-Cookie', 'foo=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/')
-    ]))
+    ])
 
     # close call forwarding
     closed = []
@@ -1095,31 +1095,31 @@ class TestSetCookie(object):
         response = wrappers.BaseResponse()
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=True)
-        strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
+        strict_eq(response.headers.to_wsgi_list(), [
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
              '01-Jan-1970 00:00:00 GMT; Max-Age=60; Secure; Path=/blub')
-        ]))
+        ])
 
     def test_httponly(self):
         response = wrappers.BaseResponse()
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=False,
                             httponly=True)
-        strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
+        strict_eq(response.headers.to_wsgi_list(), [
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
              '01-Jan-1970 00:00:00 GMT; Max-Age=60; HttpOnly; Path=/blub')
-        ]))
+        ])
 
     def test_secure_and_httponly(self):
         response = wrappers.BaseResponse()
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=True,
                             httponly=True)
-        strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
+        strict_eq(response.headers.to_wsgi_list(), [
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
              '01-Jan-1970 00:00:00 GMT; Max-Age=60; Secure; HttpOnly; '
              'Path=/blub')
-        ]))
+        ])

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -233,19 +233,19 @@ def test_base_response():
     response = wrappers.BaseResponse()
     response.set_cookie('foo', value='bar', max_age=60, expires=0,
                         path='/blub', domain='example.org')
-    strict_eq(response.headers.to_wsgi_list(), [
+    strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
         ('Content-Type', 'text/plain; charset=utf-8'),
         ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
          '01-Jan-1970 00:00:00 GMT; Max-Age=60; Path=/blub')
-    ])
+    ]))
 
     # delete cookie
     response = wrappers.BaseResponse()
     response.delete_cookie('foo')
-    strict_eq(response.headers.to_wsgi_list(), [
+    strict_eq(sorted(response.headers.to_wsgi_list()), ([
         ('Content-Type', 'text/plain; charset=utf-8'),
         ('Set-Cookie', 'foo=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/')
-    ])
+    ]))
 
     # close call forwarding
     closed = []
@@ -1095,31 +1095,32 @@ class TestSetCookie(object):
         response = wrappers.BaseResponse()
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=True)
-        strict_eq(response.headers.to_wsgi_list(), [
+        strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
              '01-Jan-1970 00:00:00 GMT; Max-Age=60; Secure; Path=/blub')
-        ])
+        ]))
 
     def test_httponly(self):
         response = wrappers.BaseResponse()
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=False,
                             httponly=True)
-        strict_eq(response.headers.to_wsgi_list(), [
+        strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
              '01-Jan-1970 00:00:00 GMT; Max-Age=60; HttpOnly; Path=/blub')
-        ])
+        ]))
 
     def test_secure_and_httponly(self):
         response = wrappers.BaseResponse()
         response.set_cookie('foo', value='bar', max_age=60, expires=0,
                             path='/blub', domain='example.org', secure=True,
                             httponly=True)
-        strict_eq(response.headers.to_wsgi_list(), [
+        print 'test headers: {}'.format(response.headers.to_wsgi_list())
+        strict_eq(sorted(response.headers.to_wsgi_list()), sorted([
             ('Content-Type', 'text/plain; charset=utf-8'),
             ('Set-Cookie', 'foo=bar; Domain=example.org; Expires=Thu, '
              '01-Jan-1970 00:00:00 GMT; Max-Age=60; Secure; HttpOnly; '
              'Path=/blub')
-        ])
+        ]))

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1258,8 +1258,23 @@ class Headers(Mapping):
         :return: list
         """
         if PY2:
-            return [(to_native(k), v.encode('latin1')) for k, v in self]
-        return list(self)
+            headers = ((to_native(k), v.encode('latin1')) for k, v in self)
+        else:
+            headers = self
+
+        # Only the Set-Cookie header appears multiple times; others
+        # other repeated headers are joined by ','
+        cookies = []
+        d = {}
+        for k, v in headers:
+            if k.lower() == 'set-cookie':
+                cookies.append((k, v))
+            elif k not in d:
+                d[k] = v
+            else:
+                d[k] = '%s,%s' % (d[k], v)
+
+        return [(k, v) for k, v in iteritems(d)] + cookies
 
     def copy(self):
         return self.__class__(self._list)

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1258,23 +1258,22 @@ class Headers(Mapping):
         :return: list
         """
         if PY2:
-            headers = ((to_native(k), v.encode('latin1')) for k, v in self)
+            h_iter = ((to_native(k), v.encode('latin1')) for k, v in self)
         else:
-            headers = self
+            h_iter = self
 
-        # Only the Set-Cookie header appears multiple times; others
-        # other repeated headers are joined by ','
-        cookies = []
+        # The Set-Cookie header appears multiple times; other repeated
+        # headers are joined by ','.
+        headers = []
         d = {}
-        for k, v in headers:
-            if k.lower() == 'set-cookie':
-                cookies.append((k, v))
-            elif k not in d:
-                d[k] = v
+        for k, v in h_iter:
+            if k.lower() == 'set-cookie' or k not in d:
+                d[k] = len(headers)
+                headers.append((k, v))
             else:
-                d[k] = '%s,%s' % (d[k], v)
+                headers[d[k]] = (k, '%s,%s' % (headers[d[k]][1], v))
 
-        return [(k, v) for k, v in iteritems(d)] + cookies
+        return headers
 
     def copy(self):
         return self.__class__(self._list)


### PR DESCRIPTION
Per [rfc2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2), repeated headers are only allowed if they can be joined by a comma.

The current behavior is that if a header is repeated, only the last one returned by `headers.to_wsgi_list()` is kept; all others are dropped.