### PR TITLE
Keep terminal input when triggering code reload during breakpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@ Unreleased
     path rather than the root path. (`#693`_, `#718`_, `#1315`_)
 -   ``path_info`` defaults to ``'/'`` for
     :meth:`Map.bind() <routing.Map.bind>`. (`#740`_, `#768`_, `#1316`_)
+-   Triggering a reload while using a tool such as PDB no longer hides
+    input. (`#1318`_)
 
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
 .. _`#693`: https://github.com/pallets/werkzeug/pull/693
@@ -82,6 +84,7 @@ Unreleased
 .. _`#1314`: https://github.com/pallets/werkzeug/pull/1314
 .. _`#1315`: https://github.com/pallets/werkzeug/pull/1315
 .. _`#1316`: https://github.com/pallets/werkzeug/pull/1316
+.. _`#1318`: https://github.com/pallets/werkzeug/pull/1318
 
 
 Version 0.14.1

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -259,25 +259,20 @@ else:
     reloader_loops['auto'] = reloader_loops['watchdog']
 
 
-try:
-    import termios
-except ImportError:
-    termios = None
-
-
 def ensure_echo_on():
-    if termios is None:
-        return
-
-    # tcgetattr will fail if stdin isn't a tty (e.g. test_serving.py test cases)
+    """Ensure that echo mode is enabled. Some tools such as PDB disable
+    it which causes usability issues after reload."""
+    # tcgetattr will fail if stdin isn't a tty
     if not sys.stdin.isatty():
         return
-
-    file_descriptor = sys.stdin.fileno()
-    attributes = termios.tcgetattr(file_descriptor)
+    try:
+        import termios
+    except ImportError:
+        return
+    attributes = termios.tcgetattr(sys.stdin)
     if not attributes[3] & termios.ECHO:
         attributes[3] |= termios.ECHO
-        termios.tcsetattr(file_descriptor, termios.TCSANOW, attributes)
+        termios.tcsetattr(sys.stdin, termios.TCSANOW, attributes)
 
 
 def run_with_reloader(main_func, extra_files=None, interval=1,


### PR DESCRIPTION
Seems to fix #1317 

Would add a test but the actual bugfix that depends on this would be a pretty bizarre thing to test, not sure how that might be automated in a practical fashion. A unit test here would be pretty meaningless w/regards to the actual issue. Happy to add any test that seems appropriate though (will fix that now-broken test in a moment)

This is pretty much just how [Pyramid](https://github.com/davisagli/pyramid/commit/a1d053cfb9818d9a24fbd78b649c8112aa2a3e81)/[Django](https://github.com/django/django/commit/f5b22ed997) both do it, with slight recontextualizing because licensing requirements are somewhat unclear
