### PR TITLE
Update formparser.py

### DIFF
--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -183,7 +183,7 @@ class FormDataParser(object):
         """
         if self.max_content_length is not None and \
            content_length is not None and \
-           content_length > self.max_content_length:
+           content_length > eval(self.max_content_length):
             raise exceptions.RequestEntityTooLarge()
         if options is None:
             options = {}


### PR DESCRIPTION
when using python 3.6.1, max_content_length is a str so it complains of TypeError: '>' not supported between instances of 'int' and 'str'