### PR TITLE
Sans-IO MultiPartParser

### DIFF
--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -124,6 +124,17 @@ class TestFormParser(object):
         req.max_form_memory_size = 400
         strict_eq(req.form["foo"], u"Hello World")
 
+    def test_cut_in_crlf(self):
+        data = b"--foo\r\nContent-Disposition: form-field; name=foo\r\n\r\n"
+        data += b"x" * (1024 * 64 - len(data) - 1) + b"\r\n--foo--"
+        req = Request.from_values(
+            input_stream=BytesIO(data),
+            content_length=len(data),
+            content_type="multipart/form-data; boundary=foo",
+            method="POST",
+        )
+        assert req.form["foo"][-1] != u"\r"
+
     def test_missing_multipart_boundary(self):
         data = (
             b"--foo\r\nContent-Disposition: form-field; name=foo\r\n\r\n"


### PR DESCRIPTION
While this PR doesn't add any asyncio code, the motivation here is making it easier to support asyncio in the form parser, which is the major piece of synchronous-only code in werkzeug.

The idea here is to rewrite the parser to be force-fed pieces of buffer by something else. `MultiPartParser`'s existing, synchronous API is then implemented by reading a file and feeding it in. This does necessitate making all parser state explicit, but the total LOC change is surprisingly light.

An effort to add async support might subclass `MultiPartParser`, and the only change required would be to drive the basic parsing logic with data acquired asynchronously.

One thing I'm not very happy with is that we need to keep `parse_multipart_headers`, as part of the documented API, despite the fact that we can't use it.