### PR TITLE
match header option value with single quotes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ unreleased
 - Secure cookie contrib works with string secret key on Python 3. (`#1205`_)
 - Shared data middleware accepts a list instead of a dict of static locations
   to preserve lookup order. (`#1197`_)
+- HTTP header values without encoding can contain single quotes. (`#1208`_)
 - The built-in dev server supports receiving requests with chunked transfer
   encoding. (`#1198`_)
 
@@ -47,6 +48,7 @@ unreleased
 .. _#1197: https://github.com/pallets/werkzeug/pull/1197
 .. _#1198: https://github.com/pallets/werkzeug/pull/1198
 .. _#1205: https://github.com/pallets/werkzeug/pull/1205
+.. _#1208: https://github.com/pallets/werkzeug/pull/1208
 
 
 Version 0.12.2

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -280,6 +280,14 @@ class TestHTTPUtility(object):
             ('form-data', {'name': u'\u016an\u012dc\u014dde\u033d',
                            'filename': 'some_file.txt'})
 
+    def test_parse_options_header_value_with_quotes(self):
+        assert http.parse_options_header(
+            'form-data; name="file"; filename="t\'es\'t.txt"'
+        ) == ('form-data', {'name': 'file', 'filename': "t'es't.txt"})
+        assert http.parse_options_header(
+            'form-data; name="file"; filename*=UTF-8\'\'"\'🐍\'.txt"'
+        ) == ('form-data', {'name': 'file', 'filename': u"'🐍'.txt"})
+
     def test_parse_options_header_broken_values(self):
         # Issue #995
         assert http.parse_options_header(' ') == ('', {})

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -62,12 +62,30 @@ _token_chars = frozenset("!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                          '^_`abcdefghijklmnopqrstuvwxyz|~')
 _etag_re = re.compile(r'([Ww]/)?(?:"(.*?)"|(.*?))(?:\s*,\s*|$)')
 _unsafe_header_chars = set('()<>@,;:\"/[]?={} \t')
-_quoted_string_re = r'"[^"\\]*(?:\\.[^"\\]*)*"'
-_option_header_piece_re = re.compile(
-    r';\s*(%s|[^\s;,=\*]+)\s*'
-    r'(?:\*?=\s*(?:([^\s]+?)\'([^\s]*?)\')?(%s|[^;,]+)?)?\s*' %
-    (_quoted_string_re, _quoted_string_re)
-)
+_option_header_piece_re = re.compile(r'''
+    ;\s*
+    (?P<key>
+        "[^"\\]*(?:\\.[^"\\]*)*"  # quoted string
+    |
+        [^\s;,=*]+  # token
+    )
+    \s*
+    (?:  # optionally followed by =value
+        (?:  # equals sign, possibly with encoding
+            \*\s*=\s*  # * indicates extended notation
+            (?P<encoding>[^\s]+?)
+            '(?P<language>[^\s]*?)'
+        |
+            =\s*  # basic notation
+        )
+        (?P<value>
+            "[^"\\]*(?:\\.[^"\\]*)*"  # quoted string
+        |
+            [^;,]+  # token
+        )?
+    )?
+    \s*
+''', flags=re.VERBOSE)
 _option_header_start_mime_type = re.compile(r',\s*([^;,\s]+)([;,]\s*.+)?')
 
 _entity_headers = frozenset([


### PR DESCRIPTION
Move the `*=` into the match for extended notation, instead of before it.

The regex became slightly stricter and no longer matches `*=` if it's not followed by a language and encoding. For example, `filename*=test.txt` no longer matches (although it was never valid and nothing should have been sending that). Allowing that (against spec) and also fixing the quoting issue would require a different solution.

fixes #1091, fixes #1177