### PR TITLE
Raise an error if query string has multiple definitions

### DIFF
--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -328,6 +328,11 @@ def test_create_environ():
     strict_eq(create_environ('/foo', 'http://example.com/')['SCRIPT_NAME'], '')
 
 
+def test_create_environ_query_string_error():
+    with pytest.raises(ValueError):
+        create_environ('/foo?bar=baz', query_string={'a': 'b'})
+
+
 def test_file_closing():
     closed = []
 

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -296,6 +296,8 @@ class EnvironBuilder(object):
                  environ_base=None, environ_overrides=None, charset='utf-8',
                  mimetype=None):
         path_s = make_literal_wrapper(path)
+        if query_string is not None and path_s('?') in path:
+            raise ValueError('Query string is defined in the path and as an argument')
         if query_string is None and path_s('?') in path:
             path, query_string = path.split(path_s('?'), 1)
         self.charset = charset


### PR DESCRIPTION
Previously to this commit if when creating an environ (i.e. for
testing) a query string is defined in the path and as an argument the
path-query-string would be ignored. This results in the path not
matching any routes and hence an unexpected result. This commit fixes
this issue by raising a ValueError if someone should do this.

Raising ValueError is considered the correct approach as it is unclear
which individual query string is the user's intention or if they
should be combined.