### PR TITLE
Fix issue 1136 Windows console_scripts called from reloader

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Project Leader / Developer:
 - Joël Charles
 - Benjamin Dopplinger
 - Nils Steinger
+- Andrew Bednar
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,11 @@
 Werkzeug Changelog
 ==================
 
+Version 0.12.3
+--------------
+
+- Fix bug in reloader on Windows.  See ``1136``
+
 Version 0.12.2
 --------------
 

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -210,8 +210,9 @@ def test_reloader_nested_broken_imports(tmpdir, dev_server):
 
 
 def test_windows_get_args_for_reloading(monkeypatch, tmpdir):
+    test_py_exe = 'C:\\Users\\test\\AppData\\Local\\Programs\\Python\\Python36\\python.exe'
     monkeypatch.setattr(os, 'name', 'nt')
-    monkeypatch.setattr(sys, 'executable', 'C:\\Users\\test\\AppData\\Local\\Programs\\Python\\Python36\\python.exe')
+    monkeypatch.setattr(sys, 'executable', )
     test_exe = tmpdir.mkdir('test').join('test.exe')
     monkeypatch.setattr(sys, 'argv', [test_exe.strpath, 'run'])
     rv = _reloader._get_args_for_reloading()

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -210,7 +210,7 @@ def test_reloader_nested_broken_imports(tmpdir, dev_server):
 
 
 def test_windows_get_args_for_reloading(monkeypatch, tmpdir):
-    test_py_exe = 'C:\\Users\\test\\AppData\\Local\\Programs\\Python\\Python36\\python.exe'
+    test_py_exe = r'C:\Users\test\AppData\Local\Programs\Python\Python36\python.exe'
     monkeypatch.setattr(os, 'name', 'nt')
     monkeypatch.setattr(sys, 'executable', test_py_exe)
     test_exe = tmpdir.mkdir('test').join('test.exe')

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -11,6 +11,7 @@
 import os
 import ssl
 import subprocess
+import sys
 import textwrap
 
 
@@ -33,7 +34,7 @@ import requests
 import requests.exceptions
 import pytest
 
-from werkzeug import __version__ as version, serving
+from werkzeug import __version__ as version, serving, _reloader
 
 
 def test_serving(dev_server):
@@ -206,6 +207,15 @@ def test_reloader_nested_broken_imports(tmpdir, dev_server):
     r = requests.get(server.url)
     assert r.status_code == 200
     assert r.content == b'hello'
+
+
+def test_windows_get_args_for_reloading(monkeypatch, tmpdir):
+    monkeypatch.setattr(os, 'name', 'nt')
+    monkeypatch.setattr(sys, 'executable', 'C:\\Users\\test\\AppData\\Local\\Programs\\Python\\Python36\\python.exe')
+    test_exe = tmpdir.mkdir('test').join('test.exe')
+    monkeypatch.setattr(sys, 'argv', [test_exe.strpath, 'run'])
+    rv = _reloader._get_args_for_reloading()
+    assert rv == [test_exe.strpath, 'run']
 
 
 def test_monkeypached_sleep(tmpdir):

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -212,7 +212,7 @@ def test_reloader_nested_broken_imports(tmpdir, dev_server):
 def test_windows_get_args_for_reloading(monkeypatch, tmpdir):
     test_py_exe = 'C:\\Users\\test\\AppData\\Local\\Programs\\Python\\Python36\\python.exe'
     monkeypatch.setattr(os, 'name', 'nt')
-    monkeypatch.setattr(sys, 'executable', )
+    monkeypatch.setattr(sys, 'executable', test_py_exe)
     test_exe = tmpdir.mkdir('test').join('test.exe')
     monkeypatch.setattr(sys, 'argv', [test_exe.strpath, 'run'])
     rv = _reloader._get_args_for_reloading()

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -61,7 +61,7 @@ def _get_args_for_reloading():
        os.path.exists(py_script + '.exe'):
         py_script += '.exe'
     if os.path.splitext(rv[0])[1] == '.exe' and os.path.splitext(py_script)[1] == '.exe':
-        rv.pop()
+        rv.pop(0)
     rv.append(py_script)
     rv.extend(sys.argv[1:])
     return rv

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -60,6 +60,8 @@ def _get_args_for_reloading():
     if os.name == 'nt' and not os.path.exists(py_script) and \
        os.path.exists(py_script + '.exe'):
         py_script += '.exe'
+    if os.path.splitext(rv[0])[1] == '.exe' and os.path.splitext(py_script)[1] == '.exe':
+        rv.pop()
     rv.append(py_script)
     rv.extend(sys.argv[1:])
     return rv


### PR DESCRIPTION
Modified _get_args_for_reloading to resolve issue [werkzueg issue 1136](https://github.com/pallets/werkzeug/issues/1136) and[ apristar issue 208](https://github.com/tomchristie/apistar/issues/208) . The function now checks if an executable is being passed to the python.exe which can generate a SyntaxError: Non-UTF-8 code on windows. If found executable and arguments are passed instead. 