### PR TITLE
Wait for Redis 3 or 4 ready messages in tests

### DIFF
--- a/tests/contrib/cache/test_cache.py
+++ b/tests/contrib/cache/test_cache.py
@@ -191,7 +191,7 @@ class TestRedisCache(CacheTests):
             pytest.skip('Python package "redis" is not installed.')
 
         def prepare(cwd):
-            return 'Ready to accept connections', ['redis-server']
+            return '[Rr]eady to accept connections', ['redis-server']
 
         xprocess.ensure('redis_server', prepare)
         yield


### PR DESCRIPTION
Some cache tests have been failing because of a failure to detect a started `redis-server` process below version 4.0. See https://travis-ci.org/pallets/werkzeug/jobs/295973846 for an example. The tests will also fail locally when running `redis-server` 3.2 or earlier. 

The reason for the failure is a difference between the Redis 3 and 4 ready messages:

```diff
4c6
<       _.-``    `.  `_.  ''-._           Redis 3.2.11 (00000000/0) 64 bit
---
>       _.-``    `.  `_.  ''-._           Redis 4.0.5 (00000000/0) 64 bit
20,29c22,31
< 1:M 04 Dec 20:15:13.876 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
< 1:M 04 Dec 20:15:13.876 # Server started, Redis version 3.2.11
< 1:M 04 Dec 20:15:13.876 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
< 1:M 04 Dec 20:15:13.876 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
< 1:M 04 Dec 20:15:13.876 * The server is now ready to accept connections on port 6379
---
> 1:M 04 Dec 20:15:25.533 # WARNING: The TCP backlog setting of 511 cannot be enforced because /proc/sys/net/core/somaxconn is set to the lower value of 128.
> 1:M 04 Dec 20:15:25.533 # Server initialized
> 1:M 04 Dec 20:15:25.533 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
> 1:M 04 Dec 20:15:25.534 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
> 1:M 04 Dec 20:15:25.534 * Ready to accept connections
```

The fix is to detect either `Ready` or `ready`.

Note: Redis 3.2 is the previous stable release, and will be officially supported until the next stable release after 4.0.