### PR TITLE
Fix UnicodeDecodeError on bytestring querystring

### DIFF
--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -199,6 +199,10 @@ def test_url_request_descriptors_hosts():
     pytest.raises(SecurityError, lambda: req.host_url)
     pytest.raises(SecurityError, lambda: req.host)
 
+def test_url_full_path_bytestring():
+    req = wrappers.Request.from_values(b'/bar?foo=\xe9')
+    strict_eq(req.full_path, u'/bar?foo=é')
+
 
 def test_authorization_mixin():
     request = wrappers.Request.from_values(headers={

--- a/werkzeug/wrappers.py
+++ b/werkzeug/wrappers.py
@@ -599,7 +599,7 @@ class BaseRequest(object):
     @cached_property
     def full_path(self):
         """Requested path as unicode, including the query string."""
-        return self.path + u'?' + to_unicode(self.query_string, self.url_charset)
+        return self.path + u'?' + to_unicode(self.query_string, 'latin1')
 
     @cached_property
     def script_root(self):


### PR DESCRIPTION
When the url is defined as a bytestring, a call to full_path raises
a UnicodeDecodeError when the querystring contains special characters.
This was observed in production with a Flask application.