### PR TITLE
Fix docstring for clear method

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -224,6 +224,7 @@ class BaseCache(object):
     def clear(self):
         """Clears the cache.  Keep in mind that not all caches support
         completely clearing the cache.
+        
         :returns: Whether the cache has been cleared.
         :rtype: boolean
         """


### PR DESCRIPTION
Added a missing newline. Without the space the :returns: and :rtype: are not rendered correctly (see http://werkzeug.pocoo.org/docs/0.11/contrib/cache/#werkzeug.contrib.cache.BaseCache.clear).