### PR TITLE
Allow failures for Python Nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
       language: generic
       env: TOXENV=py
   allow_failures:
+    - python: nightly
+      env: TOXENV=py
     - os: osx
       language: generic
       env: TOXENV=py


### PR DESCRIPTION
Flask allows failure for nightly. I think werkzeug can do that too.

This is just a typo fix PR: https://github.com/pallets/werkzeug/pull/1247. But it fails on Python Nightly.