### PR TITLE
Skip tests that use 'xprocess' fixture when not installed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,12 +27,8 @@ try:
     __import__('pytest_xprocess')
 except ImportError:
     @pytest.fixture(scope='session')
-    def subprocess():
+    def xprocess():
         pytest.skip('pytest-xprocess not installed.')
-else:
-    @pytest.fixture(scope='session')
-    def subprocess(xprocess):
-        return xprocess
 
 
 port_generator = count(13220)
@@ -117,7 +113,7 @@ class _ServerInfo(object):
 
 
 @pytest.fixture
-def dev_server(tmpdir, subprocess, request, monkeypatch):
+def dev_server(tmpdir, xprocess, request, monkeypatch):
     '''Run werkzeug.serving.run_simple in its own process.
 
     :param application: String for the module that will be created. The module
@@ -144,7 +140,7 @@ def dev_server(tmpdir, subprocess, request, monkeypatch):
             url_base = 'http://localhost:{0}'.format(port)
 
         info = _ServerInfo(
-            subprocess,
+            xprocess,
             'localhost:{0}'.format(port),
             url_base,
             port
@@ -154,7 +150,7 @@ def dev_server(tmpdir, subprocess, request, monkeypatch):
             args = [sys.executable, __file__, str(tmpdir)]
             return lambda: 'pid=%s' % info.request_pid(), args
 
-        subprocess.ensure('dev_server', preparefunc, restart=True)
+        xprocess.ensure('dev_server', preparefunc, restart=True)
 
         def teardown():
             # Killing the process group that runs the server, not just the

--- a/tests/contrib/cache/test_cache.py
+++ b/tests/contrib/cache/test_cache.py
@@ -219,7 +219,7 @@ class TestRedisCache(GenericCacheTests):
     _can_use_fast_sleep = False
 
     @pytest.fixture(scope='class', autouse=True)
-    def requirements(self, subprocess):
+    def requirements(self, xprocess):
         if redis is None:
             pytest.skip('Python package "redis" is not installed.')
 
@@ -227,7 +227,7 @@ class TestRedisCache(GenericCacheTests):
             return '[Rr]eady to accept connections', ['redis-server']
 
         try:
-            subprocess.ensure('redis_server', prepare)
+            xprocess.ensure('redis_server', prepare)
         except IOError as e:
             # xprocess raises FileNotFoundError
             if e.errno == errno.ENOENT:
@@ -236,7 +236,7 @@ class TestRedisCache(GenericCacheTests):
                 raise
 
         yield
-        subprocess.getinfo('redis_server').terminate()
+        xprocess.getinfo('redis_server').terminate()
 
     @pytest.fixture(params=(None, False, True))
     def make_cache(self, request):
@@ -271,7 +271,7 @@ class TestMemcachedCache(GenericCacheTests):
     _guaranteed_deletes = False
 
     @pytest.fixture(scope='class', autouse=True)
-    def requirements(self, subprocess):
+    def requirements(self, xprocess):
         if memcache is None:
             pytest.skip(
                 'Python package for memcache is not installed. Need one of '
@@ -282,7 +282,7 @@ class TestMemcachedCache(GenericCacheTests):
             return '', ['memcached']
 
         try:
-            subprocess.ensure('memcached', prepare)
+            xprocess.ensure('memcached', prepare)
         except IOError as e:
             # xprocess raises FileNotFoundError
             if e.errno == errno.ENOENT:
@@ -291,7 +291,7 @@ class TestMemcachedCache(GenericCacheTests):
                 raise
 
         yield
-        subprocess.getinfo('memcached').terminate()
+        xprocess.getinfo('memcached').terminate()
 
     @pytest.fixture
     def make_cache(self):


### PR DESCRIPTION
There's already a little trick to skip tests that use a fixture
called 'subprocess' when pytest-xprocess is not installed, but
many tests use the 'xprocess' fixture directly, and all of those
will still just fail. This just defines a dummy 'xprocess'
fixture as well as the dummy 'subprocess' fixture when xprocess
is not installed, so those tests as well will be skipped instead
of failing.

I noticed this when trying to run the test suite during build
of the Fedora package - xprocess isn't packaged for Fedora yet,
so there's no way to run the tests that use it unfortunately.

Signed-off-by: Adam Williamson <awilliam@redhat.com>