### PR TITLE
Allow using ResponseStream as a ZipFile target

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2014 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
+import contextlib
 import os
 
 import pytest
@@ -1117,6 +1118,25 @@ def test_is_xhr_warning():
 
     assert len(record) == 1
     assert 'Request.is_xhr is deprecated' in str(record[0].message)
+
+
+def test_write_length():
+    response = wrappers.Response()
+    length = response.stream.write(b'bar')
+    assert length == 3
+
+
+def test_stream_zip():
+    import zipfile
+
+    response = wrappers.Response()
+    with contextlib.closing(zipfile.ZipFile(response.stream, mode='w')) as z:
+        z.writestr("foo", b"bar")
+
+    buffer = BytesIO(response.get_data())
+    with contextlib.closing(zipfile.ZipFile(buffer, mode='r')) as z:
+        assert z.namelist() == ['foo']
+        assert z.read('foo') == b'bar'
 
 
 class TestSetCookie(object):

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1689,6 +1689,7 @@ class ResponseStream(object):
         self.response._ensure_sequence(mutable=True)
         self.response.response.append(value)
         self.response.headers.pop('Content-Length', None)
+        return len(value)
 
     def writelines(self, seq):
         for item in seq:
@@ -1705,6 +1706,10 @@ class ResponseStream(object):
         if self.closed:
             raise ValueError('I/O operation on closed file')
         return False
+
+    def tell(self):
+        self.response._ensure_sequence()
+        return sum(map(len, self.response.response))
 
     @property
     def encoding(self):


### PR DESCRIPTION
ResponseStream is obviously incompatible with a reading or appending `ZipFile`, but `ZipFile(s, mode="w")` should just need to sequentially write the file. However it seems to use the `write` return value (which should be the number of bytes successfully written), which currently forbids using it thus:
```
Traceback (most recent call last):
  File "test.py", line 44, in <module>
    z.writestr("thing", b"wheee")
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/zipfile.py", line 1645, in writestr
    with self.open(zinfo, mode='w') as dest:
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/zipfile.py", line 1349, in open
    return self._open_to_write(zinfo, force_zip64=force_zip64)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/zipfile.py", line 1462, in _open_to_write
    self.fp.write(zinfo.FileHeader(zip64))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/zipfile.py", line 722, in write
    self.offset += n
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```
Just returning the length of input fixes the issue, and avoids having to e.g. write to a BytesIO.