### PR TITLE
refactor ProxyFix middleware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,13 +7,12 @@ Werkzeug Changelog
 Version 0.15
 ------------
 
-Release Date not Decided
+Unreleased
 
-- Fix a bug in ``werkzeug.wsgi.ProxyMiddleware`` with query string.
-  (`#1252`_)
-- Add 412 status code.
-- Cleanup ``werkzeug.security`` module, remove predated hashlib support.
-  (`#1282`_)
+-   :class:`~werkzeug.wsgi.ProxyMiddleware` proxies the query string.
+    (`#1252`_)
+-   Cleanup ``werkzeug.security`` module, remove predated hashlib
+    support. (`#1282`_)
 -   :class:`~test.EnvironBuilder` doesn't set ``CONTENT_TYPE`` or
     ``CONTENT_LENGTH`` in the environ if they aren't set. Previously
     these used default values if they weren't set. Now it's possible to
@@ -27,14 +26,25 @@ Release Date not Decided
     for a key. It already did this when passing a dict with a list
     value. (`#724`_)
 -   :func:`wsgi.get_host` no longer looks at ``X-Forwarded-For``. Use
-    :class:`~fixers.ProxyFix` to handle that. (`#609`_, `#1303`_)
--   :class:`~fixers.ProxyFix` handles the ``X-Forwarded-Port`` header
-    set by some proxies. (`#1023`_, `#1304`_)
--   :class:`~fixers.ProxyFix` handles the ``X-Forwarded-Prefix`` header
-    set by some proxies by changing the WSGI environ ``SCRIPT_NAME``.
-    (`#1237`_)
--   :class:`~fixers.ProxyFix` handles chained ``X-Forwarded-Proto``
-    headers. (`#1312`_)
+    :class:`~contrib.fixers.ProxyFix` to handle that. (`#609`_,
+    `#1303`_)
+-   :class:`~contrib.fixers.ProxyFix` is refactored to support more
+    headers, multiple values, and more secure configuration.
+
+    -   Each header supports multiple values. The trusted number of
+        proxies is configured separately for each header. The
+        ``num_proxies`` argument is deprecated. (`#1314`_)
+    -   Sets ``SERVER_NAME`` and ``SERVER_PORT`` based on
+        ``X-Forwarded-Host``. (`#1314`_)
+    -   Sets ``SERVER_PORT`` and modifies ``HTTP_HOST`` based on
+        ``X-Forwarded-Port``. (`#1023`_, `#1304`_)
+    -   Sets ``SCRIPT_NAME`` based on ``X-Forwarded-Prefix``. (`#1237`_)
+    -   The original WSGI environment values are stored in the
+        ``werkzeug.proxy_fix.orig`` key, a dict. The individual keys
+        ``werkzeug.proxy_fix.orig_remote_addr``,
+        ``werkzeug.proxy_fix.orig_wsgi_url_scheme``, and
+        ``werkzeug.proxy_fix.orig_http_host`` are deprecated.
+
 -   :func:`http.parse_cookie` ignores empty segments rather than
     producing a cookie with no key or value. (`#1245`_, `#1301`_)
 -   Building URLs is ~7x faster. Each :class:`~routing.Rule` compiles
@@ -60,6 +70,7 @@ Release Date not Decided
 .. _`#1304`: https://github.com/pallets/werkzeug/pull/1304
 .. _`#1308`: https://github.com/pallets/werkzeug/pull/1308
 .. _`#1312`: https://github.com/pallets/werkzeug/pull/1312
+.. _`#1314`: https://github.com/pallets/werkzeug/pull/1314
 
 
 Version 0.14.1

--- a/werkzeug/contrib/fixers.py
+++ b/werkzeug/contrib/fixers.py
@@ -16,6 +16,8 @@
     :copyright: Copyright 2009 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
+import warnings
+
 try:
     from urllib import unquote
 except ImportError:
@@ -95,76 +97,181 @@ class PathInfoFromRequestUriFix(object):
 
 
 class ProxyFix(object):
