### PR TITLE
Add support for Chrome on iOS user agent

### DIFF
--- a/werkzeug/useragents.py
+++ b/werkzeug/useragents.py
@@ -49,7 +49,7 @@ class UserAgentParser(object):
         (r'aol|america\s+online\s+browser', 'aol'),
         ('opera', 'opera'),
         ('edge', 'edge'),
-        ('chrome', 'chrome'),
+        ('chrome|crios', 'chrome'),
         ('seamonkey', 'seamonkey'),
         ('firefox|firebird|phoenix|iceweasel', 'firefox'),
         ('galeon', 'galeon'),


### PR DESCRIPTION
@davidism this fixes https://github.com/pallets/werkzeug/issues/1334.

I couldn't find any tests covering the user agent parser, but happy to add tests if necessary.

```python
>>> from werkzeug import UserAgent
>>> user_agent = UserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1')
>>> print(user_agent.browser)
chrome
```