### PR TITLE
Don't include CONTENT_TYPE/CONTENT_LENGTH in environ if absent in headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
+.. currentmodule:: werkzeug
+
 Werkzeug Changelog
 ==================
+
 
 Version 0.15
 ------------
@@ -11,9 +14,15 @@ Release Date not Decided
 - Add 412 status code.
 - Cleanup ``werkzeug.security`` module, remove predated hashlib support.
   (`#1282`_)
+-   :class:`~test.EnvironBuilder` doesn't set ``CONTENT_TYPE`` or
+    ``CONTENT_LENGTH`` in the environ if they aren't set. Previously
+    these used default values if they weren't set. Now it's possible to
+    distinguish between empty and unset values. (`#1308`_)
 
 .. _`#1252`: https://github.com/pallets/werkzeug/pull/1252
 .. _`#1282`: https://github.com/pallets/werkzeug/pull/1282
+.. _`#1308`: https://github.com/pallets/werkzeug/pull/1308
+
 
 Version 0.14.1
 --------------

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -120,8 +120,6 @@ class TestFormParser(object):
         # defining the media type of that body."  In the case where either
         # headers are omitted, parse_form_data should still work.
         env = create_environ('/foo', 'http://example.org/', method='PUT')
-        del env['CONTENT_TYPE']
-        del env['CONTENT_LENGTH']
 
         stream, form, files = formparser.parse_form_data(env)
         strict_eq(stream.read(), b'')
@@ -130,8 +128,6 @@ class TestFormParser(object):
 
     def test_parse_form_data_get_without_content(self):
         env = create_environ('/foo', 'http://example.org/', method='GET')
-        del env['CONTENT_TYPE']
-        del env['CONTENT_LENGTH']
 
         stream, form, files = formparser.parse_form_data(env)
         strict_eq(stream.read(), b'')

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -264,7 +264,7 @@ def test_windows_get_args_for_reloading(monkeypatch, tmpdir):
     assert rv == [test_exe.strpath, 'run']
 
 
-def test_monkeypached_sleep(tmpdir):
+def test_monkeypatched_sleep(tmpdir):
     # removing the staticmethod wrapper in the definition of
     # ReloaderLoop._sleep works most of the time, since `sleep` is a c
     # function, and unlike python functions which are descriptors, doesn't

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -207,6 +207,9 @@ def test_environ_builder_headers_content_type():
                        headers={'Content-Type': 'text/plain'})
     env = b.get_environ()
     assert env['CONTENT_TYPE'] == 'text/html'
+    b = EnvironBuilder()
+    env = b.get_environ()
+    assert 'CONTENT_TYPE' not in env
 
 
 def test_environ_builder_paths():
@@ -311,8 +314,6 @@ def test_create_environ():
         'wsgi.multithread':     False,
         'wsgi.url_scheme':      'http',
         'SCRIPT_NAME':          '',
-        'CONTENT_TYPE':         '',
-        'CONTENT_LENGTH':       '0',
         'SERVER_NAME':          'example.org',
         'REQUEST_METHOD':       'GET',
         'HTTP_HOST':            'example.org',

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -614,8 +614,6 @@ class EnvironBuilder(object):
             'SERVER_PORT':          str(self.server_port),
             'HTTP_HOST':            self.host,
             'SERVER_PROTOCOL':      self.server_protocol,
-            'CONTENT_TYPE':         content_type or '',
-            'CONTENT_LENGTH':       str(content_length or '0'),
             'wsgi.version':         self.wsgi_version,
             'wsgi.url_scheme':      self.url_scheme,
             'wsgi.input':           input_stream,
@@ -624,6 +622,15 @@ class EnvironBuilder(object):
             'wsgi.multiprocess':    self.multiprocess,
             'wsgi.run_once':        self.run_once
         })
+        if content_type:
+            result.update({
+                'CONTENT_TYPE': content_type,
+            })
+        if content_length:
+            result.update({
+                'CONTENT_LENGTH': str(content_length),
+            })
+
         for key, value in self.headers.to_wsgi_list():
             result['HTTP_%s' % key.upper().replace('-', '_')] = value
         if self.environ_overrides:

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -622,14 +622,10 @@ class EnvironBuilder(object):
             'wsgi.multiprocess':    self.multiprocess,
             'wsgi.run_once':        self.run_once
         })
-        if content_type:
-            result.update({
-                'CONTENT_TYPE': content_type,
-            })
-        if content_length:
-            result.update({
-                'CONTENT_LENGTH': str(content_length),
-            })
+        if content_type is not None:
+            result['CONTENT_TYPE'] = content_type
+        if content_length is not None:
+            result['CONTENT_LENGTH'] = str(content_length)
 
         for key, value in self.headers.to_wsgi_list():
             result['HTTP_%s' % key.upper().replace('-', '_')] = value


### PR DESCRIPTION
This has been reported earlier in #1049 and #1159, but closed since it's valid behavior according to the WSGI spec. It is however inconsistent with how most of the wsgi servers handle it.

With the following test application I tested this for gunicorn, gevent, twisted and uwsgi:
```python
# test_app.py
from werkzeug.wrappers import Response

def application(environ, start_response):
    content_type = environ.get('CONTENT_TYPE')
    response = Response(repr(content_type) + '\n')
    return response(environ, start_response)
```

| Test case | Outcome |
|-------------------|---------|
| `gunicorn test_app` | None    |
| `gevent.WSGIServer.serve_forever()` | None |
| `twistd -n web test_app.application` | '' |
| `uwsgi --http :8000 --wsgi-file test_app.py` | None |

Of the four tested, only Twisted handles the environ the way werkzeug does, the others will experience inconsistencies between their test and production environments.

We had trouble reproducing a production error in test because of this as it's currently non-trivial to test a missing content-type header in flask. If absent by default it's easy to test both absent and empty header values, as you can send an empty string in the headers to get the old behavior.