+    """Adjust the WSGI environ based on ``Forwarded`` headers that
+    proxies in front of the application may set.
 
-    """This middleware can be applied to add HTTP proxy support to an
-    application that was not designed with HTTP proxies in mind.  It
-    sets `REMOTE_ADDR`, `HTTP_HOST` from `X-Forwarded` headers.  While
-    Werkzeug-based applications already can use
-    :py:func:`werkzeug.wsgi.get_host` to retrieve the current host even if
-    behind proxy setups, this middleware can be used for applications which
-    access the WSGI environment directly.
+    When the application is running behind a server like Nginx (or
+    another server or proxy), WSGI will see the request as coming from
+    that server rather than the real client. Proxies set various headers
+    to track where the request actually came from.
 
-    If you have more than one proxy server in front of your app, set
-    `num_proxies` accordingly.
+    This middleware should only be applied if the application is
+    actually behind such a proxy, and should be configured with the
+    number of proxies that are chained in front of it. Not all proxies
+    set all the headers. Since incoming headers can be faked, you must
+    set how many proxies are setting each header so the middleware knows
+    what to trust.
 
-    Do not use this middleware in non-proxy setups for security reasons.
+    The original values of the headers are stored in the WSGI
+    environ as ``werkzeug.proxy_fix.orig``, a dict.
 
-    The original values of `REMOTE_ADDR` and `HTTP_HOST` are stored in
-    the WSGI environment as `werkzeug.proxy_fix.orig_remote_addr` and
-    `werkzeug.proxy_fix.orig_http_host`.
+    :param app: The WSGI application.
+    :param x_for: Number of values to trust for ``X-Forwarded-For``.
+    :param x_proto: Number of values to trust for ``X-Forwarded-Proto``.
+    :param x_host: Number of values to trust for ``X-Forwarded-Host``.
+    :param x_port: Number of values to trust for ``X-Forwarded-Port``.
+    :param x_prefix: Number of values to trust for
+        ``X-Forwarded-Prefix``.
+    :param num_proxies: Deprecated, use ``x_for`` instead.
 
-    :param app: the WSGI application
-    :param num_proxies: the number of proxy servers in front of the app.
+    .. versionchanged:: 0.15
+        Support ``X-Forwarded-Port`` and ``X-Forwarded-Prefix``.
+
+    .. versionchanged:: 0.15
+        All headers support multiple values. The ``num_proxies``
+        argument is deprecated. Each header is configured with a
+        separate number of trusted proxies.
+
+    .. versionchanged:: 0.15
+        Original WSGI environ values are stored in the
+        ``werkzeug.proxy_fix.orig`` dict. ``orig_remote_addr``,
+        ``orig_wsgi_url_scheme``, and ``orig_http_host`` are deprecated.
+
+    .. versionchanged:: 0.15
+        ``X-Fowarded-Host`` and ``X-Forwarded-Port`` modify
+        ``SERVER_NAME`` and ``SERVER_PORT``.
     """
 
-    def __init__(self, app, num_proxies=1):
+    def __init__(
+        self, app, num_proxies=None,
+        x_for=1, x_proto=0, x_host=0, x_port=0, x_prefix=0
+    ):
         self.app = app
+        self.x_for = x_for
+        self.x_proto = x_proto
+        self.x_host = x_host
+        self.x_port = x_port
+        self.x_prefix = x_prefix
         self.num_proxies = num_proxies
 
+    @property
+    def num_proxies(self):
+        """The number of proxies setting ``X-Forwarded-For`` in front
+        of the application.
+
+        .. deprecated:: 0.15
+            A separate number of trusted proxies is configured for each
+            header. ``num_proxies`` maps to ``x_for``.
+
+        :internal:
+        """
+        warnings.warn(DeprecationWarning(
+            "num_proxies is deprecated. Use x_for instead."))
+        return self.x_for
+
+    @num_proxies.setter
+    def num_proxies(self, value):
+        if value is not None:
+            warnings.warn(DeprecationWarning(
+                'num_proxies is deprecated. Use x_for instead.'))
+            self.x_for = value
+
     def get_remote_addr(self, forwarded_for):
-        """Selects the new remote addr from the given list of ips in
-        X-Forwarded-For.  By default it picks the one that the `num_proxies`
-        proxy server provides.  Before 0.9 it would always pick the first.
+        """Get the real ``remote_addr`` by looking backwards ``x_for``
+        number of values in the ``X-Forwarded-For`` header.
+
+        :param forwarded_for: List of values parsed from the
+            ``X-Forwarded-For`` header.
+        :return: The real ``remote_addr``, or ``None`` if there were not
+            at least ``x_for`` values.
+
+        .. deprecated:: 0.15
+            This is handled internally for each header.
+
+        .. versionchanged:: 0.9
+            Use ``num_proxies`` instead of always picking the first
+            value.
 
         .. versionadded:: 0.8
         """
