### PR TITLE
Typo fix, "a item" -> "an item".

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -126,7 +126,7 @@ class BaseCache(object):
 
     def get_many(self, *keys):
         """Returns a list of values for the given keys.
-        For each key a item in the list is created::
+        For each key an item in the list is created::
 
             foo, bar = cache.get_many("foo", "bar")
 


### PR DESCRIPTION
I've `find . -type f | xargs grep 'a item'` and only find this `a item` typo, so I propose this little PR here.