### PR TITLE
Redirect with a 308 rather than 301 in a specific case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ Unreleased
     ``_empty_stream`` instance. This improves test isolation by preventing
     cases where closing the stream in one request would affect other usages.
     (`#1340`_)
+-   Change ``RequestRedirect`` code from 301 to 308, preserving the verb
+    and request body (form data) during redirect. (`#1342`_)
 -   The version of jQuery used by the debugger is updated to 3.3.1.
     (`#1390`_)
 -   The debugger correctly renders long ``markupsafe.Markup`` instances.
@@ -153,6 +155,7 @@ Unreleased
 .. _`#1325`: https://github.com/pallets/werkzeug/pull/1325
 .. _`#1338`: https://github.com/pallets/werkzeug/pull/1338
 .. _`#1340`: https://github.com/pallets/werkzeug/pull/1340
+.. _`#1342`: https://github.com/pallets/werkzeug/pull/1342
 .. _`#1346`: https://github.com/pallets/werkzeug/pull/1346
 .. _`#1358`: https://github.com/pallets/werkzeug/pull/1358
 .. _`#1375`: https://github.com/pallets/werkzeug/pull/1375

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -231,7 +231,7 @@ class RequestRedirect(HTTPException, RoutingException):
 
     The attribute `new_url` contains the absolute destination url.
     """
-    code = 301
+    code = 308
 
     def __init__(self, new_url):
         RoutingException.__init__(self, new_url)

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -343,10 +343,10 @@ def unescape(s):
 
 def redirect(location, code=302, Response=None):
     """Returns a response object (a WSGI application) that, if called,
-    redirects the client to the target location.  Supported codes are 301,
-    302, 303, 305, and 307.  300 is not supported because it's not a real
-    redirect and 304 because it's the answer for a request with a request
-    with defined If-Modified-Since headers.
+    redirects the client to the target location. Supported codes are
+    301, 302, 303, 305, 307, and 308. 300 is not supported because
+    it's not a real redirect and 304 because it's the answer for a
+    request with a request with defined If-Modified-Since headers.
 
     .. versionadded:: 0.6
        The location can now be a unicode string that is encoded using


### PR DESCRIPTION
With strict slashes enabled and the route defined with a trailing
slash e.g. `/a/` a request to `/a` currently results in a 301 response
to redirect to `/a/`. This is good for GET and HEAD requests, but
problematic for other verbs as clients will typically treat a 301
response as meaning redirect as a GET verb as noted in RFC 2616
section-10.3.2 (RFC 2616 stated this was erroneous, and then RFC 7231
allowed this behaviour). RFC 7538 later introduced a 308 code to work
as 301 was originally intended.

In principle I think the 301 could be changed to 308 wholesale, but
that would likely create some confusing changes to existing code. So I
hope this is a good compromise.

Note: I need to add a changelog entry. However first I'd like to see if this makes sense to others...