### PR TITLE
Update _legal_cookie_chars to include / and =

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -372,6 +372,9 @@ class TestHTTPUtility(object):
         strict_eq(dict(http.parse_cookie('fo234{=bar; blub=Blah')),
                   {'fo234{': u'bar', 'blub': u'Blah'})
 
+        strict_eq(http.dump_cookie('key', 'xxx/'), 'key=xxx/; Path=/')
+        strict_eq(http.dump_cookie('key', 'xxx='), 'key=xxx=; Path=/')
+
     def test_cookie_quoting(self):
         val = http.dump_cookie("foo", "?foo")
         strict_eq(val, 'foo="?foo"; Path=/')

--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -28,7 +28,7 @@ _cookie_params = set((b'expires', b'path', b'comment',
                       b'version'))
 _legal_cookie_chars = (string.ascii_letters +
                        string.digits +
-                       u"!#$%&'*+-.^_`|~:").encode('ascii')
+                       u"/=!#$%&'*+-.^_`|~:").encode('ascii')
 
 _cookie_quoting_map = {
     b',': b'\\054',


### PR DESCRIPTION
Both / and = may legally occur in a cookie value without requiring that the value be quoted.
Reference https://www.ietf.org/rfc/rfc6265.txt

While the presence of added quotes should be inconsequential, this is motivated by interacting with a server that did not seem to unquote the cookie value for an auth token, which strictly speaking did not need to be quoted.