### PR TITLE
Allow passing a specific ipv6 address to run_simple

### DIFF
--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -483,6 +483,17 @@ def select_ip_version(host, port):
     return socket.AF_INET
 
 
+def get_sockaddr(host, port):
+    """Returns a fully qualified socket address, that can properly used by
+    socket.bind"""
+    try:
+        res = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
+                                 socket.SOCK_STREAM, socket.SOL_TCP)
+    except socket.gaierror:
+        return (host, port)
+    return res[0][4]
+
+
 class BaseWSGIServer(HTTPServer, object):
 
     """Simple single-threaded, single-process WSGI server."""
@@ -501,7 +512,7 @@ class BaseWSGIServer(HTTPServer, object):
             real_sock = socket.fromfd(fd, self.address_family,
                                       socket.SOCK_STREAM)
             port = 0
-        HTTPServer.__init__(self, (host, int(port)), handler)
+        HTTPServer.__init__(self, get_sockaddr(host, int(port)), handler)
         self.app = app
         self.passthrough_errors = passthrough_errors
         self.shutdown_signal = False
@@ -719,7 +730,7 @@ def run_simple(hostname, port, application, use_reloader=False,
             address_family = select_ip_version(hostname, port)
             s = socket.socket(address_family, socket.SOCK_STREAM)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind((hostname, port))
+            s.bind(get_sockaddr(hostname, port))
             if hasattr(s, 'set_inheritable'):
                 s.set_inheritable(True)
 


### PR DESCRIPTION
socket.bind() requires a fully specified address when asked to bind to a specific ipv6 address.
With this patch, one can start a run_simple server on a specific ipv6 address.

The ipv6 address has to contain the interface name (separated with a %).