### PR TITLE
Fix empty iterable with delayed start_response error in test client

### DIFF
--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -938,8 +938,10 @@ def run_wsgi_app(app, environ, buffered=False):
     # a new `ClosingIterator` if we need to restore a `close` callable from the
     # original return value.
     else:
-        while not response:
-            buffer.append(next(app_iter))
+        for item in app_iter:
+            buffer.append(item)
+            if response:
+                break
         if buffer:
             app_iter = chain(buffer, app_iter)
         if close_func is not None and app_iter is not app_rv:


### PR DESCRIPTION
According to the WSGI spec[1], it is a valid case to both:

a) lazily call `start_response` in request processing

> this invocation may be performed by the iterable’s first iteration, so servers must not assume that start_response() has been called before they begin iterating over the iterable

b) return an empty iterator (e.g. in the case of a 204 No Content)

> When called by the server, the application object must return an iterable yielding zero or more strings.

When both of these were true, previously, Werkzeug's test client would propagate a `StopIteration` exception from the WSGI app's returned iterable. Since this is a valid case, we now catch the `StopIteration` exception if `start_response` has _also_ been called. If `start_response` has not been called we re-raise, as this is not a valid case under the WSGI spec, and as mentioned in the docstring of this function...

> If passed an invalid WSGI application the behavior of this function is undefined.

[1]: https://www.python.org/dev/peps/pep-0333/#specification-details

Please note that the above detail is in the commit message as well.

Thanks to @prophile for his help in debugging this and helping to find a good test case.