### PR TITLE
Read X-Forwarded-Port in ProxyFix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,13 +26,21 @@ Release Date not Decided
     a :class:`~datastructures.MultiDict` to represent multiple values
     for a key. It already did this when passing a dict with a list
     value. (`#724`_)
+-   :meth:`wsgi.get_host` no longer looks at ``X-Forwarded-For``. Use
+    :class:`~fixers.ProxyFix` to handle that. (`#609`_, `#1303`_)
+-   :class:`~fixers.ProxyFix` handles the ``X-Forwarded-Port`` header
+    set by some proxies. (`#1023`_, `#1304`_)
 
+.. _`#609`: https://github.com/pallets/werkzeug/pull/609
 .. _`#724`: https://github.com/pallets/werkzeug/pull/724
+.. _`#1023`: https://github.com/pallets/werkzeug/issues/1023
 .. _`#1231`: https://github.com/pallets/werkzeug/issues/1231
 .. _`#1233`: https://github.com/pallets/werkzeug/pull/1233
 .. _`#1252`: https://github.com/pallets/werkzeug/pull/1252
 .. _`#1255`: https://github.com/pallets/werkzeug/pull/1255
 .. _`#1282`: https://github.com/pallets/werkzeug/pull/1282
+.. _`#1303`: https://github.com/pallets/werkzeug/pull/1303
+.. _`#1304`: https://github.com/pallets/werkzeug/pull/1304
 .. _`#1308`: https://github.com/pallets/werkzeug/pull/1308
 
 

--- a/werkzeug/contrib/fixers.py
+++ b/werkzeug/contrib/fixers.py
@@ -138,9 +138,10 @@ class ProxyFix(object):
         forwarded_host = getter('HTTP_X_FORWARDED_HOST', '')
         forwarded_port = getter('HTTP_X_FORWARDED_PORT', '')
         environ.update({
-            'werkzeug.proxy_fix.orig_wsgi_url_scheme':  getter('wsgi.url_scheme'),
-            'werkzeug.proxy_fix.orig_remote_addr':      getter('REMOTE_ADDR'),
-            'werkzeug.proxy_fix.orig_http_host':        getter('HTTP_HOST')
+            'werkzeug.proxy_fix.orig_wsgi_url_scheme': getter('wsgi.url_scheme'),
+            'werkzeug.proxy_fix.orig_remote_addr': getter('REMOTE_ADDR'),
+            'werkzeug.proxy_fix.orig_http_host': getter('HTTP_HOST'),
+            'werkzeug.proxy_fix.orig_server_port': getter('SERVER_PORT'),
         })
         forwarded_for = [x for x in [x.strip() for x in forwarded_for] if x]
         remote_addr = self.get_remote_addr(forwarded_for)

--- a/werkzeug/contrib/fixers.py
+++ b/werkzeug/contrib/fixers.py
@@ -136,6 +136,7 @@ class ProxyFix(object):
         forwarded_proto = getter('HTTP_X_FORWARDED_PROTO', '')
         forwarded_for = getter('HTTP_X_FORWARDED_FOR', '').split(',')
         forwarded_host = getter('HTTP_X_FORWARDED_HOST', '')
+        forwarded_port = getter('HTTP_X_FORWARDED_PORT', '')
         environ.update({
             'werkzeug.proxy_fix.orig_wsgi_url_scheme':  getter('wsgi.url_scheme'),
             'werkzeug.proxy_fix.orig_remote_addr':      getter('REMOTE_ADDR'),
@@ -147,6 +148,15 @@ class ProxyFix(object):
             environ['REMOTE_ADDR'] = remote_addr
         if forwarded_host:
             environ['HTTP_HOST'] = forwarded_host
+        if forwarded_port:
+            if environ.get('HTTP_HOST'):
+                parts = environ['HTTP_HOST'].split(':', 1)
+                if len(parts) == 2:
+                    environ['HTTP_HOST'] = parts[0] + ':' + forwarded_port
+                else:
+                    environ['HTTP_HOST'] += ':' + forwarded_port
+            else:
+                environ['SERVER_PORT'] = forwarded_port
         if forwarded_proto:
             environ['wsgi.url_scheme'] = forwarded_proto
         return self.app(environ, start_response)


### PR DESCRIPTION
Ref #1023.

Should work also when `Host` or `X-Forwarded-Host` contain port information - in those cases, `X-Forwarded-Port` (if given) will override the port.

NOTE: Currently this contains commits of #1303, which should be first merged.