### PR TITLE
Fix regression from PR #892: Werkzeug didn't log the IP of a remote client behind a reverse proxy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Project Leader / Developer:
 - Lars Holm Nielsen
 - Joël Charles
 - Benjamin Dopplinger
+- Nils Steinger
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,15 @@
 Werkzeug Changelog
 ==================
 
+Version 0.12.2
+------------
+
+yet to be released
+
+- Fix regression: Pull request ``#892`` prevented Werkzeug from correctly
+  logging the IP of a remote client behind a reverse proxy, even when using
+  `ProxyFix`.
+
 Version 0.12.1
 --------------
 

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -279,7 +279,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return BaseHTTPRequestHandler.version_string(self).strip()
 
     def address_string(self):
-        return self.client_address[0]
+        if getattr(self, 'environ', None):
+            return self.environ['REMOTE_ADDR']
+        else:
+            return self.client_address[0]
 
     def port_integer(self):
         return self.client_address[1]


### PR DESCRIPTION
As per the discussion on PR #892, this commit combines the old behaviour with
the fallback introduced in #892:
Use self.environ if it is available (to obtain the IP detected by `ProxyFix`,
if any); fall back to self.client_address[0] otherwise.