### PR TITLE
Typo fix for a `safe_join` docstring

### DIFF
--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -253,7 +253,7 @@ def safe_join(directory, *pathnames):
     cannot be done, this function returns ``None``.
 
     :param directory: the base directory.
-    :param filename: the untrusted filename relative to that directory.
+    :param pathnames: the untrusted pathnames relative to that directory.
     """
     parts = [directory]
     for filename in pathnames:


### PR DESCRIPTION
Just fix a minor inconsistency for function params and docstring names.

The original commit comes from:
- https://github.com/pallets/flask/pull/2284/commits/2a6579430649d6514384ca592730c6995e140c43
- https://github.com/pallets/werkzeug/commit/2497866d7eafa64ca5eb4fb3d1747c05036bf318