### PR TITLE
Fix stylecheck problem encountered by Travis build

### DIFF
--- a/bench/wzbench.py
+++ b/bench/wzbench.py
@@ -461,4 +461,4 @@ if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
-        print('\nInterrupted!', file = sys.stderr)
+        print('\nInterrupted!', file=sys.stderr)


### PR DESCRIPTION
Due to commit https://github.com/pallets/werkzeug/commit/c4b4c52e1d9acbb1bee5b86093eba082fb250c68 the Travis stylecheck build has been failing with the following:

```python
stylecheck runtests: commands[0] | flake8
./bench/wzbench.py:464:37: E251 unexpected spaces around keyword / parameter equals
./bench/wzbench.py:464:39: E251 unexpected spaces around keyword / parameter equals
ERROR: InvocationError for command '/home/travis/build/pallets/werkzeug/.tox/stylecheck/bin/flake8' (exited with code 1)
```