### PR TITLE
ClosingIterator closes iterable passed to it and not the iterator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,10 @@ Unreleased
     input. (`#1318`_)
 -   The dev server can bind to a Unix socket by passing a hostname like
     ``unix://app.socket``. (`#209`_, `#1019`_)
+-   :class:`~wsgi.ClosingIterator` calls ``close`` on the wrapped
+    *iterable*, not the internal iterator. This doesn't affect objects
+    where ``__iter__`` returned ``self``. For other objects, the method
+    was not called before. (`#1259`_, `#1260`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -77,6 +81,8 @@ Unreleased
 .. _`#1245`: https://github.com/pallets/werkzeug/pull/1245
 .. _`#1252`: https://github.com/pallets/werkzeug/pull/1252
 .. _`#1255`: https://github.com/pallets/werkzeug/pull/1255
+.. _`#1259`: https://github.com/pallets/werkzeug/pull/1259
+.. _`#1260`: https://github.com/pallets/werkzeug/pull/1260
 .. _`#1281`: https://github.com/pallets/werkzeug/pull/1281
 .. _`#1282`: https://github.com/pallets/werkzeug/pull/1282
 .. _`#1283`: https://github.com/pallets/werkzeug/issues/1283

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -841,9 +841,10 @@ class DispatcherMiddleware(object):
 class ClosingIterator(object):
 
     """The WSGI specification requires that all middlewares and gateways
-    respect the `close` callback of an iterator.  Because it is useful to add
-    another close action to a returned iterator and adding a custom iterator
-    is a boring task this class can be used for that::
+    respect the `close` callback of the iterable returned by the application.
+    Because it is useful to add another close action to a returned iterable
+    and adding a custom iterable is a boring task this class can be used for
+    that::
 
         return ClosingIterator(app(environ, start_response), [cleanup_session,
                                                               cleanup_locals])
@@ -869,7 +870,7 @@ class ClosingIterator(object):
             callbacks = [callbacks]
         else:
             callbacks = list(callbacks)
-        iterable_close = getattr(iterator, 'close', None)
+        iterable_close = getattr(iterable, 'close', None)
         if iterable_close:
             callbacks.insert(0, iterable_close)
         self._callbacks = callbacks


### PR DESCRIPTION
This fixes #1259.

According to [wsgi specification](https://www.python.org/dev/peps/pep-3333):

> If the iterable returned by the application has a close() method, the
> server or gateway must call that method upon completion of the current
> request

This commit adds test for this and fixes the issue.