### PR TITLE
Allow configuring or disabling max cookie size check

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,13 @@ yet to be released
   using the converter. (``#1102``)
 - ``Authorization.qop`` is a string instead of a set, to comply with
   RFC 2617. (``#984``)
+- An exception is raised when an encoded cookie is larger than, by default,
+  4093 bytes. Browsers may silently ignore cookies larger than this.
+  ``BaseResponse`` has a new attribute ``max_cookie_size`` and ``dump_cookie``
+  has a new argument ``max_size`` to configure this. (`#780`_, `#1109`_)
+
+.. _`#780`: https://github.com/pallets/werkzeug/pull/780
+.. _`#1109`: https://github.com/pallets/werkzeug/pull/1109
 
 Version 0.12.1
 --------------

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -417,21 +417,20 @@ class TestHTTPUtility(object):
         val = http.dump_cookie('foo', 'bar', domain=u'.foo.com')
         strict_eq(val, 'foo=bar; Domain=.foo.com; Path=/')
 
-    def test_cookie_maxsize(self):
+    def test_cookie_maxsize(self, recwarn):
         val = http.dump_cookie('foo', 'bar' * 1360 + 'b')
+        assert len(recwarn) == 0
         assert len(val) == 4093
 
-        with pytest.raises(ValueError) as excinfo:
-            http.dump_cookie('foo', 'bar' * 1360 + 'ba')
+        http.dump_cookie('foo', 'bar' * 1360 + 'ba')
+        assert len(recwarn) == 1
+        w = recwarn.pop()
+        assert 'cookie is too large' in str(w.message)
 
-        assert 'Cookie too large' in str(excinfo)
-
-        with pytest.raises(ValueError) as excinfo:
-            # testing custom size, also demonstrating that the value is not the
-            # final size of the cookie
-            http.dump_cookie('foo', b'w' * 512, max_size=512)
-
-        assert 'the limit is 512 bytes' in str(excinfo)
+        http.dump_cookie('foo', b'w' * 502, max_size=512)
+        assert len(recwarn) == 1
+        w = recwarn.pop()
+        assert 'the limit is 512 bytes' in str(w.message)
 
 
 class TestRange(object):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -419,10 +419,11 @@ class TestHTTPUtility(object):
 
     def test_cookie_maxsize(self):
         val = http.dump_cookie('foo', ('bar' * 1360) + 'b')
-        assert len(val) == http.COOKIE_MAXSIZE
+        assert len(val) == 4093
 
         with pytest.raises(ValueError) as excinfo:
             http.dump_cookie('foo', ('bar' * 1360) + 'ba')
+
         assert ('Cookie too large' in str(excinfo))
 
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -418,13 +418,20 @@ class TestHTTPUtility(object):
         strict_eq(val, 'foo=bar; Domain=.foo.com; Path=/')
 
     def test_cookie_maxsize(self):
-        val = http.dump_cookie('foo', ('bar' * 1360) + 'b')
+        val = http.dump_cookie('foo', 'bar' * 1360 + 'b')
         assert len(val) == 4093
 
         with pytest.raises(ValueError) as excinfo:
-            http.dump_cookie('foo', ('bar' * 1360) + 'ba')
+            http.dump_cookie('foo', 'bar' * 1360 + 'ba')
 
-        assert ('Cookie too large' in str(excinfo))
+        assert 'Cookie too large' in str(excinfo)
+
+        with pytest.raises(ValueError) as excinfo:
+            # testing custom size, also demonstrating that the value is not the
+            # final size of the cookie
+            http.dump_cookie('foo', b'w' * 512, max_size=512)
+
+        assert 'the limit is 512 bytes' in str(excinfo)
 
 
 class TestRange(object):

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1084,9 +1084,16 @@ class BaseResponse(object):
                          supported by all browsers.
         """
         self.headers.add('Set-Cookie', dump_cookie(
-            key, value=value, max_age=max_age, expires=expires, path=path,
-            domain=domain, secure=secure, httponly=httponly,
-            charset=self.charset, max_size=self.max_cookie_size
+            key,
+            value=value,
+            max_age=max_age,
+            expires=expires,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            charset=self.charset,
+            max_size=self.max_cookie_size
         ))
 
     def delete_cookie(self, key, path='/', domain=None):

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -804,6 +804,14 @@ class BaseResponse(object):
     #: .. versionadded:: 0.8
     automatically_set_content_length = True
 
+    #: The max size in bytes of a cookie header. The default, 4093, should be
+    #: safely `supported by most browsers <cookie_>`_. A larger header may
+    #: still be sent, but it may be ignored or handled incorrectly by some
+    #: browsers. Set to 0 to disable this check.
+    #:
+    #: .. _`cookie`: http://browsercookielimits.squawky.net/
+    max_cookie_size = 4093
+
     def __init__(self, response=None, status=None, headers=None,
                  mimetype=None, content_type=None, direct_passthrough=False):
         if isinstance(headers, Headers):
@@ -1054,6 +1062,9 @@ class BaseResponse(object):
         """Sets a cookie. The parameters are the same as in the cookie `Morsel`
         object in the Python standard library but it accepts unicode data, too.
 
+        The size of the encoded cookie is determined by
+        :attr:`max_cookie_size`.
+
         :param key: the key (name) of the cookie to be set.
         :param value: the value of the cookie.
         :param max_age: should be a number of seconds, or `None` (default) if
@@ -1072,15 +1083,11 @@ class BaseResponse(object):
                          extension to the cookie standard and probably not
                          supported by all browsers.
         """
-        self.headers.add('Set-Cookie', dump_cookie(key,
-                                                   value=value,
-                                                   max_age=max_age,
-                                                   expires=expires,
-                                                   path=path,
-                                                   domain=domain,
-                                                   secure=secure,
-                                                   httponly=httponly,
-                                                   charset=self.charset))
+        self.headers.add('Set-Cookie', dump_cookie(
+            key, value=value, max_age=max_age, expires=expires, path=path,
+            domain=domain, secure=secure, httponly=httponly,
+            charset=self.charset, max_size=self.max_cookie_size
+        ))
 
     def delete_cookie(self, key, path='/', domain=None):
         """Delete a cookie.  Fails silently if key doesn't exist.

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -804,10 +804,12 @@ class BaseResponse(object):
     #: .. versionadded:: 0.8
     automatically_set_content_length = True
 
-    #: The max size in bytes of a cookie header. The default, 4093, should be
-    #: safely `supported by most browsers <cookie_>`_. A larger header may
-    #: still be sent, but it may be ignored or handled incorrectly by some
-    #: browsers. Set to 0 to disable this check.
+    #: Warn if a cookie header exceeds this size. The default, 4093, should be
+    #: safely `supported by most browsers <cookie_>`_. A cookie larger than
+    #: this size will still be sent, but it may be ignored or handled
+    #: incorrectly by some browsers. Set to 0 to disable this check.
+    #:
+    #: .. versionadded:: 0.13
     #:
     #: .. _`cookie`: http://browsercookielimits.squawky.net/
     max_cookie_size = 4093
@@ -1062,8 +1064,8 @@ class BaseResponse(object):
         """Sets a cookie. The parameters are the same as in the cookie `Morsel`
         object in the Python standard library but it accepts unicode data, too.
 
-        The size of the encoded cookie is determined by
-        :attr:`max_cookie_size`.
+        A warning is raised if the size of the cookie header exceeds
+        :attr:`max_cookie_size`, but the header will still be set.
 
         :param key: the key (name) of the cookie to be set.
         :param value: the value of the cookie.


### PR DESCRIPTION
Continue #780 

* use arg instead of const for `dump_cookie` `max_size`
* add `max_cookie_size` attr to `BaseResponse`
* add changelog