### PR TITLE
fix IterO.seek on newly created IterO object

### DIFF
--- a/tests/contrib/test_iterio.py
+++ b/tests/contrib/test_iterio.py
@@ -18,6 +18,7 @@ class TestIterO(object):
 
     def test_basic_native(self):
         io = IterIO(["Hello", "World", "1", "2", "3"])
+        io.seek(0)
         assert io.tell() == 0
         assert io.read(2) == "He"
         assert io.tell() == 2

--- a/werkzeug/contrib/iterio.py
+++ b/werkzeug/contrib/iterio.py
@@ -258,7 +258,7 @@ class IterO(IterIO):
             raise IOError('Invalid argument')
         buf = []
         try:
-            tmp_end_pos = len(self._buf)
+            tmp_end_pos = len(self._buf or '')
             while pos > tmp_end_pos:
                 item = next(self._gen)
                 tmp_end_pos += len(item)


### PR DESCRIPTION
Without the patch `seek(0)` raises `TypeError` on just created `IterO` object.

```python
tests/contrib/test_iterio.py F

============================================================================================================= FAILURES =============================================================================================================
___________________________________________________________________________________________________ TestIterO.test_basic_native ____________________________________________________________________________________________________

self = <tests.contrib.test_iterio.TestIterO object at 0x109fd1190>

    def test_basic_native(self):
        io = IterIO(["Hello", "World", "1", "2", "3"])
>       io.seek(0)

tests/contrib/test_iterio.py:21:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <werkzeug.contrib.iterio.IterO object at 0x109fd16d0>, pos = 0, mode = 0

    def seek(self, pos, mode=0):
        if self.closed:
            raise ValueError('I/O operation on closed file')
        if mode == 1:
            pos += self.pos
        elif mode == 2:
            self.read()
            self.pos = min(self.pos, self.pos + pos)
            return
        elif mode != 0:
            raise IOError('Invalid argument')
        buf = []
        try:
>           tmp_end_pos = len(self._buf)
E           TypeError: object of type 'NoneType' has no len()

werkzeug/contrib/iterio.py:261: TypeError
```