### PR TITLE
Allow period character in converter argument

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -520,6 +520,18 @@ def test_converter_with_tuples():
     assert kwargs['foo'] == ('qwert', 'yuiop')
 
 
+def test_anyconverter():
+    m = r.Map([
+        r.Rule('/<any(a1, a2):a>', endpoint='no_dot'),
+        r.Rule('/<any(a.1, a.2):a>', endpoint='yes_dot')
+    ])
+    a = m.bind('example.org', '/')
+    assert a.match('/a1') == ('no_dot', {'a': 'a1'})
+    assert a.match('/a2') == ('no_dot', {'a': 'a2'})
+    assert a.match('/a.1') == ('yes_dot', {'a': 'a.1'})
+    assert a.match('/a.2') == ('yes_dot', {'a': 'a.2'})
+
+
 def test_build_append_unknown():
     map = r.Map([
         r.Rule('/bar/<float:bazf>', endpoint='barf')

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -131,10 +131,7 @@ _converter_args_re = re.compile(r'''
     ((?P<name>\w+)\s*=\s*)?
     (?P<value>
         True|False|
-        \d+.\d+|
-        \d+.|
-        \d+|
-        \w+|
+        [a-zA-Z0-9_.]+|
         [urUR]?(?P<stringval>"[^"]*?"|'[^']*')
     )\s*,
 ''', re.VERBOSE | re.UNICODE)


### PR DESCRIPTION
This patch addresses issue #1123. Make
`werkzeug.routing._converter_args_re` less strict.
Add test case for `AnyConverter`.