### PR TITLE
Never send Content-Length for 204

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1173,6 +1173,19 @@ def test_204_and_1XX_response_has_no_content_length():
     assert 'Content-Length' not in headers
 
 
+def test_malformed_204_response_has_no_content_length():
+    # flask-restful can generate a malformed response when doing `return '', 204`
+    response = wrappers.Response(status=204)
+    response.set_data(b'test')
+    assert response.content_length == 4
+
+    env = create_environ()
+    app_iter, status, headers = response.get_wsgi_response(env)
+    assert status == '204 NO CONTENT'
+    assert 'Content-Length' not in headers
+    assert b''.join(app_iter) == b''  # ensure data will not be sent
+
+
 def test_modified_url_encoding():
     class ModifiedRequest(wrappers.Request):
         url_charset = 'euc-kr'

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -1247,7 +1247,11 @@ class BaseResponse(object):
            isinstance(content_location, text_type):
             headers['Content-Location'] = iri_to_uri(content_location)
 
-        if status in (304, 412):
+        if 100 <= status < 200 or status == 204:
+            # Per section 3.3.2 of RFC 7230, "a server MUST NOT send a Content-Length header field
+            # in any response with a status code of 1xx (Informational) or 204 (No Content)."
+            headers.remove('Content-Length')
+        elif status in (304, 412):
             remove_entity_headers(headers)
 
         # if we can determine the content length automatically, we


### PR DESCRIPTION
With flask-restful, it's easy to make a malformed response by doing `return '', 204` or `return None, 204`. It might be idiomatic, but it would result in a 204 response with a non-empty body (containing a JSON payload such as `''` or `null`).

We used to reset the Content-Length to 0 for status code 204, but since 1c70c3e1855d32a285843c0851f52e20160f6656 we keep `Content-Length: N` while the body is eliminated (see `BaseResponse.get_app_iter`). This broke existing flask-restful applications:
https://github.com/flask-restful/flask-restful/issues/736

Per section 3.3.2 of RFC 7230,  "a server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content)". This change enforces it in `get_wsgi_headers`.