### PR TITLE
Add condition of not being under Windows to reuse file descriptor

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ Version 0.12.1
 
 yet to be released
 
+- Fix crash of reloader (used on debug mode) on Windows.
+(`OSError: [WinError 10038]`). See pull request ``#1081``
+
 Version 0.12
 ------------
 

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -88,13 +88,13 @@ else:
 # important: do not use relative imports here or python -m will break
 import werkzeug
 from werkzeug._internal import _log
-from werkzeug._compat import PY2, reraise, wsgi_encoding_dance
+from werkzeug._compat import PY2, WIN, reraise, wsgi_encoding_dance
 from werkzeug.urls import url_parse, url_unquote
 from werkzeug.exceptions import InternalServerError
 
 
 LISTEN_QUEUE = 128
-can_open_by_fd = hasattr(socket, 'fromfd')
+can_open_by_fd = not WIN and hasattr(socket, 'fromfd')
 
 
 class WSGIRequestHandler(BaseHTTPRequestHandler, object):


### PR DESCRIPTION
Given that, under Windows, `socket.fileno`'s output "can't be used where a file descriptor can be used" ([`socket.fileno` docs]), we need to add the condition of not being in Windows to be able to reuse the file descriptor when the app is reloaded

Closes pallets/werkzeug#993
Closes pallets/flask#2194

[`socket.fileno` docs]: https://docs.python.org/3.5/library/socket.html#socket.socket.fileno