### PR TITLE
Update datastructure.py

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -546,7 +546,7 @@ class MultiDict(TypeConversionDict):
                 yield key, values[0]
 
     def lists(self):
-        """Return a list of ``(key, values)`` pairs, where values is the list
+        """Return a iterator of ``(key, values)`` pairs, where values is the list
         of all values associated with the key."""
 
         for key, values in iteritems(dict, self):


### PR DESCRIPTION
I think `MultiDict.lists()`'s docstring contain a mistake, origin it say "Return a list of ``(key, values)`` pairs", but not true, and not consistent with `.values()`, `listvalues()`