### PR TITLE
Reloader: Force the key of environment variable into string type

### DIFF
--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -126,7 +126,9 @@ class ReloaderLoop(object):
             if os.name == 'nt' and PY2:
                 for key, value in iteritems(new_environ):
                     if isinstance(key, text_type) or isinstance(value, text_type):
-                        new_environ[key.encode('iso-8859-1')] = new_environ.pop(key).encode('iso-8859-1')
+                        new_key = key.encode('iso-8859-1')
+                        new_value = new_environ.pop(key).encode('iso-8859-1')
+                        new_environ[new_key] = new_value
 
             exit_code = subprocess.call(args, env=new_environ,
                                         close_fds=False)

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -125,8 +125,8 @@ class ReloaderLoop(object):
             # to latin1 and continue.
             if os.name == 'nt' and PY2:
                 for key, value in iteritems(new_environ):
-                    if isinstance(value, text_type):
-                        new_environ[key] = value.encode('iso-8859-1')
+                    if isinstance(key, text_type) or isinstance(value, text_type):
+                        new_environ[key.encode('iso-8859-1')] = new_environ.pop(key).encode('iso-8859-1')
 
             exit_code = subprocess.call(args, env=new_environ,
                                         close_fds=False)


### PR DESCRIPTION
When enabling reloader with Python2 on Windows, it always throw out `TypeError: environment can only contain strings`:
```pytb
Traceback (most recent call last):
  File "c:\python27\Lib\runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "c:\python27\Lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "C:\Users\Administrator\.virtualenvs\bluelog-deploy-96IrcjQo\Scripts\flask.exe\__main__.py", line 9, in <module>
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\flask\cli.py", line 894, in main
    cli.main(args=args, prog_name=name)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\flask\cli.py", line 557, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\click\core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\click\decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\flask\cli.py", line 771, in run_command
    threaded=with_threads, ssl_context=cert)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\werkzeug\serving.py", line 812, in run_simple
    reloader_type)
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\werkzeug\_reloader.py", line 283, in run_with_reloader
    sys.exit(reloader.restart_with_reloader())
  File "c:\users\administrator\.virtualenvs\bluelog-deploy-96ircjqo\lib\site-packages\werkzeug\_reloader.py", line 140, in restart_with_reloader
    close_fds=False)
  File "c:\python27\Lib\subprocess.py", line 168, in call
    return Popen(*popenargs, **kwargs).wait()
  File "c:\python27\Lib\subprocess.py", line 390, in __init__
    errread, errwrite)
  File "c:\python27\Lib\subprocess.py", line 640, in _execute_child
    startupinfo)
TypeError: environment can only contain strings
```

Dig into the source, the problem root is at [werkzeug/_reloader.py#L123](https://github.com/pallets/werkzeug/blob/master/werkzeug/_reloader.py#L123):
```py
   def restart_with_reloader(self):
       # ...
            # a weird bug on windows. sometimes unicode strings end up in the
            # environment and subprocess.call does not like this, encode them
            # to latin1 and continue.
            if os.name == 'nt' and PY2:
                for key, value in iteritems(new_environ):
                    if isinstance(value, text_type):
                        new_environ[key] = value.encode('iso-8859-1')  # <-- only ecode value
            # ...
```
I found it only encode the value of the enviroment variable. So I try to print the `new_environ` after the process:
```py
{'SYSTEMROOT': 'C:\\Windows', u'FLASK_APP': 'bluelog', 'PATH': 'C:\\Users\\Administrator\\.virtualenvs\\bluelog-dep...'}
```
I got something like ` u'FLASK_APP': 'bluelog'`, the key still be unicode!

This PR will encode the key of the enviroment variable into string type to prevent this issue.