### PR TITLE
Pull flags out of regular expressions

### DIFF
--- a/examples/cupoftee/utils.py
+++ b/examples/cupoftee/utils.py
@@ -11,7 +11,7 @@
 import re
 
 
-_sort_re = re.compile(r'\w+(?u)')
+_sort_re = re.compile(r'\w+', re.UNICODE)
 
 
 def unicodecmp(a, b):

--- a/scripts/make-release.py
+++ b/scripts/make-release.py
@@ -36,7 +36,8 @@ def parse_changelog():
                     break
 
             match = re.search(r'released on (\w+\s+\d+\w+\s+\d+)'
-                              r'(?:, codename (.*))?(?i)', change_info)
+                              r'(?:, codename (.*))?', change_info,
+                              flags=re.IGNORECASE)
             if match is None:
                 continue
 
@@ -66,8 +67,9 @@ def set_filename_version(filename, version_number, pattern):
         changed.append(True)
         return before + version_number + after
     with open(filename) as f:
-        contents = re.sub(r"^(\s*%s\s*=\s*')(.+?)(')(?sm)" % pattern,
-                          inject_version, f.read())
+        contents = re.sub(r"^(\s*%s\s*=\s*')(.+?)(')" % pattern,
+                          inject_version, f.read(),
+                          flags=re.DOTALL | re.MULTILINE)
 
     if not changed:
         fail('Could not find %s in %s', pattern, filename)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -137,22 +137,22 @@ class TestDebugHelpers(object):
         drg = DebugReprGenerator()
         out = drg.dump_object(Foo())
         assert re.search('Details for tests.test_debug.Foo object at', out)
-        assert re.search('<th>x.*<span class="number">42</span>(?s)', out)
-        assert re.search('<th>y.*<span class="number">23</span>(?s)', out)
-        assert re.search('<th>z.*<span class="number">15</span>(?s)', out)
+        assert re.search('<th>x.*<span class="number">42</span>', out, flags=re.DOTALL)
+        assert re.search('<th>y.*<span class="number">23</span>', out, flags=re.DOTALL)
+        assert re.search('<th>z.*<span class="number">15</span>', out, flags=re.DOTALL)
 
         out = drg.dump_object({'x': 42, 'y': 23})
         assert re.search('Contents of', out)
-        assert re.search('<th>x.*<span class="number">42</span>(?s)', out)
-        assert re.search('<th>y.*<span class="number">23</span>(?s)', out)
+        assert re.search('<th>x.*<span class="number">42</span>', out, flags=re.DOTALL)
+        assert re.search('<th>y.*<span class="number">23</span>', out, flags=re.DOTALL)
 
         out = drg.dump_object({'x': 42, 'y': 23, 23: 11})
         assert not re.search('Contents of', out)
 
         out = drg.dump_locals({'x': 42, 'y': 23})
         assert re.search('Local variables in frame', out)
-        assert re.search('<th>x.*<span class="number">42</span>(?s)', out)
-        assert re.search('<th>y.*<span class="number">23</span>(?s)', out)
+        assert re.search('<th>x.*<span class="number">42</span>', out, flags=re.DOTALL)
+        assert re.search('<th>y.*<span class="number">23</span>', out, flags=re.DOTALL)
 
     def test_debug_dump(self):
         old = sys.stdout

--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -43,7 +43,7 @@ for _i in chain(range_type(32), range_type(127, 256)):
 _octal_re = re.compile(b'\\\\[0-3][0-7][0-7]')
 _quote_re = re.compile(b'[\\\\].')
 _legal_cookie_chars_re = b'[\w\d!#%&\'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\=]'
-_cookie_re = re.compile(b"""(?x)
+_cookie_re = re.compile(b"""
     (?P<key>[^=]+)
     \s*=\s*
     (?P<val>
@@ -51,7 +51,7 @@ _cookie_re = re.compile(b"""(?x)
          (?:.*?)
     )
     \s*;
-""")
+""", flags=re.VERBOSE)
 
 
 class _Missing(object):

--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -26,7 +26,7 @@ from werkzeug.filesystem import get_filesystem_encoding
 
 
 _coding_re = re.compile(br'coding[:=]\s*([-\w.]+)')
-_line_re = re.compile(br'^(.*?)$(?m)')
+_line_re = re.compile(br'^(.*?)$', re.MULTILINE)
 _funcdef_re = re.compile(r'^(\s*def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)')
 UTF8_COOKIE = b'\xef\xbb\xbf'
 

--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -66,7 +66,7 @@ class UserAgentParser(object):
         ('mozilla', 'mozilla')
     )
 
-    _browser_version_re = r'(?:%s)[/\sa-z(]*(\d+[.\da-z]+)?(?i)'
+    _browser_version_re = r'(?:%s)[/\sa-z(]*(\d+[.\da-z]+)?'
     _language_re = re.compile(
         r'(?:;\s*|\s+)(\b\w{2}\b(?:-\b\w{2}\b)?)\s*;|'
         r'(?:\(|\[|;)\s*(\b\w{2}\b(?:-\b\w{2}\b)?)\s*(?:\]|\)|;)'
@@ -74,7 +74,7 @@ class UserAgentParser(object):
 
     def __init__(self):
         self.platforms = [(b, re.compile(a, re.I)) for a, b in self.platforms]
-        self.browsers = [(b, re.compile(self._browser_version_re % a))
+        self.browsers = [(b, re.compile(self._browser_version_re % a, re.I))
                          for a, b in self.browsers]
 
     def __call__(self, user_agent):


### PR DESCRIPTION
In Python, you can pass flags to regular expressions. There are two ways to do so: by passing the flag as a `flag` argument to whatever regex function you're using, or by embedding the flag in the regex itself. If the flag is embedded in the regex, it is ambiguous unless it is at the start of the expression, and in Python 3.6 this is now deprecated.

This pull request pulls all flags out of regexes and passes them via the `flag` argument, instead. This is clearer and more consistent.