### PR TITLE
Modernize security module, remove _find_hashlib_algorithms.

### DIFF
--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -134,13 +134,3 @@ def test_pbkdf2():
           '139c30c0966bc32ba55fdbf212530ac9c5ec59f1a452f5cc9ad940fea0598ed1')
     check('X' * 65, 'pass phrase exceeds block size', 1200, 32, 'sha1',
           '9ccad6d468770cd51b10e6a68721be611a8b4d282601db3b36be9246915ec82a')
-
-
-def test_pbkdf2_non_native():
-    import werkzeug.security as sec
-    prev_value = sec._has_native_pbkdf2
-    sec._has_native_pbkdf2 = None
-
-    assert pbkdf2_hex('password', 'salt', 1, 20, 'sha1') \
-        == '0c60c80f961f0e71f3a9b524af6012062fe037a6'
-    sec._has_native_pbkdf2 = prev_value

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -50,7 +50,7 @@ def test_password_hashing():
     assert hash1.startswith('sha1$')
     assert hash2.startswith('sha1$')
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         check_password_hash('$made$up$', 'default')
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
Cleanup the code via https://github.com/pallets/werkzeug/pull/1226#issuecomment-354356625

Here is a breaking change `_hash_internal`, it once raised `TypeError` when hash func was invalid. However, the default behavior of `hashlib.new` or `hmac.HMAC` is raising `ValueError`. You can find the breaking change in test case.