### PR TITLE
Don't set CONTENT_TYPE / CONTENT_LENGTH if they're not provided by the client

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Werkzeug Changelog
 ==================
 
+Version 0.11.16
+---------------
+
+- werkzeug.serving: set CONTENT_TYPE / CONTENT_LENGTH if only they're provided by the client
+
 Version 0.11.15
 ---------------
 

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -123,8 +123,6 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             'SCRIPT_NAME':          '',
             'PATH_INFO':            wsgi_encoding_dance(path_info),
             'QUERY_STRING':         wsgi_encoding_dance(request_url.query),
-            'CONTENT_TYPE':         self.headers.get('Content-Type', ''),
-            'CONTENT_LENGTH':       self.headers.get('Content-Length', ''),
             'REMOTE_ADDR':          self.address_string(),
             'REMOTE_PORT':          self.port_integer(),
             'SERVER_NAME':          self.server.server_address[0],
@@ -133,9 +131,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         }
 
         for key, value in self.headers.items():
-            key = 'HTTP_' + key.upper().replace('-', '_')
-            if key not in ('HTTP_CONTENT_TYPE', 'HTTP_CONTENT_LENGTH'):
-                environ[key] = value
+            key = key.upper().replace('-', '_')
+            if key not in ('CONTENT_TYPE', 'CONTENT_LENGTH'):
+                key = 'HTTP_' + key
+            environ[key] = value
 
         if request_url.scheme and request_url.netloc:
             environ['HTTP_HOST'] = request_url.netloc


### PR DESCRIPTION
Fix: https://github.com/pallets/werkzeug/issues/1049

according to (PEP333)(https://www.python.org/dev/peps/pep-0333/#environ-variables) it's ok if they're absent

![image](https://cloud.githubusercontent.com/assets/321947/21563719/b24d06c4-cebf-11e6-9c17-e77049bceb87.png)