### PR TITLE
Update recognized useragent platform and browser docs

### DIFF
--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -140,7 +140,7 @@ class UserAgent(object):
 
         the name of the browser.  The following browsers are currently
         recognized:
-        
+
         -   `aol` *
         -   `ask` *
         -   `baidu` *

--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -117,16 +117,22 @@ class UserAgent(object):
        -   `aix`
        -   `amiga`
        -   `android`
+       -   `blackberry`
        -   `bsd`
        -   `chromeos`
+       -   `dragonflybsd`
+       -   `freebsd`
        -   `hpux`
-       -   `iphone`
        -   `ipad`
+       -   `iphone`
        -   `irix`
        -   `linux`
        -   `macos`
+       -   `netbsd`
+       -   `openbsd`
        -   `sco`
        -   `solaris`
+       -   `symbian`
        -   `wii`
        -   `windows`
 
@@ -134,9 +140,11 @@ class UserAgent(object):
 
         the name of the browser.  The following browsers are currently
         recognized:
-
+        
         -   `aol` *
         -   `ask` *
+        -   `baidu` *
+        -   `bing` *
         -   `camino`
         -   `chrome`
         -   `firefox`
@@ -146,6 +154,7 @@ class UserAgent(object):
         -   `konqueror`
         -   `links`
         -   `lynx`
+        -   `mozilla`
         -   `msie`
         -   `msn`
         -   `netscape`


### PR DESCRIPTION
Noticed that the useragent recognized platform and browser docs were out of date.

Doesn't look like doc changes are usually reflected in `CHANGES`, so I didn't touch that.