### PR TITLE
Fix TypeError in LintMiddleware

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,7 +20,7 @@ yet to be released
   4093 bytes. Browsers may silently ignore cookies larger than this.
   ``BaseResponse`` has a new attribute ``max_cookie_size`` and ``dump_cookie``
   has a new argument ``max_size`` to configure this. (`#780`_, `#1109`_)
-- Fix a TypeError in ``werkzueg.contrib.lint.GuardedIterator.close``.
+- Fix a TypeError in ``werkzeug.contrib.lint.GuardedIterator.close``.
 
 .. _`#780`: https://github.com/pallets/werkzeug/pull/780
 .. _`#1109`: https://github.com/pallets/werkzeug/pull/1109

--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@ yet to be released
   4093 bytes. Browsers may silently ignore cookies larger than this.
   ``BaseResponse`` has a new attribute ``max_cookie_size`` and ``dump_cookie``
   has a new argument ``max_size`` to configure this. (`#780`_, `#1109`_)
+- Fix a TypeError in ``werkzueg.contrib.lint.GuardedIterator.close``.
 
 .. _`#780`: https://github.com/pallets/werkzeug/pull/780
 .. _`#1109`: https://github.com/pallets/werkzeug/pull/1109

--- a/werkzeug/contrib/lint.py
+++ b/werkzeug/contrib/lint.py
@@ -172,7 +172,7 @@ class GuardedIterator(object):
             elif 100 <= status_code < 200 or status_code == 204:
                 if content_length != 0:
                     warn(HTTPWarning('%r responses must have an empty '
-                                     'content length') % status_code)
+                                     'content length' % status_code))
                 if bytes_sent:
                     warn(HTTPWarning('%r responses must not have a body' %
                                      status_code))


### PR DESCRIPTION
This PR fixes a TypeError in  werkzueg.contrib.lint.GuardedIterator.close, triggered by a response that, contrary to what the linter expects, has a non-zero content-length.

```
                if content_length != 0:
                    warn(HTTPWarning('%r responses must have an empty '
>                                    'content length') % status_code)
E                   TypeError: unsupported operand type(s) for %: 'HTTPWarning' and 'int'
```