-        if len(forwarded_for) >= self.num_proxies:
-            return forwarded_for[-self.num_proxies]
+        warnings.warn(DeprecationWarning("get_remote_addr is deprecated."))
+        return self._get_trusted_comma(self.x_for, ','.join(forwarded_for))
+
+    def _get_trusted_comma(self, trusted, value):
+        """Get the real value from a comma-separated header based on the
+        configured number of trusted proxies.
+
+        :param trusted: Number of values to trust in the header.
+        :param value: Header value to parse.
+        :return: The real value, or ``None`` if there are fewer values
+            than the number of trusted proxies.
+
+        .. versionadded:: 0.15
+        """
+        if not (trusted and value):
+            return
+        values = [x.strip() for x in value.split(',')]
+        if len(values) >= trusted:
+            return values[-trusted]
 
     def __call__(self, environ, start_response):
-        getter = environ.get
-        forwarded_proto = getter('HTTP_X_FORWARDED_PROTO', '').split(',')
-        forwarded_for = getter('HTTP_X_FORWARDED_FOR', '').split(',')
-        forwarded_host = getter('HTTP_X_FORWARDED_HOST', '')
-        forwarded_port = getter('HTTP_X_FORWARDED_PORT', '')
-        forwarded_prefix = getter('HTTP_X_FORWARDED_PREFIX', '')
+        """Modify the WSGI environ based on the various ``Forwarded``
+        headers before calling the wrapped application. Store the
+        original environ values in ``werkzeug.proxy_fix.orig_{key}``.
+        """
+        environ_get = environ.get
+        orig_remote_addr = environ_get('REMOTE_ADDR')
+        orig_wsgi_url_scheme = environ_get('wsgi.url_scheme')
+        orig_http_host = environ_get('HTTP_HOST')
         environ.update({
-            'werkzeug.proxy_fix.orig_wsgi_url_scheme': getter('wsgi.url_scheme'),
-            'werkzeug.proxy_fix.orig_remote_addr': getter('REMOTE_ADDR'),
-            'werkzeug.proxy_fix.orig_http_host': getter('HTTP_HOST'),
-            'werkzeug.proxy_fix.orig_server_port': getter('SERVER_PORT'),
-            'werkzeug.proxy_fix.orig_script_name': getter('SCRIPT_NAME'),
+            'werkzeug.proxy_fix.orig': {
+                'REMOTE_ADDR': orig_remote_addr,
+                'wsgi.url_scheme': orig_wsgi_url_scheme,
+                'HTTP_HOST': orig_http_host,
+                'SERVER_NAME': environ_get('SERVER_NAME'),
+                'SERVER_PORT': environ_get('SERVER_PORT'),
+                'SCRIPT_NAME': environ_get('SCRIPT_NAME'),
+            },
+            # todo: remove deprecated keys
+            'werkzeug.proxy_fix.orig_remote_addr': orig_remote_addr,
+            'werkzeug.proxy_fix.orig_wsgi_url_scheme': orig_wsgi_url_scheme,
+            'werkzeug.proxy_fix.orig_http_host': orig_http_host,
         })
