### PR TITLE
Hack so that the reloader works for __init__.py files that failed to load

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -21,6 +21,10 @@ def _iter_module_files():
             continue
         filename = getattr(module, '__file__', None)
         if filename:
+            if (os.path.isdir(filename) and
+                os.path.exists(os.path.join(filename, "__init__.py"))):
+                filename = os.path.join(filename, "__init__.py")
+
             old = None
             while not os.path.isfile(filename):
                 old = filename


### PR DESCRIPTION
See: https://github.com/pallets/flask/issues/2423

We might still want an hack in Flask so that we get the `SyntaxError` rather than the `NoAppException`.