### PR TITLE
Support chunked transfer encoding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/res/chunked.txt binary
+

--- a/tests/res/chunked.txt
+++ b/tests/res/chunked.txt
@@ -1,0 +1,25 @@
+94
+----------------------------898239224156930639461866
+Content-Disposition: form-data; name="file"; filename="test.txt"
+Content-Type: text/plain
+
+
+f
+This is a test
+
+2
+
+
+65
+----------------------------898239224156930639461866
+Content-Disposition: form-data; name="type"
+
+
+a
+text/plain
+3a
+
+----------------------------898239224156930639461866--
+
+0
+

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -10,6 +10,7 @@
 """
 import os
 import ssl
+import sys
 import subprocess
 import textwrap
 
@@ -322,8 +323,12 @@ def test_chunked_encoding(dev_server):
 
     testfile = os.path.join(os.path.dirname(__file__), 'res', 'chunked.txt')
 
-    import httplib
-    conn = httplib.HTTPConnection('127.0.0.1', server.port)
+    if sys.version_info[0] == 2:
+        from httplib import HTTPConnection
+    else:
+        from http.client import HTTPConnection
+
+    conn = HTTPConnection('127.0.0.1', server.port)
     conn.connect()
     conn.putrequest('POST', '/', skip_host=1, skip_accept_encoding=1)
     conn.putheader('Accept', 'text/plain')

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -300,25 +300,15 @@ def test_port_must_be_integer(dev_server):
 def test_chunked_encoding(dev_server):
     server = dev_server(r'''
     from werkzeug.wrappers import Request
-    from werkzeug.serving import run_simple
-
     def app(environ, start_response):
-        if environ['REQUEST_METHOD'] != 'POST':
-            start_response('204 OK', [])
-            return []
-
-        try:
-            assert environ['HTTP_TRANSFER_ENCODING'] == 'chunked'
-            assert environ.get('wsgi.input_terminated', False)
-            request = Request(environ)
-            assert request.mimetype == 'multipart/form-data'
-            assert request.files['file'].read() == b'This is a test\n'
-            assert request.form['type'] == b'text/plain'
-            start_response('200 OK', [('Content-Type', 'text/plain')])
-            return [b'YES']
-        except Exception as e:
-            start_response('200 OK', [('Content-Type', 'text/plain')])
-            return [str(e)]
+        assert environ['HTTP_TRANSFER_ENCODING'] == 'chunked'
+        assert environ.get('wsgi.input_terminated', False)
+        request = Request(environ)
+        assert request.mimetype == 'multipart/form-data'
+        assert request.files['file'].read() == b'This is a test\n'
+        assert request.form['type'] == b'text/plain'
+        start_response('200 OK', [('Content-Type', 'text/plain')])
+        return [b'YES']
     ''')
 
     testfile = os.path.join(os.path.dirname(__file__), 'res', 'chunked.txt')

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -306,7 +306,7 @@ def test_chunked_encoding(dev_server):
         request = Request(environ)
         assert request.mimetype == 'multipart/form-data'
         assert request.files['file'].read() == b'This is a test\n'
-        assert request.form['type'] == b'text/plain'
+        assert request.form['type'] == 'text/plain'
         start_response('200 OK', [('Content-Type', 'text/plain')])
         return [b'YES']
     ''')

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -323,8 +323,14 @@ def test_chunked_encoding(dev_server):
     conn.putrequest('POST', '/', skip_host=1, skip_accept_encoding=1)
     conn.putheader('Accept', 'text/plain')
     conn.putheader('Transfer-Encoding', 'chunked')
-    conn.putheader('Content-Type', 'multipart/form-data; boundary=--------------------------898239224156930639461866')
-    conn.endheaders(open(testfile, 'rb').read())
+    conn.putheader(
+        'Content-Type',
+        'multipart/form-data; boundary='
+        '--------------------------898239224156930639461866')
+    conn.endheaders()
+
+    with open(testfile, 'rb') as f:
+        conn.send(f.read())
 
     res = conn.getresponse()
     assert res.status == 200
@@ -359,11 +365,16 @@ def test_chunked_encoding_with_content_length(dev_server):
     conn.putrequest('POST', '/', skip_host=1, skip_accept_encoding=1)
     conn.putheader('Accept', 'text/plain')
     conn.putheader('Transfer-Encoding', 'chunked')
-    # Content-Length is actually invalid, but some libraries might still send it
+    # Content-Length is invalid for chunked, but some libraries might send it
     conn.putheader('Content-Length', '372')
     conn.putheader(
-        'Content-Type', 'multipart/form-data; boundary=--------------------------898239224156930639461866')
-    conn.endheaders(open(testfile, 'rb').read())
+        'Content-Type',
+        'multipart/form-data; boundary='
+        '--------------------------898239224156930639461866')
+    conn.endheaders()
+
+    with open(testfile, 'rb') as f:
+        conn.send(f.read())
 
     res = conn.getresponse()
     assert res.status == 200

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -12,7 +12,7 @@
 import re
 import codecs
 from io import BytesIO
-from tempfile import TemporaryFile
+from tempfile import SpooledTemporaryFile
 from itertools import chain, repeat, tee
 from functools import update_wrapper
 
@@ -38,9 +38,7 @@ _supported_multipart_encodings = frozenset(['base64', 'quoted-printable'])
 def default_stream_factory(total_content_length, filename, content_type,
                            content_length=None):
     """The stream factory that is used per default."""
-    if total_content_length is None or total_content_length > 1024 * 500:
-        return TemporaryFile('wb+')
-    return BytesIO()
+    return SpooledTemporaryFile(max_size=1024 * 500, mode='wb+')
 
 
 def parse_form_data(environ, stream_factory=None, charset='utf-8',

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -11,7 +11,6 @@
 """
 import re
 import codecs