-        forwarded_for = [x for x in [x.strip() for x in forwarded_for] if x]
-        forwarded_proto = [x for x in [x.strip() for x in forwarded_proto] if x]
-        remote_addr = self.get_remote_addr(forwarded_for)
-        if remote_addr is not None:
-            environ['REMOTE_ADDR'] = remote_addr
-        if forwarded_host:
-            environ['HTTP_HOST'] = forwarded_host
-        if forwarded_port:
-            if environ.get('HTTP_HOST'):
-                parts = environ['HTTP_HOST'].split(':', 1)
-                if len(parts) == 2:
-                    environ['HTTP_HOST'] = parts[0] + ':' + forwarded_port
-                else:
-                    environ['HTTP_HOST'] += ':' + forwarded_port
-            else:
-                environ['SERVER_PORT'] = forwarded_port
-        if forwarded_proto:
-            environ['wsgi.url_scheme'] = forwarded_proto[0]
-        if forwarded_prefix:
-            environ['SCRIPT_NAME'] = forwarded_prefix
+
+        x_for = self._get_trusted_comma(
+            self.x_for, environ_get('HTTP_X_FORWARDED_FOR'))
+        if x_for:
+            environ['REMOTE_ADDR'] = x_for
+
+        x_proto = self._get_trusted_comma(
+            self.x_proto, environ_get('HTTP_X_FORWARDED_PROTO'))
+        if x_proto:
+            environ['wsgi.url_scheme'] = x_proto
+
+        x_host = self._get_trusted_comma(
+            self.x_host, environ_get('HTTP_X_FORWARDED_HOST'))
+        if x_host:
+            environ['HTTP_HOST'] = x_host
+            parts = x_host.split(':', 1)
+            environ['SERVER_NAME'] = parts[0]
+            if len(parts) == 2:
+                environ['SERVER_PORT'] = parts[1]
+
+        x_port = self._get_trusted_comma(
+            self.x_port, environ_get('HTTP_X_FORWARDED_PORT'))
+        if x_port:
+            host = environ.get('HTTP_HOST')
+            if host:
+                parts = host.split(':', 1)
+                host = parts[0] if len(parts) == 2 else host
+                environ['HTTP_HOST'] = '%s:%s' % (host, x_port)
+            environ['SERVER_PORT'] = x_port
+
+        x_prefix = self._get_trusted_comma(
+            self.x_for, environ_get('HTTP_X_FORWARDED_PREFIX'))
+        if x_prefix:
+            environ['SCRIPT_NAME'] = x_prefix
+
         return self.app(environ, start_response)
 
 

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -1435,8 +1435,9 @@ class Map(object):
         `encoding_errors` and `host_matching` was added.
     """
 
+    #: A dict of default converters to use.
+    #:
     #: .. versionadded:: 0.6
-    #:    a dict of default converters to be used.
     default_converters = ImmutableDict(DEFAULT_CONVERTERS)
 
     def __init__(self, rules=None, default_subdomain='', charset='utf-8',

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -143,17 +143,20 @@ def host_is_trusted(hostname, trusted_list):
 
 
 def get_host(environ, trusted_hosts=None):
-    """Return the real host for the given WSGI environment.  This first checks
-    the normal `Host` header, and if it's not present, then `SERVER_NAME`
-    and `SERVER_PORT` environment variables.
+    """Return the host for the given WSGI environment. This first checks
+    the ``Host`` header. If it's not present, then ``SERVER_NAME`` and
+    ``SERVER_PORT`` are used. The host will only contain the port if it
+    is different than the standard port for the protocol.
 
-    Optionally it verifies that the host is in a list of trusted hosts.
-    If the host is not in there it will raise a
-    :exc:`~werkzeug.exceptions.SecurityError`.
+    Optionally, verify that the host is trusted using
+    :func:`host_is_trusted` and raise a
+    :exc:`~werkzeug.exceptions.SecurityError` if it is not.
 
-    :param environ: the WSGI environment to get the host of.
-    :param trusted_hosts: a list of trusted hosts, see :func:`host_is_trusted`
-                          for more information.
+    :param environ: The WSGI environment to get the host from.
+    :param trusted_hosts: A list of trusted hosts.
+    :return: Host, with port if necessary.
+    :raise ~werkzeug.exceptions.SecurityError: If the host is not
+        trusted.
     """
     if 'HTTP_HOST' in environ:
         rv = environ['HTTP_HOST']


### PR DESCRIPTION
* Support multiple values for all headers.
* Configured the number of proxies to trust for each header separately. `num_proxies` is deprecated. For backwards compatibility with the common case, `x_for` defaults to 1.
* The original WSGI environ values are stored in a dict under `werkzeug.proxy_fix.orig` instead of individual keys. The keys in the dict match the environ keys.
* Parametrize tests and rewrite docs for `ProxyFix` and `get_host`.

I want to add support for the [standard `Forwarded` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded).

I considered refactoring the somewhat repetitious code in `__call__` with a for loop, but it ended up being about as complicated and seemed harder to follow.

Eventually this should be moved out of contrib into a new `werkzeug.middleware.proxy_fix` module.