### PR TITLE
Improve error message for Redis Cache with None as host -- fixes #1179

### DIFF
--- a/tests/contrib/cache/test_cache.py
+++ b/tests/contrib/cache/test_cache.py
@@ -12,6 +12,7 @@ import os
 
 import pytest
 
+from werkzeug._compat import text_type
 from werkzeug.contrib import cache
 
 try:
@@ -218,6 +219,11 @@ class TestRedisCache(CacheTests):
         assert c.get('foo') == b'Awesome'
         assert c._client.set(c.key_prefix + 'foo', '42')
         assert c.get('foo') == 42
+
+    def test_empty_host(self):
+        with pytest.raises(ValueError) as exc_info:
+            cache.RedisCache(host=None)
+        assert text_type(exc_info.value) == 'RedisCache host parameter may not be None'
 
 
 class TestMemcachedCache(CacheTests):

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -560,6 +560,8 @@ class RedisCache(BaseCache):
     def __init__(self, host='localhost', port=6379, password=None,
                  db=0, default_timeout=300, key_prefix=None, **kwargs):
         BaseCache.__init__(self, default_timeout)
+        if host is None:
+            raise ValueError('RedisCache host parameter may not be None')
         if isinstance(host, string_types):
             try:
                 import redis


### PR DESCRIPTION
Improve the error message when trying to instantiate a RedisCache with None as host.