### PR TITLE
Replace shared global _empty_stream with separate instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,11 @@ Unreleased
     `#795`_)
 -   The test client raises a ``ValueError`` if a query string argument
     would overwrite a query string in the path. (`#1338`_)
+-   :class:`~test.EnvironBuilder`, :class:`~datastructures.FileStorage`,
+    and :func:`wsgi.get_input_stream` no longer share a global
+    ``_empty_stream`` instance. This improves test isolation by preventing
+    cases where closing the stream in one request would affect other usages.
+    (`#1340`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -104,6 +109,7 @@ Unreleased
 .. _`#1316`: https://github.com/pallets/werkzeug/pull/1316
 .. _`#1318`: https://github.com/pallets/werkzeug/pull/1318
 .. _`#1338`: https://github.com/pallets/werkzeug/pull/1338
+.. _`#1340`: https://github.com/pallets/werkzeug/pull/1340
 
 
 Version 0.14.1

--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -15,12 +15,11 @@ from weakref import WeakKeyDictionary
 from datetime import datetime, date
 from itertools import chain
 
-from werkzeug._compat import iter_bytes, text_type, BytesIO, int_to_byte, \
-    range_type, integer_types
+from werkzeug._compat import iter_bytes, text_type, int_to_byte, range_type, \
+    integer_types
 
 
 _logger = None
-_empty_stream = BytesIO()
 _signature_cache = WeakKeyDictionary()
 _epoch_ord = date(1970, 1, 1).toordinal()
 _cookie_params = set((b'expires', b'path', b'comment',

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -15,10 +15,10 @@ from copy import deepcopy
 from itertools import repeat
 from collections import Container, Iterable, MutableSet
 
-from werkzeug._internal import _missing, _empty_stream
-from werkzeug._compat import iterkeys, itervalues, iteritems, iterlists, \
-    PY2, text_type, integer_types, string_types, make_literal_wrapper, \
-    to_native
+from werkzeug._internal import _missing
+from werkzeug._compat import BytesIO, iterkeys, itervalues, iteritems, \
+    iterlists, PY2, text_type, integer_types, string_types, \
+    make_literal_wrapper, to_native
 from werkzeug.filesystem import get_filesystem_encoding
 
 
@@ -2639,7 +2639,7 @@ class FileStorage(object):
                  content_type=None, content_length=None,
                  headers=None):
         self.name = name
-        self.stream = stream or _empty_stream
+        self.stream = stream or BytesIO()
 
         # if no filename is provided we can attempt to get the filename
         # from the stream object passed.  There we have to be careful to

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -28,7 +28,7 @@ except ImportError:  # Py2
 from werkzeug._compat import iterlists, iteritems, itervalues, to_bytes, \
     string_types, text_type, reraise, wsgi_encoding_dance, \
     make_literal_wrapper
-from werkzeug._internal import _empty_stream, _get_environ
+from werkzeug._internal import _get_environ
 from werkzeug.wrappers import BaseRequest
 from werkzeug.urls import url_encode, url_fix, iri_to_uri, url_unquote, \
     url_unparse, url_parse
@@ -596,7 +596,7 @@ class EnvironBuilder(object):
             content_length = len(values)
             input_stream = BytesIO(values)
         else:
-            input_stream = _empty_stream
+            input_stream = BytesIO()
 
         result = {}
         if self.environ_base:

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -27,7 +27,7 @@ from zlib import adler32
 from werkzeug._compat import BytesIO, PY2, implements_iterator, iteritems, \
     make_literal_wrapper, string_types, text_type, to_bytes, to_unicode, \
     try_coerce_native, wsgi_get_bytes
-from werkzeug._internal import _empty_stream, _encode_idna
+from werkzeug._internal import _encode_idna
 from werkzeug.filesystem import get_filesystem_encoding
 from werkzeug.http import http_date, is_resource_modified, \
     is_hop_by_hop_header
@@ -226,7 +226,7 @@ def get_input_stream(environ, safe_fallback=True):
     # potentially dangerous because it could be infinite, malicious or not. If
     # safe_fallback is true, return an empty stream instead for safety.
     if content_length is None:
-        return safe_fallback and _empty_stream or stream
+        return safe_fallback and BytesIO() or stream
 
     # Otherwise limit the stream to the content length
     return LimitedStream(stream, content_length)


### PR DESCRIPTION
The use of a shared `_empty_stream` instance can cause subtle failures when a test or process closes the shared stream.

For example, if a test initializes a request with a file upload `FileStorage` with a falsy `stream` argument, the `FileStorage` will use the shared `_empty_stream`:

https://github.com/pallets/werkzeug/blob/ac230a2257eaa647ef1e52b565507a6ecd5dfe20/werkzeug/datastructures.py#L2642

When the request is torn down, it will close the shared `_empty_stream`:

https://github.com/pallets/werkzeug/blob/ac230a2257eaa647ef1e52b565507a6ecd5dfe20/werkzeug/wrappers.py#L416

https://github.com/pallets/werkzeug/blob/ac230a2257eaa647ef1e52b565507a6ecd5dfe20/werkzeug/datastructures.py#L2736

Subsequently, if a test environment is created with no specified `input_stream`, it will use the closed `_empty_stream`:

https://github.com/pallets/werkzeug/blob/816a1e9e3c358b43047cf284b82407161690fd76/werkzeug/test.py#L599

Now calls to `request.get_data()` and other operations on the stream will fail.

In the case where we discovered this behavior at Patreon, two unrelated tests were causing a failure: one which initialized an `FileStorage` with `_empty_stream`, and one which called `request.get_data()`.

I believe that replacing this shared instance with individually created `BytesIO` buffers would reduce the chances of such spooky shared global bugs without creating much overhead. What do you think?

