### PR TITLE
Invalid cookies

### DIFF
--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -271,9 +271,15 @@ def _cookie_parse_impl(b):
     split_on_semicolon = (x.strip() for x in b.split(b';') if len(x) > 0 )
     split_on_equal = ( x.split(b'=', 2) for x in split_on_semicolon )
     cookies = ( (_b_strip(x[0]), _b_strip(x[1]),) for x in split_on_equal if len(x) == 2 )
+
+    # Although not specified in the RFCs, it is a de facto standard in the case
+    # of duplicate keys, the first one is used, due to browser ordering cookies
+    # from most specific scope to most generic.
+    cookeys = set()
     for k, v in cookies:
-        #if key.lower() not in _cookie_params:
-        yield _cookie_unquote(k), _cookie_unquote(v)
+        if k not in cookeys:
+            cookeys.add(k)
+            yield _cookie_unquote(k), _cookie_unquote(v)
 
 
 def _encode_idna(domain):


### PR DESCRIPTION
Closes #1117 and #1118. It also address #841 although discards the one cookie without equal signs, but no longer discards the valid cookies.

This can be tested with the following code:
```python2
#!/usr/bin/env python2

import sys
sys.path.insert(0, '/export/scratch/repos/forks/werkzeug')
from werkzeug.wrappers import Request, Response

@Request.application
def application(request):
    print(request.cookies)
    return Response('Hello World!\n')

if __name__ == '__main__':
    from werkzeug.serving import run_simple
    run_simple('localhost', 8080, application)
```

And `curl -b 'first=IamTheFirst ; a=1; oops  ; a=2 ; second = andMeTwo;' localhost:8080`
