### PR TITLE
don't raise an exception in NullCache.has

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,13 @@
 Werkzeug Changelog
 ==================
 
+Version 0.12.3
+--------------
+
+yet to be released
+
+- Don't raise an exception in NullCache.has
+
 Version 0.12.2
 --------------
 

--- a/tests/contrib/test_cache.py
+++ b/tests/contrib/test_cache.py
@@ -267,3 +267,18 @@ class TestUWSGICache(CacheTests):
         c = cache.UWSGICache(cache='werkzeugtest')
         request.addfinalizer(c.clear)
         return lambda: c
+
+
+class TestNullCache(object):
+
+    @pytest.fixture
+    def make_cache(self):
+        return cache.NullCache
+
+    @pytest.fixture
+    def c(self, make_cache):
+        return make_cache()
+
+    def test_nullcache_has(self, c):
+        assert c.has('foo') in (False, 0)
+        assert c.has('spam') in (False, 0)

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -265,6 +265,9 @@ class NullCache(BaseCache):
                             for API compatibility with other caches.
     """
 
+    def has(self, key):
+        return False
+
 
 class SimpleCache(BaseCache):
 


### PR DESCRIPTION
NullCache is supposed to be a drop-in debugging replacement for other caches, but currently its has function crashes the application.

As requested, this new pull request is rebased against the maintenance-0.12 branch and includes both a changelog entry and a test.