### PR TITLE
Catch HTTP exceptions in Request.application

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Werkzeug Changelog
 Version 0.14
 ------------
 
-- HTTP execptions are now automatically caught by
+- HTTP exceptions are now automatically caught by
   ``Request.application``.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Werkzeug Changelog
 Version 0.14
 ------------
 
-Unreleased
+- HTTP execptions are now automatically caught by
+  ``Request.application``.
 
 
 Version 0.13


### PR DESCRIPTION
This catches HTTP exceptions in Request.application which just generally
makes that function a bit more useful. I don't think there are that many
users of this but for simple apps it's actually not that useless.