### PR TITLE
Raise TypeError if port is not an integer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,8 @@ Version 0.13
 
 yet to be released
 
+- Raise `TypeError` when port is not an integer.
+
 Version 0.12.1
 --------------
 

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -278,3 +278,19 @@ def test_set_content_length_and_content_type_if_provided_by_client(dev_server):
         'content_type': 'application/json'
     })
     assert r.content == b'YES'
+
+
+def test_port_must_be_integer(dev_server):
+    def app(environ, start_response):
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return [b'hello']
+
+    with pytest.raises(TypeError) as excinfo:
+        serving.run_simple(hostname='localhost', port='5001',
+                           application=app, use_reloader=True)
+    assert 'port must be an integer' in str(excinfo.value)
+
+    with pytest.raises(TypeError) as excinfo:
+        serving.run_simple(hostname='localhost', port='5001',
+                           application=app, use_reloader=False)
+    assert 'port must be an integer' in str(excinfo.value)

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -668,6 +668,8 @@ def run_simple(hostname, port, application, use_reloader=False,
                         the server should automatically create one, or ``None``
                         to disable SSL (which is the default).
     """
+    if not isinstance(port, int):
+        raise TypeError('port must be an integer')
     if use_debugger:
         from werkzeug.debug import DebuggedApplication
         application = DebuggedApplication(application, use_evalex)


### PR DESCRIPTION
As explained in pallets/flask#2220 `port` should be an integer and in other cases a `TypeError` exception should be raised. This PR includes a type check to raise said exception and a test to check if the exception is raised (when `use_reloader` is `True` and when its `False`).

Closes pallets/flask#2220