### PR TITLE
Do not add python executable to executable scripts when reloading

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,9 @@ Unreleased
     by setting ``e.args = ()``. (`#1395`_)
 -   Add support for status code 424 :exc:`~exceptions.FailedDependency`.
     (`#1358`_)
+-   The reloader will not prepend the Python executable to the command
+    line if the Python file is marked executable. This allows the
+    reloader to work on NixOS. (`#1242`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -112,6 +115,7 @@ Unreleased
 .. _`#1231`: https://github.com/pallets/werkzeug/issues/1231
 .. _`#1233`: https://github.com/pallets/werkzeug/pull/1233
 .. _`#1237`: https://github.com/pallets/werkzeug/pull/1237
+.. _`#1242`: https://github.com/pallets/werkzeug/pull/1242
 .. _`#1245`: https://github.com/pallets/werkzeug/pull/1245
 .. _`#1249`: https://github.com/pallets/werkzeug/issues/1249
 .. _`#1252`: https://github.com/pallets/werkzeug/pull/1252

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -64,7 +64,7 @@ def _get_args_for_reloading():
     a program other than python)
     """
     rv = [sys.executable]
-    py_script = sys.argv[0]
+    py_script = os.path.abspath(sys.argv[0])
 
     if os.name == 'nt' and not os.path.exists(py_script) and \
        os.path.exists(py_script + '.exe'):

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -59,14 +59,21 @@ def _find_observable_paths(extra_files=None):
 def _get_args_for_reloading():
     """Returns the executable. This contains a workaround for windows
     if the executable is incorrectly reported to not have the .exe
-    extension which can cause bugs on reloading.
+    extension which can cause bugs on reloading.  This also contains
+    a workaround for linux where the file is executable (possibly with
+    a program other than python)
     """
     rv = [sys.executable]
     py_script = sys.argv[0]
     if os.name == 'nt' and not os.path.exists(py_script) and \
        os.path.exists(py_script + '.exe'):
         py_script += '.exe'
-    if os.path.splitext(rv[0])[1] == '.exe' and os.path.splitext(py_script)[1] == '.exe':
+
+    windows_workaround = (os.path.splitext(rv[0])[1] == '.exe' and
+                          os.path.splitext(py_script)[1] == '.exe')
+    nix_workaround = (os.path.isfile(py_script) and
+                      os.access(py_script, os.X_OK))
+    if windows_workaround or nix_workaround:
         rv.pop(0)
     rv.append(py_script)
     rv.extend(sys.argv[1:])

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -65,16 +65,20 @@ def _get_args_for_reloading():
     """
     rv = [sys.executable]
     py_script = sys.argv[0]
+
     if os.name == 'nt' and not os.path.exists(py_script) and \
        os.path.exists(py_script + '.exe'):
         py_script += '.exe'
 
-    windows_workaround = (os.path.splitext(rv[0])[1] == '.exe' and
-                          os.path.splitext(py_script)[1] == '.exe')
-    nix_workaround = (os.path.isfile(py_script) and
-                      os.access(py_script, os.X_OK))
+    windows_workaround = (
+        os.path.splitext(rv[0])[1] == '.exe'
+        and os.path.splitext(py_script)[1] == '.exe'
+    )
+    nix_workaround = os.path.isfile(py_script) and os.access(py_script, os.X_OK)
+
     if windows_workaround or nix_workaround:
         rv.pop(0)
+
     rv.append(py_script)
     rv.extend(sys.argv[1:])
     return rv


### PR DESCRIPTION
Sometimes, the file in `sys.argv[0]` may use an interpreter
other than python.  For example; NixOs replaces `sys.argv[0]` to a
wrapper shell script which changes the environment variables before
running the main entrypoint.

Currently, the reloader assumes that all scripts need the python
interpreter appended their command line.  This patch changes that to
check if the script is set as executable, and does not use the
python command if it is.