### PR TITLE
Add support for WWW-Authenticate header to Unauthorized

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,10 @@ Unreleased
     *iterable*, not the internal iterator. This doesn't affect objects
     where ``__iter__`` returned ``self``. For other objects, the method
     was not called before. (`#1259`_, `#1260`_)
+-   :class:`~exceptions.Unauthorized` takes a ``www_authenticate``
+    parameter to set the ``WWW-Authenticate`` header for the response,
+    which is technically required for a valid 401 response. (`#772`_,
+    `#795`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -73,6 +77,8 @@ Unreleased
 .. _`#724`: https://github.com/pallets/werkzeug/pull/724
 .. _`#740`: https://github.com/pallets/werkzeug/issues/740
 .. _`#768`: https://github.com/pallets/werkzeug/pull/768
+.. _`#772`: https://github.com/pallets/werkzeug/pull/772
+.. _`#795`: https://github.com/pallets/werkzeug/pull/795
 .. _`#1019`: https://github.com/pallets/werkzeug/issues/1019
 .. _`#1023`: https://github.com/pallets/werkzeug/issues/1023
 .. _`#1231`: https://github.com/pallets/werkzeug/issues/1231

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -140,8 +140,6 @@ methods.  In any case you should have a look at the sourcecode of the
 exceptions module.
 
 You can override the default description in the constructor with the
-`description` parameter (it's the first argument for all exceptions
-except of the :exc:`MethodNotAllowed` which accepts a list of allowed methods
-as first argument)::
+``description`` parameter::
 
-    raise BadRequest('Request failed because X was not present')
+    raise BadRequest(description='Request failed because X was not present')

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -15,6 +15,7 @@
 import pytest
 
 from werkzeug import exceptions
+from werkzeug.datastructures import WWWAuthenticate
 from werkzeug.wrappers import Response
 from werkzeug._compat import text_type
 
@@ -30,7 +31,7 @@ def test_proxy_exception():
 
 @pytest.mark.parametrize('test', [
     (exceptions.BadRequest, 400),
-    (exceptions.Unauthorized, 401, ['Basic "test realm"']),
+    (exceptions.Unauthorized, 401, 'Basic "test realm"'),
     (exceptions.Forbidden, 403),
     (exceptions.NotFound, 404),
     (exceptions.MethodNotAllowed, 405, ['GET', 'HEAD']),
@@ -85,13 +86,23 @@ def test_exception_repr():
     assert repr(exc) == "<HTTPException '???: Unknown Error'>"
 
 
-def test_special_exceptions():
+def test_method_not_allowed_methods():
     exc = exceptions.MethodNotAllowed(['GET', 'HEAD', 'POST'])
     h = dict(exc.get_headers({}))
     assert h['Allow'] == 'GET, HEAD, POST'
     assert 'The method is not allowed' in exc.get_description()
 
-    exc = exceptions.Unauthorized(['Basic realm1', 'Digest realm=...'])
+
+def test_unauthorized_www_authenticate():
+    basic = WWWAuthenticate()
+    basic.set_basic("test")
+    digest = WWWAuthenticate()
+    digest.set_digest("test", "test")
+
+    exc = exceptions.Unauthorized(www_authenticate=basic)
     h = dict(exc.get_headers({}))
-    assert h['WWW-Authenticate'] == 'Basic realm1, Digest realm=...'
-    assert 'authorized' in exc.get_description()
+    assert h['WWW-Authenticate'] == str(basic)
+
+    exc = exceptions.Unauthorized(www_authenticate=[digest, basic])
+    h = dict(exc.get_headers({}))
+    assert h['WWW-Authenticate'] == ', '.join((str(digest), str(basic)))

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -30,7 +30,7 @@ def test_proxy_exception():
 
 @pytest.mark.parametrize('test', [
     (exceptions.BadRequest, 400),
-    (exceptions.Unauthorized, 401),
+    (exceptions.Unauthorized, 401, ['Basic "test realm"']),
     (exceptions.Forbidden, 403),
     (exceptions.NotFound, 404),
     (exceptions.MethodNotAllowed, 405, ['GET', 'HEAD']),
@@ -90,3 +90,8 @@ def test_special_exceptions():
     h = dict(exc.get_headers({}))
     assert h['Allow'] == 'GET, HEAD, POST'
     assert 'The method is not allowed' in exc.get_description()
+
+    exc = exceptions.Unauthorized(['Basic realm1', 'Digest realm=...'])
+    h = dict(exc.get_headers({}))
+    assert h['WWW-Authenticate'] == 'Basic realm1, Digest realm=...'
+    assert 'authorized' in exc.get_description()

--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -213,32 +213,43 @@ class BadHost(BadRequest):
 
 class Unauthorized(HTTPException):
 
-    """*401* `Unauthorized`
+    """*401* ``Unauthorized``
 
-    Raise if the user is not authorized.  Also used if you want to use HTTP
-    basic auth.
+    Raise if the user is not authorized to access a resource.
 
-    The first argument for this exception should be a list of WWW-Authenticate
-    challenges.  Strictly speaking the response would be invalid if you don't 
-    provide at least one challenge.
+    The ``www_authenticate`` argument should be used to set the
+    ``WWW-Authenticate`` header. This is used for HTTP basic auth and
+    other schemes. Use :class:`~werkzeug.datastructures.WWWAuthenticate`
+    to create correctly formatted values. Strictly speaking a 401
+    response is invalid if it doesn't provide at least one value for
+    this header, although real clients typically don't care.
+
+    :param www-authenticate: A single value, or list of values, for the
+        WWW-Authenticate header.
+    :param description: Override the default message used for the body
+        of the response.
     """
     code = 401
     description = (
-        'The server could not verify that you are authorized to access '
-        'the URL requested.  You either supplied the wrong credentials (e.g. '
-        'a bad password), or your browser doesn\'t understand how to supply '
-        'the credentials required.'
+        'The server could not verify that you are authorized to access'
+        ' the URL requested. You either supplied the wrong credentials'
+        " (e.g. a bad password), or your browser doesn't understand"
+        ' how to supply the credentials required.'
     )
-    
-    def __init__(self, challenges=None, description=None):
-        """Takes an optional list of WWW-Authenticate challenges."""
-        HTTPException.__init__(self, description)
-        self.challenges = challenges
 
-    def get_headers(self, environ):
+    def __init__(self, www_authenticate=None, description=None):
+        HTTPException.__init__(self, description)
+        if not isinstance(www_authenticate, (tuple, list)):
+            www_authenticate = (www_authenticate,)
+        self.www_authenticate = www_authenticate
+
+    def get_headers(self, environ=None):
         headers = HTTPException.get_headers(self, environ)
-        if self.challenges:
-            headers.append(('WWW-Authenticate', ', '.join(self.challenges)))
+        if self.www_authenticate:
+            headers.append((
+                'WWW-Authenticate',
+                ', '.join([str(x) for x in self.www_authenticate])
+            ))
         return headers
 
 

--- a/werkzeug/exceptions.py
+++ b/werkzeug/exceptions.py
@@ -217,6 +217,10 @@ class Unauthorized(HTTPException):
 
     Raise if the user is not authorized.  Also used if you want to use HTTP
     basic auth.
+
+    The first argument for this exception should be a list of WWW-Authenticate
+    challenges.  Strictly speaking the response would be invalid if you don't 
+    provide at least one challenge.
     """
     code = 401
     description = (
@@ -225,6 +229,17 @@ class Unauthorized(HTTPException):
         'a bad password), or your browser doesn\'t understand how to supply '
         'the credentials required.'
     )
+    
+    def __init__(self, challenges=None, description=None):
+        """Takes an optional list of WWW-Authenticate challenges."""
+        HTTPException.__init__(self, description)
+        self.challenges = challenges
+
+    def get_headers(self, environ):
+        headers = HTTPException.get_headers(self, environ)
+        if self.challenges:
+            headers.append(('WWW-Authenticate', ', '.join(self.challenges)))
+        return headers
 
 
 class Forbidden(HTTPException):


### PR DESCRIPTION
continues #795 
closes #772 

Allows passing a single value or a list of values to `www_authenticate` argument. Values are converted to string, which supports using `datastructures.WWWAuthenticate` to help build the values.