### PR TITLE
Fix Cache.get_many

### DIFF
--- a/tests/contrib/cache/test_cache.py
+++ b/tests/contrib/cache/test_cache.py
@@ -80,7 +80,7 @@ class CacheTests(object):
     def test_generic_get_many(self, c):
         assert c.set('foo', ['bar'])
         assert c.set('spam', 'eggs')
-        assert list(c.get_many('foo', 'spam')) == [['bar'], 'eggs']
+        assert c.get_many('foo', 'spam') == [['bar'], 'eggs']
 
     def test_generic_set_many(self, c):
         assert c.set_many({'foo': 'bar', 'spam': ['eggs']})

--- a/werkzeug/contrib/cache.py
+++ b/werkzeug/contrib/cache.py
@@ -135,7 +135,7 @@ class BaseCache(object):
         :param keys: The function accepts multiple keys as positional
                      arguments.
         """
-        return map(self.get, keys)
+        return [self.get(k) for k in keys]
 
     def get_dict(self, *keys):
         """Like :meth:`get_many` but return a dict::


### PR DESCRIPTION
The ``map`` function behaviors differently between Python 2 and Python 3. In Python 3, you can't access the results returned by ``get_many`` with index.

e.g.

```python
items = cache.get_many('a', 'b', 'c')
# this will raise error in Python 3
items[0]
```