### PR TITLE
Fix bug in TypeConversionDict

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -545,6 +545,20 @@ class TestOrderedMultiDict(_MutableMultiDictTests):
         assert sorted(iterkeys(ab)) == ["key_a", "key_b"]
 
 
+class TestTypeConversionDict(object):
+    storage_class = datastructures.TypeConversionDict
+
+    def test_return_default_when_conversion_is_not_possible(self):
+        d = self.storage_class(foo='bar')
+        assert d.get('foo', default=-1, type=int) == -1
+
+    def test_raise_key_error_in_conversion(self):
+        d = self.storage_class(foo='bar')
+
+        with pytest.raises(KeyError):
+            d.get('baz', default=-1, type=int)
+
+
 class TestCombinedMultiDict(object):
     storage_class = datastructures.CombinedMultiDict
 

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -297,12 +297,16 @@ class TypeConversionDict(dict):
                      :class:`MultiDict`.  If a :exc:`ValueError` is raised
                      by this callable the default value is returned.
         """
-        try:
-            rv = self[key]
-            if type is not None:
-                rv = type(rv)
-        except (KeyError, ValueError):
-            rv = default
+        if type is not None:
+            try:
+                rv = type(self[key])
+            except ValueError:
+                rv = default
+        else:
+            try:
+                rv = self[key]
+            except KeyError:
+                rv = default
         return rv
 
 


### PR DESCRIPTION
TypeConversionDict should raise KeyError during conversion when key is not present, but now is returning the default value. This PR fixes this bug and adds the corresponding test cases.

Fixes #1102 