### PR TITLE
Eliminate `//` in paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ Unreleased
 -   The ``429 TooManyRequests`` and ``503 ServiceUnavailable`` HTTP
     exceptions takes a ``retry_after`` parameter to set the
     ``Retry-After`` header. :issue:`1657`
+-   ``Map`` and ``Rule`` have a ``merge_slashes`` option to collapse
+    multiple slashes into one, similar to how many HTTP servers behave.
+    :pr:`1286`
 
 
 Version 0.16.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,7 +80,7 @@ Unreleased
     ``Retry-After`` header. :issue:`1657`
 -   ``Map`` and ``Rule`` have a ``merge_slashes`` option to collapse
     multiple slashes into one, similar to how many HTTP servers behave.
-    :pr:`1286`
+    This is enabled by default. :pr:`1286`
 
 
 Version 0.16.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "pallets_sphinx_themes",
     "sphinx_issues",
+    "sphinxcontrib.log_cabinet",
 ]
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 issues_github_path = "pallets/werkzeug"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx~=1.8.3
 Pallets-Sphinx-Themes~=1.1.2
 sphinx-issues~=1.2.0
+sphinxcontrib-log-cabinet~=1.0.1

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -70,24 +70,30 @@ exceptions have a look at the documentation of the :meth:`MapAdapter.match` meth
 Rule Format
 ===========
 
-Rule strings basically are just normal URL paths with placeholders in the
-format ``<converter(arguments):name>``, where converter and the arguments
-are optional.  If no converter is defined, the `default` converter is used
-(which means `string` in the normal configuration).
+Rule strings are URL paths with placeholders for variable parts in the
+format ``<converter(arguments):name>``. ``converter`` and ``arguments``
+(with parentheses) are optional. If no converter is given, the
+``default`` converter is used (``string`` by default). The available
+converters are discussed below.
 
-URL rules that end with a slash are branch URLs, others are leaves.  If you
-have `strict_slashes` enabled (which is the default), all branch URLs that are
-visited without a trailing slash will trigger a redirect to the same URL with
-that slash appended.
+Rules that end with a slash are "branches", others are "leaves". If
+``strict_slashes`` is enabled (the default), visiting a branch URL
+without a trailing slash will redirect to the URL with a slash appended.
 
-The list of converters can be extended, the default converters are explained
-below.
+Many HTTP servers merge consecutive slashes into one when receiving
+requests. If ``merge_slashes`` is enabled (the default), rules will
+merge slashes in non-variable parts when matching and building. Visiting
+a URL with consecutive slashes will redirect to the URL with slashes
+merged. If you want to disable ``merge_slashes`` for a :class:`Rule` or
+:class:`Map`, you'll also need to configure your web server
+appropriately.
 
 
-Builtin Converters
-==================
+Built-in Converters
+===================
 
-Here a list of converters that come with Werkzeug:
+Converters for common types of URL variables are built-in. The available
+converters can be overridden or extended through :attr:`Map.converters`.
 
 .. autoclass:: UnicodeConverter
 

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -588,9 +588,9 @@ class Rule(RuleFactory):
         not specified the `Map` setting is used.
 
     `merge_slashes`
-        Override the `Map` setting for `merge_slashes` for this rule.
+        Override the ``Map`` setting for ``merge_slashes`` for this rule.
 
-        .. versionadded:: 0.15
+        .. versionadded:: 1.0
 
     `build_only`
         Set this to True and the rule will never match but will create a URL
@@ -1337,8 +1337,11 @@ class Map(object):
     :param default_subdomain: The default subdomain for rules without a
                               subdomain defined.
     :param charset: charset of the url. defaults to ``"utf-8"``
-    :param strict_slashes: Take care of trailing slashes.
-    :param merge_slashes: Take care of repeated slashes.
+    :param strict_slashes: If a rule ends with a slash but the matched
+        URL does not, redirect to the URL with a trailing slash.
+    :param merge_slashes: Merge consecutive slashes when matching or
+        building URLs. Matches will redirect to the normalized URL.
+        Slashes in variable parts are not merged.
     :param redirect_defaults: This will redirect to the default rule if it
                               wasn't visited that way. This helps creating
                               unique URLs.
@@ -1354,14 +1357,14 @@ class Map(object):
                           enabled the `host` parameter to rules is used
                           instead of the `subdomain` one.
 
-    .. versionadded:: 0.5
-        `sort_parameters` and `sort_key` was added.
-
-    .. versionadded:: 0.7
-        `encoding_errors` and `host_matching` was added.
-
-    .. versionadded:: 1.0.0
+    .. versionchanged:: 1.0
         Added ``merge_slashes``.
+
+    .. versionchanged:: 0.7
+        Added ``encoding_errors`` and ``host_matching``.
+
+    .. versionchanged:: 0.5
+        Added ``sort_parameters`` and ``sort_key``.
     """
 
     #: A dict of default converters to be used.

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -787,7 +787,7 @@ class Rule(RuleFactory):
                                 regex_parts.append(r"/+?")
                                 self._trace.append((False, "/"))
                             else:
-                                regex.parts.append(part)
+                                regex_parts.append(part)
                                 self._trace.append((False, part))
                             continue
                         self._trace.append((False, part))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -85,9 +85,10 @@ def test_multi_slash():
 
     ep, rv = adapter.match("/quux/http://splud/")
     assert rv["slub"] == "http://splud/"
+    ep, rv = adapter.match("/quux/x//splud/")
+    assert rv["slub"] == "x//splud/"
 
-    with pytest.warns(r.InvalidURLWarning):
-        map = r.Map([r.Rule("/frob//zarf", endpoint="blorwoop")])
+    map = r.Map([r.Rule("/frob//zarf", endpoint="blorwoop")])
     adapter = map.bind("localhost", "/")
     assert adapter.build("blorwoop") == "/frob/zarf"
 


### PR DESCRIPTION
Incoming paths are redirected to remove repeated slashes upon matching. Rules containing repeated slashes collapse them to just one and send a warning.

I haven't included a way to turn this off; do people have reasons to?

closes #1132 