### PR TITLE
Make `LocalProxy._get_current_object()` public

### DIFF
--- a/werkzeug/local.py
+++ b/werkzeug/local.py
@@ -298,6 +298,12 @@ class LocalProxy(object):
             object.__setattr__(self, '__wrapped__', local)
 
     def _get_current_object(self):
+        """
+        Backward compatibility.
+        """
+        return self.get_current_object
+    
+    def get_current_object(self):
         """Return the current object.  This is useful if you want the real
         object behind the proxy at a time for performance reasons or because
         you want to pass the object into a different context.

--- a/werkzeug/local.py
+++ b/werkzeug/local.py
@@ -301,7 +301,7 @@ class LocalProxy(object):
         """
         Backward compatibility.
         """
-        return self.get_current_object
+        return self.get_current_object()
     
     def get_current_object(self):
         """Return the current object.  This is useful if you want the real


### PR DESCRIPTION
There is any reason why this method should be protected? Isn't completely legit to have the necessity to access the current object if you need to work on a different context?

One example I can think of:

```
from queue import Queue
from threading import Thread

from flask import request

QUEUE = Queue()

def some_view():
    QUEUE.put(request._get_current_object())
    return 'Accepted', 202

def some_worker():
    while True:
         request = QUEUE.get()
         ...   # do some IO-intensive work

thread = Thread(target=some_worker())
thread.start()
```

While still feasible with the protected method, there is any reason as of why it should be protected?