### PR TITLE
Add deprecation warning to `Request.is_xhr`

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1088,6 +1088,17 @@ def test_request_method_case_sensitivity():
     assert req.method == 'GET'
 
 
+def test_is_xhr_warning():
+    warning_message = ('Request.is_xhr is deprecated. Given that the '
+                       'X-Requested-With header is not a part of any spec, '
+                       'it is not reliable')
+    req = wrappers.Request.from_values()
+    with pytest.warns(DeprecationWarning) as record:
+        req.is_xhr
+    assert len(record) == 1
+    assert str(record[0].message) == warning_message
+
+
 class TestSetCookie(object):
     """Tests for :meth:`werkzeug.wrappers.BaseResponse.set_cookie`."""
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1089,14 +1089,13 @@ def test_request_method_case_sensitivity():
 
 
 def test_is_xhr_warning():
-    warning_message = ('Request.is_xhr is deprecated. Given that the '
-                       'X-Requested-With header is not a part of any spec, '
-                       'it is not reliable')
     req = wrappers.Request.from_values()
+
     with pytest.warns(DeprecationWarning) as record:
         req.is_xhr
+
     assert len(record) == 1
-    assert str(record[0].message) == warning_message
+    assert 'Request.is_xhr is deprecated' in str(record[0].message)
 
 
 class TestSetCookie(object):

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -672,18 +672,20 @@ class BaseRequest(object):
     @property
     def is_xhr(self):
         """True if the request was triggered via a JavaScript XMLHttpRequest.
-        This only works with libraries that support the `X-Requested-With`
+        This only works with libraries that support the ``X-Requested-With``
         header and set it to "XMLHttpRequest".  Libraries that do that are
         prototype, jQuery and Mochikit and probably some more.
 
         .. deprecated:: 0.13
-            ``X-Requested-With`` is not standard and is unreliable."""
-        warn(DeprecationWarning('Request.is_xhr is deprecated. '
-                                'Given that the X-Requested-With header is '
-                                'not a part of any spec, it is not reliable'),
-             stacklevel=2)
-        return self.environ.get('HTTP_X_REQUESTED_WITH', '').lower() \
-            == 'xmlhttprequest'
+            ``X-Requested-With`` is not standard and is unreliable.
+        """
+        warn(DeprecationWarning(
+            'Request.is_xhr is deprecated. Given that the X-Requested-With '
+            'header is not a part of any spec, it is not reliable'
+        ), stacklevel=2)
+        return self.environ.get(
+            'HTTP_X_REQUESTED_WITH', ''
+        ).lower() == 'xmlhttprequest'
 
     is_secure = property(lambda x: x.environ['wsgi.url_scheme'] == 'https',
                          doc='`True` if the request is secure.')


### PR DESCRIPTION
As explained in #1077, the `X-Requested-With` header is not reliable, so it's safe to this property