### PR TITLE
Add RAW_URI to environ (as Gunicorn does)

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -122,7 +122,8 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             'REMOTE_PORT':          self.port_integer(),
             'SERVER_NAME':          self.server.server_address[0],
             'SERVER_PORT':          str(self.server.server_address[1]),
-            'SERVER_PROTOCOL':      self.request_version
+            'SERVER_PROTOCOL':      self.request_version,
+            'RAW_URI':              self.path,
         }
 
         for key, value in self.headers.items():


### PR DESCRIPTION
Add the original raw URI to environ, as Gunicorn does.

This provides access to the original request URI, without breaking existing code or standards. Simply using something like request.url wouldn't work if the client included URL-encoded characters like slash, equals, semi-colon or question-mark, as these would be unquoted and then not requoted.

Having the same environ name as in Gunicorn means we can use Gunicorn in production and Werkzeug server for development, and they will both have the same environ variable.

See also:
https://github.com/benoitc/gunicorn/pull/1211#issuecomment-188283031
https://github.com/pallets/werkzeug/issues/477