### PR TITLE
Convert dict.keys() to a list when calling get_multi

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -420,7 +420,8 @@ class MemcachedCache(BaseCache):
                 have_encoded_keys = True
             if _test_memcached_key(key):
                 key_mapping[encoded_key] = key
-        d = rv = self._client.get_multi(key_mapping.keys())
+        _keys = list(key_mapping.keys())
+        d = rv = self._client.get_multi(_keys)
         if have_encoded_keys or self.key_prefix:
             rv = {}
             for key, value in iteritems(d):

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -420,7 +420,7 @@ class MemcachedCache(BaseCache):
                 have_encoded_keys = True
             if _test_memcached_key(key):
                 key_mapping[encoded_key] = key
-        _keys = list(key_mapping.keys())
+        _keys = list(key_mapping)
         d = rv = self._client.get_multi(_keys)
         if have_encoded_keys or self.key_prefix:
             rv = {}


### PR DESCRIPTION
Some clients, e.g., [bmemcached](https://github.com/jaysonsantos/python-binary-memcached/blob/769d5e9fcab1e9592b1a5e5e937a52049639c246/bmemcached/protocol.py#L446), expect a `list` as the argument to `get_multi`. This patch prevents the `TypeError` caused when a `dict_keys` object is given instead.