### PR TITLE
don't raise an exception in NullCache.has

### DIFF
--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -265,6 +265,9 @@ class NullCache(BaseCache):
                             for API compatibility with other caches.
     """
 
+    def has(self, key):
+        return False
+
 
 class SimpleCache(BaseCache):
 


### PR DESCRIPTION
NullCache is supposed to be a drop-in debugging replacement for other caches, but currently its `has` function crashes the application.