### PR TITLE
Minor optimization for url_quote

### DIFF
--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -471,7 +471,7 @@ def url_quote(string, charset='utf-8', errors='strict', safe='/:', unsafe=''):
         if char in safe:
             rv.append(char)
         else:
-            rv.extend(('%%%02X' % char).encode('ascii'))
+            rv.extend(b'%%%02X' % char)
     return to_native(bytes(rv))
 
 

--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -38,6 +38,9 @@ _hextobyte = dict(
     ((a + b).encode(), int(a + b, 16))
     for a in _hexdigits for b in _hexdigits
 )
+_bytetohex = [
+    ('%%%02X' % char).encode('ascii') for char in range(256)
+]
 
 
 _URLTuple = fix_tuple_repr(namedtuple(
@@ -471,7 +474,7 @@ def url_quote(string, charset='utf-8', errors='strict', safe='/:', unsafe=''):
         if char in safe:
             rv.append(char)
         else:
-            rv.extend(b'%%%02X' % char)
+            rv.extend(_bytetohex[char])
     return to_native(bytes(rv))
 
 


### PR DESCRIPTION
Since we're working with bytes here anyway, there's no need to use strings and encode. This yields ~9% performance gain with python3 and ~23% performance gain with python2. This is useful for generating pages which contain many links.