### PR TITLE
Properly exit the watchdog Observer to avoid daemon thread crashes

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -212,26 +212,30 @@ class WatchdogReloaderLoop(ReloaderLoop):
         observer = self.observer_class()
         observer.start()
 
-        while not self.should_reload:
-            to_delete = set(watches)
-            paths = _find_observable_paths(self.extra_files)
-            for path in paths:
-                if path not in watches:
-                    try:
-                        watches[path] = observer.schedule(
-                            self.event_handler, path, recursive=True)
-                    except OSError:
-                        # Clear this path from list of watches We don't want
-                        # the same error message showing again in the next
-                        # iteration.
-                        watches[path] = None
-                to_delete.discard(path)
-            for path in to_delete:
-                watch = watches.pop(path, None)
-                if watch is not None:
-                    observer.unschedule(watch)
-            self.observable_paths = paths
-            self._sleep(self.interval)
+        try:
+            while not self.should_reload:
+                to_delete = set(watches)
+                paths = _find_observable_paths(self.extra_files)
+                for path in paths:
+                    if path not in watches:
+                        try:
+                            watches[path] = observer.schedule(
+                                self.event_handler, path, recursive=True)
+                        except OSError:
+                            # Clear this path from list of watches We don't want
+                            # the same error message showing again in the next
+                            # iteration.
+                            watches[path] = None
+                    to_delete.discard(path)
+                for path in to_delete:
+                    watch = watches.pop(path, None)
+                    if watch is not None:
+                        observer.unschedule(watch)
+                self.observable_paths = paths
+                self._sleep(self.interval)
+        finally:
+            observer.stop()
+            observer.join()
 
         sys.exit(3)
 


### PR DESCRIPTION
Daemon threads can cause Python to crash on exit: http://bugs.python.org/issue1856. This was fixed for Python 3.2+ but was backed out from Python 2.7: http://bugs.python.org/issue21963.

I literally get the very same crash on exit described in the Python issue randomly (Debugged with Symbols). It reproduces for me by stressing the reloader. That means constantly modifying files.

Reproduces for me on Windows.