### PR TITLE
Fixed docstring for func abort in exceptions.py

### DIFF
--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -688,7 +688,7 @@ class Aborter(object):
 
 
 def abort(status, *args, **kwargs):
-    '''
+    """
     Raises an :py:exc:`HTTPException` for the given status code or WSGI
     application::
 
@@ -703,7 +703,7 @@ def abort(status, *args, **kwargs):
        abort(404)
        abort(Response('Hello World'))
 
-    '''
+    """
     return _aborter(status, *args, **kwargs)
 
 _aborter = Aborter()


### PR DESCRIPTION
The docstring was using triple single rather than triple double quotes, this caused help(abort) to display wrong documentation (docs for the Aborter class). This also bubbled up to flask's api documentation, yielding the wrong docstring for flask.abort. I found this while looking into this issue https://github.com/pallets/flask/issues/2218