### PR TITLE
Added support for CSV x-forwarded-proto header in ProxyFix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Release Date not Decided
 -   :class:`~fixers.ProxyFix` handles the ``X-Forwarded-Prefix`` header
     set by some proxies by changing the WSGI environ ``SCRIPT_NAME``.
     (`#1237`_)
+-   :class:`~fixers.ProxyFix` handles chained ``X-Forwarded-Proto``
+    headers. (`#1312`_)
 -   :func:`http.parse_cookie` ignores empty segments rather than
     producing a cookie with no key or value. (`#1245`_, `#1301`_)
 -   Building URLs is ~7x faster. Each :class:`~routing.Rule` compiles
@@ -57,6 +59,7 @@ Release Date not Decided
 .. _`#1303`: https://github.com/pallets/werkzeug/pull/1303
 .. _`#1304`: https://github.com/pallets/werkzeug/pull/1304
 .. _`#1308`: https://github.com/pallets/werkzeug/pull/1308
+.. _`#1312`: https://github.com/pallets/werkzeug/pull/1312
 
 
 Version 0.14.1

--- a/tests/contrib/test_fixers.py
+++ b/tests/contrib/test_fixers.py
@@ -119,6 +119,11 @@ class TestServerFixer(object):
             'HTTP_X_FORWARDED_PORT': '443',
             'HTTP_X_FORWARDED_FOR': '1.2.3.4, 5.6.7.8'
         }, '1.2.3.4', 'https://example.com', id='All together'),
+        pytest.param({
+            'HTTP_HOST': 'internal',
+            'REMOTE_ADDR': '192.168.0.1',
+            'HTTP_X_FORWARDED_PROTO': 'https, http',
+        }, '192.168.0.1', 'https://internal', id='Multiple Proto'),
     ])
     def test_proxy_fix(self, environ, assumed_addr, assumed_host):
         @Request.application

--- a/werkzeug/contrib/fixers.py
+++ b/werkzeug/contrib/fixers.py
@@ -133,7 +133,7 @@ class ProxyFix(object):
 
     def __call__(self, environ, start_response):
         getter = environ.get
-        forwarded_proto = getter('HTTP_X_FORWARDED_PROTO', '')
+        forwarded_proto = getter('HTTP_X_FORWARDED_PROTO', '').split(',')
         forwarded_for = getter('HTTP_X_FORWARDED_FOR', '').split(',')
         forwarded_host = getter('HTTP_X_FORWARDED_HOST', '')
         forwarded_port = getter('HTTP_X_FORWARDED_PORT', '')
@@ -146,6 +146,7 @@ class ProxyFix(object):
             'werkzeug.proxy_fix.orig_script_name': getter('SCRIPT_NAME'),
         })
         forwarded_for = [x for x in [x.strip() for x in forwarded_for] if x]
+        forwarded_proto = [x for x in [x.strip() for x in forwarded_proto] if x]
         remote_addr = self.get_remote_addr(forwarded_for)
         if remote_addr is not None:
             environ['REMOTE_ADDR'] = remote_addr
@@ -161,7 +162,7 @@ class ProxyFix(object):
             else:
                 environ['SERVER_PORT'] = forwarded_port
         if forwarded_proto:
-            environ['wsgi.url_scheme'] = forwarded_proto
+            environ['wsgi.url_scheme'] = forwarded_proto[0]
         if forwarded_prefix:
             environ['SCRIPT_NAME'] = forwarded_prefix
         return self.app(environ, start_response)


### PR DESCRIPTION
It is a common practice to add CSV based  'x-forwarded-proto' headers
An example is node's http-proxy