### PR TITLE
add option for SameSite cookies

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -384,6 +384,10 @@ class TestHTTPUtility(object):
         val = http.dump_cookie('foo', 'bar', domain=u'\N{SNOWMAN}.com')
         strict_eq(val, 'foo=bar; Domain=xn--n3h.com; Path=/')
 
+    def test_cookie_samesite(self):
+        val = http.dump_cookie('foo', 'bar', samesite=True)
+        strict_eq(val, 'foo=bar; SameSite=Strict; Path=/')
+
     def test_cookie_unicode_dumping(self):
         val = http.dump_cookie('foo', u'\N{SNOWMAN}')
         h = datastructures.Headers()

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -937,7 +937,7 @@ def parse_cookie(header, charset='utf-8', errors='replace', cls=None):
 
 def dump_cookie(key, value='', max_age=None, expires=None, path='/',
                 domain=None, secure=False, httponly=False,
-                charset='utf-8', sync_expires=True):
+                charset='utf-8', sync_expires=True, samesite=None):
     """Creates a new Set-Cookie header without the ``Set-Cookie`` prefix
     The parameters are the same as in the cookie Morsel object in the
     Python standard library but it accepts unicode data, too.
@@ -988,6 +988,9 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
     elif max_age is not None and sync_expires:
         expires = to_bytes(cookie_date(time() + max_age))
 
+    if samesite:
+        samesite = 'Strict'
+
     buf = [key + b'=' + _cookie_quote(value)]
 
     # XXX: In theory all of these parameters that are not marked with `None`
@@ -998,6 +1001,7 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
                     (b'Max-Age', max_age, False),
                     (b'Secure', secure, None),
                     (b'HttpOnly', httponly, None),
+                    (b'SameSite', samesite, False),
                     (b'Path', path, False)):
         if q is None:
             if v:

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1003,7 +1003,8 @@ class BaseResponse(object):
         return _iter_encoded(self.response, self.charset)
 
     def set_cookie(self, key, value='', max_age=None, expires=None,
-                   path='/', domain=None, secure=False, httponly=False):
+                   path='/', domain=None, secure=False, httponly=False,
+                   samesite=None):
         """Sets a cookie. The parameters are the same as in the cookie `Morsel`
         object in the Python standard library but it accepts unicode data, too.
 
@@ -1033,7 +1034,8 @@ class BaseResponse(object):
                                                    domain=domain,
                                                    secure=secure,
                                                    httponly=httponly,
-                                                   charset=self.charset))
+                                                   charset=self.charset,
+                                                   samesite=samesite))
 
     def delete_cookie(self, key, path='/', domain=None):
         """Delete a cookie.  Fails silently if key doesn't exist.


### PR DESCRIPTION
This MR adds support for the `SameSite=Strict` cookie directive as described here:
https://tools.ietf.org/html/draft-west-first-party-cookies-07