### PR TITLE
If the mimetype is `application/json` the charset will be appended as  charset parameter

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Project Leader / Developer:
 - Joël Charles
 - Benjamin Dopplinger
 - Nils Steinger
+- Xiaoquan Kong <u1mail2me@gmail.com>
 
 Contributors of code for werkzeug/examples are:
 

--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ unreleased
   Otherwise, keeps the previous behavior of returning empty streams when
   ``Content-Length`` is not set. This allows chunk-encoded requests while
   guarding against infinite streams. (`#1126`_)
+- If the mimetype is `application/json` the charset will be appended as
+  charset parameter
 
 .. _`#780`: https://github.com/pallets/werkzeug/pull/780
 .. _`#1109`: https://github.com/pallets/werkzeug/pull/1109

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -224,6 +224,7 @@ def get_content_type(mimetype, charset):
     """
     if mimetype.startswith('text/') or \
        mimetype == 'application/xml' or \
+       mimetype == 'application/json' or \
        (mimetype.startswith('application/') and
             mimetype.endswith('+xml')):
         mimetype += '; charset=' + charset


### PR DESCRIPTION
Hi all,
I made a small enhance: if the mimetype is `application/json` the charset will be appended as  charset parameter.

This enhance is very useful when user use such as `jsonify` from `flask` or other ways to return json to browser, original behavior will not add charset parameter to content-type, this will lead unicode character display issue, especially when user set app.config['JSON_AS_ASCII'] to False in flask. this PR will enhance werkzeug's ability to process mime-type of `application/json`.

If there is something wrong or something needs I do, please tell me.