### PR TITLE
Use 302 instead of 301 for request redirect

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -267,7 +267,7 @@ def test_dispatch():
     )
 
     assert dispatch('/').data == b"('root', {})"
-    assert dispatch('/foo').status_code == 301
+    assert dispatch('/foo').status_code == 302
     raise_this = r.NotFound()
     pytest.raises(r.NotFound, lambda: dispatch('/bar'))
     assert dispatch('/bar', True).status_code == 404

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -227,7 +227,7 @@ class RequestRedirect(HTTPException, RoutingException):
 
     The attribute `new_url` contains the absolute destination url.
     """
-    code = 301
+    code = 302
 
     def __init__(self, new_url):
         RoutingException.__init__(self, new_url)


### PR DESCRIPTION
In version 0.1, this behavior is using `302`. It started to use 301 since version 0.2. I find it a really serious problem, since 301 is cached by chrome and firefox for a permanent time, maybe there are other browsers.