### PR TITLE
Implemented SSL user authentication setup

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -234,7 +234,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         try:
             peer_cert = self.connection.getpeercert()
             if peer_cert is not None:
-                environ['SOCKET_PEER_CERT'] = peer_cert
+                environ['SSL_CLIENT_CERT'] = peer_cert
         except ValueError:
             self.server.log('error', 'Cannot fetch SSL peer certificate info')
 

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -231,6 +231,13 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         if request_url.scheme and request_url.netloc:
             environ["HTTP_HOST"] = request_url.netloc
 
+        try:
+            peer_cert = self.connection.getpeercert()
+            if peer_cert is not None:
+                environ['SOCKET_PEER_CERT'] = peer_cert
+        except ValueError:
+            self.server.log('error', 'Cannot fetch SSL peer certificate info')
+
         return environ
 
     def run_wsgi(self):
@@ -691,9 +698,16 @@ class BaseWSGIServer(HTTPServer, object):
             self.server_address = self.socket.getsockname()
 
         if ssl_context is not None:
+            ssl_kwargs = {'server_side': True}
             if isinstance(ssl_context, tuple):
                 ssl_context = load_ssl_context(*ssl_context)
-            if ssl_context == "adhoc":
+            if isinstance(ssl_context, dict):
+                cert_file = ssl_context.pop('cert_file')
+                pkey_file = ssl_context.pop('pkey_file')
+                for key in ssl_context:
+                    ssl_kwargs[key] = ssl_context[key]
+                ssl_context = load_ssl_context(cert_file, pkey_file)
+            if ssl_context == 'adhoc':
                 ssl_context = generate_adhoc_ssl_context()
             # If we are on Python 2 the return value from socket.fromfd
             # is an internal socket object but what we need for ssl wrap
@@ -701,7 +715,7 @@ class BaseWSGIServer(HTTPServer, object):
             sock = self.socket
             if PY2 and not isinstance(sock, socket.socket):
                 sock = socket.socket(sock.family, sock.type, sock.proto, sock)
-            self.socket = ssl_context.wrap_socket(sock, server_side=True)
+            self.socket = ssl_context.wrap_socket(sock, **ssl_kwargs)
             self.ssl_context = ssl_context
         else:
             self.ssl_context = None

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -237,6 +237,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                 environ['SSL_CLIENT_CERT'] = peer_cert
         except ValueError:
             self.server.log('error', 'Cannot fetch SSL peer certificate info')
+        except AttributeError:
+            # This error indicates that no TLS setup was made, and it is 
+            # raised because socket will not have such function getpeercert()
+            pass
 
         return environ
 


### PR DESCRIPTION
With this change added, one can use a dict with extra information to be added to socket creation on `load_ssl_context`. 

Adding a more complex set of parameters to `ssl_context`, when using Flask, for example, will be possible through a new valid instance of ssl context, such as:

```
from flask import Flask
app = Flask(__name__)
ssl_context = {
		'cert_file': 'auth/server/crt.crt',
		'pkey_file': 'auth/server/key.key',
		'ca_certs': 'auth/server/ca.crt',
		'cert_reqs': ssl.CERT_REQUIRED
	}
	app.run(debug=True, ssl_context=ssl_context)
```

If possible - and valid, returned values from `SSLSocket.getpeercert`  will be stored into `environ['SOCKET_PEER_CERT']`.