### PR TITLE
remove lighttpd version check in CGIRootFix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,10 @@ Unreleased
 -   If a nested ``ImportError`` occurs from :func:`~utils.import_string`
     the traceback mentions the nested import. Removes an untested code
     path for handling "modules not yet set up by the parent." (`#735`_)
+-   ``CGIRootFix`` no longer modifies ``PATH_INFO`` for very old
+    versions of Lighttpd. ``LighttpdCGIRootFix`` was renamed to
+    ``CGIRootFix`` in 0.9. The old name emits a deprecation warning and
+    will be removed in the next version. (`#1141`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -123,6 +127,7 @@ Unreleased
 .. _`#795`: https://github.com/pallets/werkzeug/pull/795
 .. _`#1019`: https://github.com/pallets/werkzeug/issues/1019
 .. _`#1023`: https://github.com/pallets/werkzeug/issues/1023
+.. _`#1141`: https://github.com/pallets/werkzeug/issues/1141
 .. _`#1231`: https://github.com/pallets/werkzeug/issues/1231
 .. _`#1233`: https://github.com/pallets/werkzeug/pull/1233
 .. _`#1237`: https://github.com/pallets/werkzeug/pull/1237

--- a/tests/contrib/test_fixers.py
+++ b/tests/contrib/test_fixers.py
@@ -35,18 +35,17 @@ class TestServerFixer(object):
             app,
             dict(create_environ(),
                  SCRIPT_NAME='/foo',
-                 PATH_INFO='/bar',
-                 SERVER_SOFTWARE='lighttpd/1.4.27'))
-        assert response.get_data() == b'PATH_INFO: /foo/bar\nSCRIPT_NAME: '
+                 PATH_INFO='/bar'))
+        assert response.get_data() == b'PATH_INFO: /bar\nSCRIPT_NAME: '
 
     def test_cgi_root_fix_custom_app_root(self):
-        app = fixers.CGIRootFix(path_check_app, app_root='/baz/poop/')
+        app = fixers.CGIRootFix(path_check_app, app_root='/baz/')
         response = Response.from_app(
             app,
             dict(create_environ(),
                  SCRIPT_NAME='/foo',
                  PATH_INFO='/bar'))
-        assert response.get_data() == b'PATH_INFO: /foo/bar\nSCRIPT_NAME: baz/poop'
+        assert response.get_data() == b'PATH_INFO: /bar\nSCRIPT_NAME: baz'
 
     def test_path_info_from_request_uri_fix(self):
         app = fixers.PathInfoFromRequestUriFix(path_check_app)

--- a/werkzeug/contrib/__init__.py
+++ b/werkzeug/contrib/__init__.py
@@ -21,4 +21,4 @@ class WerkzeugContribDeprecationWarning(DeprecationWarning):
     pass
 
 
-warnings.simplefilter("module", WerkzeugContribDeprecationWarning)
+warnings.simplefilter("default", WerkzeugContribDeprecationWarning)


### PR DESCRIPTION
According to #266, CGIRootFix is not only for lighttpd now.
So, SERVER_SOFTWARE should not be assumed to start with `'lighttpd/'`, as this value can be `'Apache/x.x.x'` (less than `'lighttpd/1.4.28'`) or `'nginx/x.x.x'` (greater), for example.