### PR TITLE
Ignore empty cookie keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,19 +26,23 @@ Release Date not Decided
     a :class:`~datastructures.MultiDict` to represent multiple values
     for a key. It already did this when passing a dict with a list
     value. (`#724`_)
--   :meth:`wsgi.get_host` no longer looks at ``X-Forwarded-For``. Use
+-   :func:`wsgi.get_host` no longer looks at ``X-Forwarded-For``. Use
     :class:`~fixers.ProxyFix` to handle that. (`#609`_, `#1303`_)
 -   :class:`~fixers.ProxyFix` handles the ``X-Forwarded-Port`` header
     set by some proxies. (`#1023`_, `#1304`_)
+-   :func:`http.parse_cookie` ignores empty segments rather than
+    producing a cookie with no key or value. (`#1245`_, `#1301`_)
 
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
 .. _`#724`: https://github.com/pallets/werkzeug/pull/724
 .. _`#1023`: https://github.com/pallets/werkzeug/issues/1023
 .. _`#1231`: https://github.com/pallets/werkzeug/issues/1231
 .. _`#1233`: https://github.com/pallets/werkzeug/pull/1233
+.. _`#1245`: https://github.com/pallets/werkzeug/pull/1245
 .. _`#1252`: https://github.com/pallets/werkzeug/pull/1252
 .. _`#1255`: https://github.com/pallets/werkzeug/pull/1255
 .. _`#1282`: https://github.com/pallets/werkzeug/pull/1282
+.. _`#1301`: https://github.com/pallets/werkzeug/pull/1301
 .. _`#1303`: https://github.com/pallets/werkzeug/pull/1303
 .. _`#1304`: https://github.com/pallets/werkzeug/pull/1304
 .. _`#1308`: https://github.com/pallets/werkzeug/pull/1308

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -396,6 +396,18 @@ class TestHTTPUtility(object):
             }
         )
 
+    def test_empty_keys_are_ignored(self):
+        strict_eq(
+            dict(http.parse_cookie(
+                'first=IamTheFirst ; a=1; a=2 ;second=andMeTwo; ; '
+            )),
+            {
+                'first': u'IamTheFirst',
+                'a': u'2',
+                'second': u'andMeTwo'
+            }
+        )
+
     def test_cookie_quoting(self):
         val = http.dump_cookie("foo", "?foo")
         strict_eq(val, 'foo="?foo"; Path=/')

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -999,6 +999,8 @@ def parse_cookie(header, charset='utf-8', errors='replace', cls=None):
     def _parse_pairs():
         for key, val in _cookie_parse_impl(header):
             key = to_unicode(key, charset, errors, allow_none_charset=True)
+            if not key:
+                continue
             val = to_unicode(val, charset, errors, allow_none_charset=True)
             yield try_coerce_native(key), val
 


### PR DESCRIPTION
Without this check for the 'key' variable, there is an empty key in the resulting dictionary, e.g:

```
{ 
   'first': u'IamTheFirst', 
   'a': u'2', 
   'second': u'andMeTwo', 
   '': '' 
}
```

closes #1245 