### PR TITLE
GH #1234 - Ignore empty cookie keys

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -396,6 +396,18 @@ class TestHTTPUtility(object):
             }
         )
 
+    def test_empty_keys_are_ignored(self):
+        strict_eq(
+            dict(http.parse_cookie(
+                'first=IamTheFirst ; a=1; a=2 ;second=andMeTwo; ; '
+            )),
+            {
+                'first': u'IamTheFirst',
+                'a': u'2',
+                'second': u'andMeTwo'
+            }
+        )
+
     def test_cookie_quoting(self):
         val = http.dump_cookie("foo", "?foo")
         strict_eq(val, 'foo="?foo"; Path=/')

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -999,11 +999,12 @@ def parse_cookie(header, charset='utf-8', errors='replace', cls=None):
     def _parse_pairs():
         for key, val in _cookie_parse_impl(header):
             key = to_unicode(key, charset, errors, allow_none_charset=True)
+            if not key:
+                continue
             val = to_unicode(val, charset, errors, allow_none_charset=True)
             yield try_coerce_native(key), val
 
     return cls(_parse_pairs())
-
 
 def dump_cookie(key, value='', max_age=None, expires=None, path='/',
                 domain=None, secure=False, httponly=False,


### PR DESCRIPTION
Without this check for the 'key' variable, there is an empty key in the resulting dictionary, e.g:

`{
    'first': u'IamTheFirst',
    'a': u'2',
    'second': u'andMeTwo',
    '': ''
}`