### PR TITLE
Allow chunk request

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,11 +4,11 @@ Werkzeug Changelog
 Version 0.13
 ------------
 
-Released on May 16 2017
+unreleased
 
-- Raise `TypeError` when port is not an integer.
-- Fully deprecate `werkzeug.script`. Use `click`
-  (http://click.pocoo.org) instead.
+- Raise ``TypeError`` when port is not an integer.
+- Fully deprecate ``werkzeug.script``. Use `Click <http://click.pocoo.org>`_
+  instead.
 - ``response.age`` is parsed as a ``timedelta``. Previously, it was incorrectly
   treated as a ``datetime``. The header value is an integer number of seconds,
   not a date string. (``#414``)
@@ -21,11 +21,16 @@ Released on May 16 2017
   ``BaseResponse`` has a new attribute ``max_cookie_size`` and ``dump_cookie``
   has a new argument ``max_size`` to configure this. (`#780`_, `#1109`_)
 - Fix a TypeError in ``werkzeug.contrib.lint.GuardedIterator.close``.
-- `BaseResponse.calculate_content_length` now correctly works for unicode
-  responses on Python 3. It first encodes using `iter_encoded`.
+- ``BaseResponse.calculate_content_length`` now correctly works for unicode
+  responses on Python 3. It first encodes using ``iter_encoded``.
+- ``Request.stream`` is limited to ``Request.max_content_length`` if it is set.
+  Otherwise, keeps the previous behavior of returning empty streams when
+  ``Content-Length`` is not set. This allows chunk-encoded requests while
+  guarding against infinite streams. (`#1126`_)
 
 .. _`#780`: https://github.com/pallets/werkzeug/pull/780
 .. _`#1109`: https://github.com/pallets/werkzeug/pull/1109
+.. _`#1126`: https://github.com/pallets/werkzeug/pull/1126
 
 
 Version 0.12.2

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -427,7 +427,7 @@ class BaseRequest(object):
            parsing happened.
         """
         _assert_not_shallow(self)
-        return get_input_stream(self.environ)
+        return get_input_stream(self.environ, max_content_length=self.max_content_length)
 
     input_stream = environ_property('wsgi.input', """
     The WSGI input stream.

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -336,7 +336,7 @@ class BaseRequest(object):
         return bool(self.environ.get('CONTENT_TYPE'))
 
     def make_form_data_parser(self):
-        """Creates the form data parser.  Instanciates the
+        """Creates the form data parser. Instantiates the
         :attr:`form_data_parser_class` with some parameters.
 
         .. versionadded:: 0.8
@@ -421,13 +421,20 @@ class BaseRequest(object):
         internally always refer to this stream to read data which makes it
         possible to wrap this object with a stream that does filtering.
 
+        .. versionchanged:: 0.13
+            The stream will be limited to :attr:`max_content_length` if the
+            request does not specify a content length or it is greater than the
+            configured max.
+
         .. versionchanged:: 0.9
            This stream is now always available but might be consumed by the
            form parser later on.  Previously the stream was only set if no
            parsing happened.
         """
         _assert_not_shallow(self)
-        return get_input_stream(self.environ, max_content_length=self.max_content_length)
+        return get_input_stream(
+            self.environ, max_content_length=self.max_content_length
+        )
 
     input_stream = environ_property('wsgi.input', """
     The WSGI input stream.


### PR DESCRIPTION
Pass `request.max_content_length` into `get_input_stream` to always return a
`LimitedStream` if the `CONTENT_LENGTH` is not set in the `environ` variable.
Client is expected to set the `max_content_length` variable to the request object.
This patch should fix issue #1094 and #1096.