### PR TITLE
Add `pytest-xprocess` to list of test requirements

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,7 +54,7 @@ Install Werkzeug in editable mode::
 
 Install the minimal test requirements::
 
-    pip install pytest requests
+    pip install pytest pytest-xprocess requests
 
 Then you can run the testsuite with::
 


### PR DESCRIPTION
The `pytest-xprocess` package is required to run the test suite, so
mention it as a minimal test requirement in the contribution guidelines.