### PR TITLE
Add translation of werkzeug

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 Werkzeug
 ========
 
+*werkzeug* German noun: "tool". Etymology: *werk* ("work"), *zeug* ("stuff")
+
+
 Werkzeug is a comprehensive `WSGI`_ web application library. It began as
 a simple collection of various utilities for WSGI applications and has
 become one of the most advanced WSGI utility libraries.


### PR DESCRIPTION
I couldn't find any reference to the translation in the docs. The etymology is interesting, and knowing the German translation might help solidify the use of this project for non-German speakers.  