### PR TITLE
Use raw strings to avoid escape errors in Python 3.6+

### DIFF
--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -40,14 +40,14 @@ for _i in chain(range_type(32), range_type(127, 256)):
     _cookie_quoting_map[int_to_byte(_i)] = ('\\%03o' % _i).encode('latin1')
 
 
-_octal_re = re.compile(b'\\\\[0-3][0-7][0-7]')
-_quote_re = re.compile(b'[\\\\].')
-_legal_cookie_chars_re = b'[\w\d!#%&\'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\=]'
-_cookie_re = re.compile(b"""
+_octal_re = re.compile(br'\\[0-3][0-7][0-7]')
+_quote_re = re.compile(br'[\\].')
+_legal_cookie_chars_re = br'[\w\d!#%&\'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\=]'
+_cookie_re = re.compile(br"""
     (?P<key>[^=]+)
     \s*=\s*
     (?P<val>
-        "(?:[^\\\\"]|\\\\.)*" |
+        "(?:[^\\"]|\\.)*" |
          (?:.*?)
     )
     \s*;


### PR DESCRIPTION
This PR is an improved version of #1176 that also converts `_octal_re` and `_quote_re` to raw strings and removes the escapes that are no longer necessary.