### PR TITLE
Add support for SameSite cookies.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Project Leader / Developer:
 - Lars Holm Nielsen
 - Joël Charles
 - Benjamin Dopplinger
+- Ian Carroll <ian@ian.sh>
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,7 @@ Unreleased.
 - Color run_simple's terminal output based on HTTP codes ``#1013``.
 - Fix self-XSS in debugger console, see ``#1031``.
 - Fix IPython 5.x shell support, see ``#1033``.
+- Add support for SameSite cookies.
 
 Version 0.11.14
 ---------------

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -937,7 +937,7 @@ def parse_cookie(header, charset='utf-8', errors='replace', cls=None):
 
 def dump_cookie(key, value='', max_age=None, expires=None, path='/',
                 domain=None, secure=False, httponly=False,
-                charset='utf-8', sync_expires=True):
+                samesite=None, charset='utf-8', sync_expires=True):
     """Creates a new Set-Cookie header without the ``Set-Cookie`` prefix
     The parameters are the same as in the cookie Morsel object in the
     Python standard library but it accepts unicode data, too.
@@ -970,6 +970,9 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
     :param httponly: disallow JavaScript to access the cookie.  This is an
                      extension to the cookie standard and probably not
                      supported by all browsers.
+    :param samesite: Restrict access to cookies by other sites. Valid values
+                     are `Lax` and `Strict`. This is an extension to the cookie 
+                     standard and probably not supported by all browsers.
     :param charset: the encoding for unicode values.
     :param sync_expires: automatically set expires if max_age is defined
                          but expires not.
@@ -997,6 +1000,7 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
                     (b'Expires', expires, False,),
                     (b'Max-Age', max_age, False),
                     (b'Secure', secure, None),
+                    (b'SameSite', samesite, False),
                     (b'HttpOnly', httponly, None),
                     (b'Path', path, False)):
         if q is None:

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -971,7 +971,7 @@ def dump_cookie(key, value='', max_age=None, expires=None, path='/',
                      extension to the cookie standard and probably not
                      supported by all browsers.
     :param samesite: Restrict access to cookies by other sites. Valid values
-                     are `Lax` and `Strict`. This is an extension to the cookie 
+                     are `Lax` and `Strict`. This is an extension to the cookie
                      standard and probably not supported by all browsers.
     :param charset: the encoding for unicode values.
     :param sync_expires: automatically set expires if max_age is defined

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1053,7 +1053,7 @@ class BaseResponse(object):
                          extension to the cookie standard and probably not
                          supported by all browsers.
         :param samesite: Restrict access to cookies by other sites. Valid values
-                         are `Lax` and `Strict`. This is an extension to the cookie 
+                         are `Lax` and `Strict`. This is an extension to the cookie
                          standard and probably not supported by all browsers.
         """
         self.headers.add('Set-Cookie', dump_cookie(key,

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1031,7 +1031,7 @@ class BaseResponse(object):
         return _iter_encoded(self.response, self.charset)
 
     def set_cookie(self, key, value='', max_age=None, expires=None,
-                   path='/', domain=None, secure=False, httponly=False):
+                   path='/', domain=None, secure=False, httponly=False, samesite=None):
         """Sets a cookie. The parameters are the same as in the cookie `Morsel`
         object in the Python standard library but it accepts unicode data, too.
 
@@ -1052,6 +1052,9 @@ class BaseResponse(object):
         :param httponly: disallow JavaScript to access the cookie.  This is an
                          extension to the cookie standard and probably not
                          supported by all browsers.
+        :param samesite: Restrict access to cookies by other sites. Valid values
+                         are `Lax` and `Strict`. This is an extension to the cookie 
+                         standard and probably not supported by all browsers.
         """
         self.headers.add('Set-Cookie', dump_cookie(key,
                                                    value=value,

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1064,6 +1064,7 @@ class BaseResponse(object):
                                                    domain=domain,
                                                    secure=secure,
                                                    httponly=httponly,
+                                                   samesite=samesite,
                                                    charset=self.charset))
 
     def delete_cookie(self, key, path='/', domain=None):


### PR DESCRIPTION
This PR adds support for [SameSite cookies](https://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/). 

The SameSite cookie attribute can have three states:
- Not set at all
- Set to `Strict` by `SameSite=Strict` or just `SameSite`
- Set to `Lax` by `SameSite=Lax`

This should allow you to call `set_cookie` with `samesite="Lax"` or `samesite="Strict"`.