### PR TITLE
Make rename exception-handling code py3-compatible

### DIFF
--- a/werkzeug/posixemulation.py
+++ b/werkzeug/posixemulation.py
@@ -94,7 +94,7 @@ if os.name == 'nt':  # pragma: no cover
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-            old = "%s-%08x" % (dst, random.randint(0, sys.maxint))
+            old = "%s-%08x" % (dst, random.randint(0, sys.maxsize))
             os.rename(dst, old)
             os.rename(src, dst)
             try:


### PR DESCRIPTION
sys.maxint doesn't exist in py3, but sys.maxnum will have desired functionality in both py2/py3

Similar to solution implemented here: https://github.com/pallets/werkzeug/commit/0bad0c25f7d04da98328907d1c94a9b72fe57c57#diff-5561c422f09af0c38ec8260f0d17a52dR280

Issue encountered here: https://github.com/sh4nks/flask-caching/issues/53