### PR TITLE
Replace os.path with posixpath; fixes test on Windows

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import os
+import posixpath
 import pytest
 
 from werkzeug.security import check_password_hash, generate_password_hash, \
@@ -71,7 +72,7 @@ def test_password_hashing():
 
 
 def test_safe_join():
-    assert safe_join('foo', 'bar/baz') == os.path.join('foo', 'bar/baz')
+    assert safe_join('foo', 'bar/baz') == posixpath.join('foo', 'bar/baz')
     assert safe_join('foo', '../bar/baz') is None
     if os.name == 'nt':
         assert safe_join('foo', 'foo\\bar') is None


### PR DESCRIPTION
Currently `test_security#test_safe_join` fails on Windows (7 & 10, at least) since the assertion tests against the results of `os.path.join` instead of `posixpath.join`. `security.safe_join` returns a path that uses the directory separator `/` consistently, while `os.path.join`'s result yields `foo\bar/baz`. 

It seems that a test assertion that uses `posixpath.join` would be more correct in any case since `safe_join` is written to use `posixpath`'s `join` facilities.