### PR TITLE
add specificity sorting to Accept datastructures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Project Leader / Developer:
 - Lars Holm Nielsen
 - Joël Charles
 - Benjamin Dopplinger
+- Felix König
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -49,6 +49,9 @@ Unreleased.
 - Color run_simple's terminal output based on HTTP codes ``#1013``.
 - Fix self-XSS in debugger console, see ``#1031``.
 - Fix IPython 5.x shell support, see ``#1033``.
+- Change Accept datastructure to sort by specificity first, allowing for more
+  accurate results when using ``best_match`` for mime types (for example in
+  ``requests.accept_mimetypes.best_match``)
 
 Version 0.11.16
 ---------------

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -948,7 +948,14 @@ class TestAccept(object):
             'asterisk'
         assert accept.best_match(['star'], default=None) is None
 
-    @pytest.mark.skipif(True, reason='Werkzeug doesn\'t respect specificity.')
+    def test_accept_keep_order(self):
+        accept = self.storage_class([('*', 1)])
+        assert accept.best_match(["alice", "bob"]) == "alice"
+        assert accept.best_match(["bob", "alice"]) == "bob"
+        accept = self.storage_class([('alice', 1), ('bob', 1)])
+        assert accept.best_match(["alice", "bob"]) == "alice"
+        assert accept.best_match(["bob", "alice"]) == "bob"
+
     def test_accept_wildcard_specificity(self):
         accept = self.storage_class([('asterisk', 0), ('star', 0.5), ('*', 1)])
         assert accept.best_match(['star', 'asterisk'], default=None) == 'star'
@@ -956,6 +963,25 @@ class TestAccept(object):
         assert accept.best_match(['asterisk', 'times'], default=None) == \
             'times'
         assert accept.best_match(['asterisk'], default=None) is None
+
+
+class TestMIMEAccept(object):
+    storage_class = datastructures.MIMEAccept
+
+    def test_accept_wildcard_subtype(self):
+        accept = self.storage_class([('text/*', 1)])
+        assert accept.best_match(['text/html'], default=None) == 'text/html'
+        assert accept.best_match(['image/png', 'text/plain']) == 'text/plain'
+        assert accept.best_match(['image/png'], default=None) is None
+
+    def test_accept_wildcard_specificity(self):
+        accept = self.storage_class([('*/*', 1), ('text/html', 1)])
+        assert accept.best_match(['image/png', 'text/html']) == 'text/html'
+        assert accept.best_match(['image/png', 'text/plain']) == 'image/png'
+        accept = self.storage_class([('*/*', 1), ('text/html', 1),
+                                     ('image/*', 1)])
+        assert accept.best_match(['image/png', 'text/html']) == 'text/html'
+        assert accept.best_match(['text/plain', 'image/png']) == 'image/png'
 
 
 class TestFileStorage(object):


### PR DESCRIPTION
First off, sorry for arriving with a pull request straight away instead of an issue for discussion. Consider this the place for discussion with reference code attached.

The original problem: [RFC2616](https://tools.ietf.org/html/rfc2616#section-14.1) dictates that in the Accept-Header more specific entries have precedence over lesser specific ones. Werkzeug currently does not support this. This PR fixes that. (additional mime type parameters get ignored though, so this isn't a 100% solution)

For example, if the client accepts `text/html,*/*`, and the server offers `application/json,text/html`, then the best match must be `text/html`, regardless of any reordering. This is the current situation:

    >>> accept = MIMEAccept([('text/html', 1), ('*/*', 1)])
    >>> accept.best_match(['application/json', 'text/html'])
    'application/json'

I stumbled upon this because Microsoft Edge's Accept-Header currently looks like this: `
   Accept: text/html, application/xhtml+xml, image/jxr, */*`, which actually broke a site of mine that had multiple representations based on the Accept-Header.

This change possibly breaks code that depends on:
  - Accept datastructures being sorted by `quality` only instead of `specificity` first.
  - `best_match()` returning the best quality result instead of the best result based on both specificity and quality.

This approach could also potentially be extended to `LanguageAccept`, making locales like `en` equivalent to `en-*` and have them match `en-US` for example. See also pull request #450 