### PR TITLE
Force body background color to be white

### DIFF
--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -60,7 +60,7 @@ HEADER = u'''\
           SECRET = "%(secret)s";
     </script>
   </head>
-  <body>
+  <body style="background-color: #fff">
     <div class="debugger">
 '''
 FOOTER = u'''\


### PR DESCRIPTION
When one uses Chrome DevTools with a dark theme error pages generated by `tbtools` look pretty unclear in `network/preview` tab (black text on a dark background).

Before this change: ![image](https://cloud.githubusercontent.com/assets/1437211/22289988/812b5f50-e30f-11e6-9a5d-27700c996164.png)
With explicit background color: ![image](https://cloud.githubusercontent.com/assets/1437211/22289990/85123d1e-e30f-11e6-9122-b9e932bdc17b.png)
