### PR TITLE
Fix return doc for werkzeug.http.is_hop_by_hop_header

### DIFF
--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -887,7 +887,7 @@ def is_hop_by_hop_header(header):
     .. versionadded:: 0.5
 
     :param header: the header to test.
-    :return: `True` if it's an entity header, `False` otherwise.
+    :return: `True` if it's an HTTP/1.1 "Hop-by-Hop" header, `False` otherwise.
     """
     return header.lower() in _hop_by_hop_headers
 


### PR DESCRIPTION
Looks like the return doc string was copied from ``werkzeug.http.is_entity_header``.

Fixing to be more correct.