-from io import BytesIO
 from tempfile import SpooledTemporaryFile
 from itertools import chain, repeat, tee
 from functools import update_wrapper

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -38,7 +38,7 @@ _supported_multipart_encodings = frozenset(['base64', 'quoted-printable'])
 def default_stream_factory(total_content_length, filename, content_type,
                            content_length=None):
     """The stream factory that is used per default."""
-    if total_content_length > 1024 * 500:
+    if total_content_length is None or total_content_length > 1024 * 500:
         return TemporaryFile('wb+')
     return BytesIO()
 

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -99,6 +99,8 @@ can_open_by_fd = not WIN and hasattr(socket, 'fromfd')
 
 
 class DechunkedInput(io.RawIOBase):
+    """An input stream that handles Transfer-Encoding 'chunked'"""
+
     def __init__(self, rfile):
         self._rfile = rfile
         self._done = False
@@ -107,31 +109,46 @@ class DechunkedInput(io.RawIOBase):
     def readable(self):
         return True
 
-    def readinto(self, buf):
-        if self._done:
-            return 0
-
-        if self._len == 0:
-            try:
-                self._len = int(self._rfile.readline().decode('latin1').strip(), 16)
-            except ValueError:
-                raise IOError('Invalid chunk header')
-
-        if self._len < 0:
+    def read_chunk_len(self):
+        try:
+            line = self._rfile.readline().decode('latin1')
+            _len = int(line.strip(), 16)
+        except ValueError:
+            raise IOError('Invalid chunk header')
+        if _len < 0:
             raise IOError('Negative chunk length not allowed')
-        elif self._len > 0:
-            n = min(len(buf), self._len)
-            buf[:n] = self._rfile.read(n)
-            self._len -= n
-        else:
-            self._done = True
-            n = 0
+        return _len
 
-        if self._len == 0:
-            if self._rfile.readline() not in (b'\n', b'\r\n', b'\r'):
-                raise IOError('Missing chunk spacing')
+    def readinto(self, buf):
+        read = 0
+        while not self._done and read < len(buf):
+            if self._len == 0:
+                # This is the first chunk or we fully consumed the previous
+                # one. Read the next length of the next chunk
+                self._len = self.read_chunk_len()
 
-        return n
+            if self._len == 0:
+                # Found the final chunk of size 0. The stream is now exhausted,
+                # but there is still a final newline that should be consumed
+                self._done = True
+
+            if self._len > 0:
+                # There is data (left) in this chunk, so append it to the
+                # buffer. If this operation fully consumes the chunk, this will
+                # reset self._len to 0.
+                n = min(len(buf), self._len)
+                buf[read:read + n] = self._rfile.read(n)
+                self._len -= n
+                read += n
+
+            if self._len == 0:
+                # Skip the terminating newline of a chunk that has been fully
+                # consumed. This also applies to the 0-sized final chunk
+                terminator = self._rfile.readline()
+                if terminator not in (b'\n', b'\r\n', b'\r'):
+                    raise IOError('Missing chunk terminating newline')
+
+        return read
 
 
 class WSGIRequestHandler(BaseHTTPRequestHandler, object):

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -154,7 +154,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         environ = {
             'wsgi.version':         (1, 0),
             'wsgi.url_scheme':      url_scheme,
-            'wsgi.input':           self.rfile, # TODO: Wrap this
+            'wsgi.input':           self.rfile,
             'wsgi.errors':          sys.stderr,
             'wsgi.multithread':     self.server.multithread,
             'wsgi.multiprocess':    self.server.multiprocess,

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -166,12 +166,16 @@ def get_host(environ, trusted_hosts=None):
 
 def get_content_length(environ):
     """Returns the content length from the WSGI environment as
-    integer. If it's not available ``None`` is returned.
+    integer. If it's not available or chunked transfer encoding is used,
+    ``None`` is returned.
 
     .. versionadded:: 0.9
 
     :param environ: the WSGI environ to fetch the content length from.
     """
+    if environ.get('HTTP_TRANSFER_ENCODING', '') == 'chunked':
+        return None
+
     content_length = environ.get('CONTENT_LENGTH')
     if content_length is not None:
         try:


### PR DESCRIPTION
This PR introduces support for requests with chunked transfer encoding to `WSGIRequestHandler` by wrapping the input in a `DechunkedInput`. Chunks are unrolled in the following way

 - Read a line to get the chunk's size in bytes
 - Read the chunk data, but only to the length of the buffer
 - Reduce the chunk size by the number of bytes read
 - At the end of the chunk, skip the chunk's final newline

Once a chunk of size zero is encountered, a final newline is read, and then the input is marked as `done`. All further requests to `readinto` will exit early.

There is only a test for the success case. It needs to issue a manual HTTP to achieve a proper chunked multipart payload. 

**Note**: For some reason, werkzeug crashes when parsing the response body if a `Content-Length` header is present. If you would like this fixed in this PR too, let me know. [RFC 2616, Section 4.4](https://www.greenbytes.de/tech/webdav/rfc2616.html#rfc.section.4.4) states that the `Content-Length` header must be ignored with any `Transfer-Encoding` other than `identity`. 

Fixes #1149