### PR TITLE
Fix an issue using `securecookie` with Python 3

### DIFF
--- a/tests/contrib/test_securecookie.py
+++ b/tests/contrib/test_securecookie.py
@@ -36,6 +36,10 @@ def test_basic_support():
     assert not c3.new
     assert c3 == {}
 
+    c4 = SecureCookie({'x': 42}, 'foo')
+    c4_serialized = c4.serialize()
+    assert SecureCookie.unserialize(c4_serialized, 'foo') == c4
+
 
 def test_wrapper_support():
     req = Request.from_values()

--- a/werkzeug/contrib/securecookie.py
+++ b/werkzeug/contrib/securecookie.py
@@ -94,7 +94,7 @@ from hmac import new as hmac
 from time import time
 from hashlib import sha1 as _default_hash
 
-from werkzeug._compat import iteritems, text_type
+from werkzeug._compat import iteritems, text_type, to_bytes
 from werkzeug.urls import url_quote_plus, url_unquote_plus
 from werkzeug._internal import _date_to_unix
 from werkzeug.contrib.sessions import ModificationTrackingDict
@@ -152,10 +152,7 @@ class SecureCookie(ModificationTrackingDict):
         # explicitly convert it into a bytestring because python 2.6
         # no longer performs an implicit string conversion on hmac
         if secret_key is not None:
-            try:
-                secret_key = bytes(secret_key)
-            except TypeError:
-                secret_key = secret_key.encode('utf-8')
+            secret_key = to_bytes(secret_key, 'utf-8')
         self.secret_key = secret_key
         self.new = new
 

--- a/werkzeug/contrib/securecookie.py
+++ b/werkzeug/contrib/securecookie.py
@@ -152,7 +152,10 @@ class SecureCookie(ModificationTrackingDict):
         # explicitly convert it into a bytestring because python 2.6
         # no longer performs an implicit string conversion on hmac
         if secret_key is not None:
-            secret_key = bytes(secret_key)
+            try:
+                secret_key = bytes(secret_key)
+            except TypeError:
+                secret_key = secret_key.encode('utf-8')
         self.secret_key = secret_key
         self.new = new
 


### PR DESCRIPTION
When using a string for the `secret_key` (as per the docs) Python 3 fails with a `TypeError`.

This catches the error and uses the `encode` method instead.

Addresses #1204