### PR TITLE
Replace some <and or> expressions to <if else> expressions.

### DIFF
--- a/examples/cupoftee/pages.py
+++ b/examples/cupoftee/pages.py
@@ -24,7 +24,7 @@ class ServerList(Page):
         desc = False
         if name == self.order_by:
             desc = not self.order_desc
-            cls = ' class="%s"' % (desc and 'down' or 'up')
+            cls = ' class="%s"' % ('down' if desc else 'up')
         if desc:
             link += '&amp;dir=desc'
         return '<a href="%s"%s>%s</a>' % (link, cls, title)

--- a/examples/cupoftee/templates/search.html
+++ b/examples/cupoftee/templates/search.html
@@ -16,7 +16,7 @@
 <% if results %>
   <p>
     The nickname "$escape(user)" is currently playing on the
-    following ${len(results) == 1 and 'server' or 'servers'}:
+    following ${'server' if len(results) == 1 else 'servers'}:
   </p>
   <ul>
   <% for server in results %>

--- a/examples/cupoftee/templates/serverlist.html
+++ b/examples/cupoftee/templates/serverlist.html
@@ -27,7 +27,7 @@
       <td>$escape(server.map)</td>
       <td>$server.gametype</td>
       <td>$server.player_count / $server.max_players</td>
-      <td>${server.progression >= 0 and '%d%%' % server.progression or '?'}</td>
+      <td>${'%d%%' % server.progression if server.progression >= 0 else '?'}</td>
     </tr>
     <% endfor %>
   </tbody>

--- a/examples/cupoftee/utils.py
+++ b/examples/cupoftee/utils.py
@@ -16,4 +16,4 @@ _sort_re = re.compile(r'\w+', re.UNICODE)
 
 def unicodecmp(a, b):
     x, y = map(_sort_re.search, [a, b])
-    return cmp((x and x.group() or a).lower(), (y and y.group() or b).lower())
+    return cmp((x.group() if x else a).lower(), (y.group() if y else b).lower())

--- a/examples/i18nurls/application.py
+++ b/examples/i18nurls/application.py
@@ -72,7 +72,7 @@ class Application(object):
             req.matched_url = (endpoint, args)
             if endpoint == '#language_select':
                 lng = req.accept_languages.best
-                lng = lng and lng.split('-')[0].lower() or 'en'
+                lng = lng.split('-')[0].lower() if lng else 'en'
                 index_url = urls.build('index', {'lang_code': lng})
                 resp = Response('Moved to %s' % index_url, status=302)
                 resp.headers['Location'] = index_url

--- a/examples/i18nurls/application.py
+++ b/examples/i18nurls/application.py
@@ -72,7 +72,7 @@ class Application(object):
             req.matched_url = (endpoint, args)
             if endpoint == '#language_select':
                 lng = req.accept_languages.best
-                lng = lng.split('-')[0].lower() if lng else 'en'
+                lng = lng and lng.split('-')[0].lower() or 'en'
                 index_url = urls.build('index', {'lang_code': lng})
                 resp = Response('Moved to %s' % index_url, status=302)
                 resp.headers['Location'] = index_url

--- a/examples/plnt/sync.py
+++ b/examples/plnt/sync.py
@@ -54,7 +54,7 @@ def sync():
             else:
                 title = entry.get('title')
             url = entry.get('link') or blog.blog_url
-            text = entry.content[0] if 'content' in entry else \
+            text = 'content' in entry and entry.content[0] or \
                    entry.get('summary_detail')
 
             if not title or not text:

--- a/examples/plnt/sync.py
+++ b/examples/plnt/sync.py
@@ -54,7 +54,7 @@ def sync():
             else:
                 title = entry.get('title')
             url = entry.get('link') or blog.blog_url
-            text = 'content' in entry and entry.content[0] or \
+            text = entry.content[0] if 'content' in entry else \
                    entry.get('summary_detail')
 
             if not title or not text:

--- a/examples/simplewiki/templates/action_edit.html
+++ b/examples/simplewiki/templates/action_edit.html
@@ -5,12 +5,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:xi="http://www.w3.org/2001/XInclude"
       xmlns:py="http://genshi.edgewall.org/"><xi:include href="layout.html" />
   <head>
-    <title>${new and 'Create' or 'Edit'} Page</title>
+    <title>${'Create' if new else 'Edit'} Page</title>
   </head>
   <body>
-    <h1>${new and 'Create' or 'Edit'} “${page.title or page_name}”</h1>
+    <h1>${'Create' if new else 'Edit'} “${page.title or page_name}”</h1>
     <p>
-      You can now ${new and 'create' or 'modify'} the page contents.  To
+      You can now ${'create' if new else 'modify'} the page contents.  To
       format your text you can use <a href="http://www.wikicreole.org/">creole markup</a>.
     </p>
     <p class="error" py:if="error">${error}</p>

--- a/examples/simplewiki/templates/action_log.html
+++ b/examples/simplewiki/templates/action_log.html
@@ -21,14 +21,14 @@
           <th class="actions">Actions</th>
         </tr>
         <tr py:for="idx, revision in enumerate(page.revisions)"
-            class="${idx % 2 == 1 and 'even' or 'odd'}">
+            class="${'even' if idx % 2 == 1 else 'odd'}">
           <td class="timestamp">${format_datetime(revision.timestamp)}</td>
           <td class="change_note">${revision.change_note}</td>
           <td class="diff">
             <input type="radio" name="old" value="${revision.revision_id}"
-                   checked="${idx == 1 and 'checked' or None}" />
+                   checked="${'checked' if idx == 1 else None}" />
             <input type="radio" name="new" value="${revision.revision_id}"
-                   checked="${idx == 0 and 'checked' or None}" />
+                   checked="${'checked' if idx == 0 else None}" />
           </td>
           <td class="actions">
             <a href="${href(page.name, rev=revision.revision_id)}">show</a>

--- a/examples/simplewiki/templates/layout.html
+++ b/examples/simplewiki/templates/layout.html
@@ -27,7 +27,7 @@
                 ('edit', href(page.name, action='edit'), 'edit'),
                 ('log', href(page.name, action='log'), 'log')
               )">
-                <a href="${href}" class="${id == page_action and 'active' or
+                <a href="${href}" class="${'active' if id == page_action else
                   None}">${title}</a> |
               </py:for>
             </py:if>

--- a/examples/simplewiki/templates/recent_changes.html
+++ b/examples/simplewiki/templates/recent_changes.html
@@ -15,7 +15,7 @@
         <th class="change_note">Change Note</th>
       </tr>
       <tr py:for="idx, entry in enumerate(pagination.entries)"
-          class="${idx % 2 == 1 and 'even' or 'odd'}">
+          class="${'even' if idx % 2 == 1 else 'odd'}">
         <td class="timestamp">${format_datetime(entry.timestamp)}</td>
         <td class="page"><a href="${href(entry.name)}">${entry.title}</a></td>
         <td class="change_note">${entry.change_note}</td>

--- a/examples/simplewiki/utils.py
+++ b/examples/simplewiki/utils.py
@@ -65,9 +65,9 @@ def href(*args, **kw):
     Simple function for URL generation.  Position arguments are used for the
     URL path and keyword arguments are used for the url parameters.
     """
-    result = [(request and request.script_root or '') + '/']
+    result = [(request.script_root if request else '') + '/']
     for idx, arg in enumerate(args):
-        result.append((idx and '/' or '') + url_quote(arg))
+        result.append(('/' if idx else '') + url_quote(arg))
     if kw:
         result.append('?' + url_encode(kw))
     return ''.join(result)

--- a/werkzeug/contrib/atom.py
+++ b/werkzeug/contrib/atom.py
@@ -120,7 +120,7 @@ class AtomFeed(object):
         if self.generator is None:
             self.generator = self.default_generator
         self.links = kwargs.get('links', [])
-        self.entries = entries and list(entries) or []
+        self.entries = list(entries) if entries else []
 
         if not hasattr(self.author, '__iter__') \
            or isinstance(self.author, string_types + (dict,)):
@@ -164,7 +164,7 @@ class AtomFeed(object):
 
         if not self.updated:
             dates = sorted([entry.updated for entry in self.entries])
-            self.updated = dates and dates[-1] or datetime.utcnow()
+            self.updated = dates[-1] if dates else datetime.utcnow()
 
         yield u'<?xml version="1.0" encoding="utf-8"?>\n'
         yield u'<feed xmlns="http://www.w3.org/2005/Atom">\n'

--- a/werkzeug/contrib/jsrouting.py
+++ b/werkzeug/contrib/jsrouting.py
@@ -211,7 +211,7 @@ def generate_map(map, name='url_map'):
             u'defaults':    rule.defaults
         })
 
-    return render_template(name_parts=name and name.split('.') or [],
+    return render_template(name_parts=name.split('.') if name else [],
                            rules=dumps(rules),
                            converters=converters)
 

--- a/werkzeug/contrib/securecookie.py
+++ b/werkzeug/contrib/securecookie.py
@@ -160,7 +160,7 @@ class SecureCookie(ModificationTrackingDict):
         return '<%s %s%s>' % (
             self.__class__.__name__,
             dict.__repr__(self),
-            self.should_save and '*' or ''
+            '*' if self.should_save else ''
         )
 
     @property

--- a/werkzeug/contrib/sessions.py
+++ b/werkzeug/contrib/sessions.py
@@ -128,7 +128,7 @@ class Session(ModificationTrackingDict):
         return '<%s %s%s>' % (
             self.__class__.__name__,
             dict.__repr__(self),
-            self.should_save and '*' or ''
+            '*' if self.should_save else ''
         )
 
     @property

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1782,7 +1782,7 @@ class MIMEAccept(Accept):
     def _value_matches(self, value, item):
         def _normalize(x):
             x = x.lower()
-            return x == '*' and ('*', '*') or x.split('/', 1)
+            return ('*', '*') if x == '*' else x.split('/', 1)
 
         # this is from the application which is trusted.  to avoid developer
         # frustration we actually check these for valid values
@@ -2334,7 +2334,7 @@ class Range(object):
         ranges = []
         for begin, end in self.ranges:
             if end is None:
-                ranges.append(begin >= 0 and '%s-' % begin or str(begin))
+                ranges.append('%s-' % begin if begin >= 0 else str(begin))
             else:
                 ranges.append('%s-%s' % (begin, end - 1))
         return '%s=%s' % (self.units, ','.join(ranges))
@@ -2614,7 +2614,7 @@ class WWWAuthenticate(UpdateDictMixin, dict):
         if value is None:
             self.pop('stale', None)
         else:
-            self['stale'] = value and 'TRUE' or 'FALSE'
+            self['stale'] = 'TRUE' if value else 'FALSE'
     stale = property(_get_stale, _set_stale, doc='''
         A flag, indicating that the previous request from the client was
         rejected because the nonce value was stale.''')

--- a/werkzeug/debug/__init__.py
+++ b/werkzeug/debug/__init__.py
@@ -380,7 +380,7 @@ class DebuggedApplication(object):
         return (time.time() - PIN_TIME) < int(ts)
 
     def _fail_pin_auth(self):
-        time.sleep(self._failed_pin_auth > 5 and 5.0 or 0.5)
+        time.sleep(5.0 if self._failed_pin_auth > 5 else 0.5)
         self._failed_pin_auth += 1
 
     def pin_auth(self, request):

--- a/werkzeug/debug/console.py
+++ b/werkzeug/debug/console.py
@@ -161,7 +161,7 @@ class _InteractiveConsole(code.InteractiveInterpreter):
     def runsource(self, source):
         source = source.rstrip() + '\n'
         ThreadedStream.push()
-        prompt = self.more and '... ' or '>>> '
+        prompt = '... ' if self.more else '>>> '
         try:
             source_to_eval = ''.join(self.buffer + [source])
             if code.InteractiveInterpreter.runsource(self,

--- a/werkzeug/debug/repr.py
+++ b/werkzeug/debug/repr.py
@@ -275,6 +275,6 @@ class DebugReprGenerator(object):
             html_items.append('<tr><td><em>Nothing</em>')
         return OBJECT_DUMP_HTML % {
             'title':    escape(title),
-            'repr':     repr and '<pre class=repr>%s</pre>' % repr or '',
+            'repr':     '<pre class=repr>%s</pre>' % repr if repr else '',
             'items':    '\n'.join(html_items)
         }

--- a/werkzeug/debug/tbtools.py
+++ b/werkzeug/debug/tbtools.py
@@ -330,7 +330,7 @@ class Traceback(object):
 
         for frame in self.frames:
             frames.append(u'<li%s>%s' % (
-                frame.info and u' title="%s"' % escape(frame.info) or u'',
+                u' title="%s"' % escape(frame.info) if frame.info else u'',
                 frame.render()
             ))
 
@@ -341,7 +341,7 @@ class Traceback(object):
 
         return SUMMARY_HTML % {
             'classes':      u' '.join(classes),
-            'title':        title and u'<h3>%s</h3>' % title or u'',
+            'title':        u'<h3>%s</h3>' % title if title else u'',
             'frames':       u'\n'.join(frames),
             'description':  description_wrapper % escape(self.exception)
         }
@@ -351,8 +351,8 @@ class Traceback(object):
         """Render the Full HTML page with the traceback info."""
         exc = escape(self.exception)
         return PAGE_HTML % {
-            'evalex':           evalex and 'true' or 'false',
-            'evalex_trusted':   evalex_trusted and 'true' or 'false',
+            'evalex':           'true' if evalex else 'false',
+            'evalex_trusted':   'true' if evalex_trusted else 'false',
             'console':          'false',
             'title':            exc,
             'exception':        exc,

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -741,7 +741,7 @@ class Rule(RuleFactory):
         _build_regex(domain_rule)
         regex_parts.append('\\|')
         self._trace.append((False, '|'))
-        _build_regex(self.is_leaf and self.rule or self.rule.rstrip('/'))
+        _build_regex(self.rule if self.is_leaf else self.rule.rstrip('/'))
         if not self.is_leaf:
             self._trace.append((False, '/'))
 
@@ -1182,7 +1182,7 @@ class Rule(RuleFactory):
 
         :internal:
         """
-        return self.alias and 1 or 0, -len(self.arguments), \
+        return 1 if self.alias else 0, -len(self.arguments), \
             -len(self.defaults or ())
 
     def __eq__(self, other):
@@ -1848,7 +1848,7 @@ class MapAdapter(object):
                     redirect_url = rule.redirect_to(self, **rv)
                 raise RequestRedirect(str(url_join('%s://%s%s%s' % (
                     self.url_scheme or 'http',
-                    self.subdomain and self.subdomain + '.' or '',
+                    self.subdomain + '.' if self.subdomain else '',
                     self.server_name,
                     self.script_name
                 ), redirect_url)))
@@ -1906,7 +1906,7 @@ class MapAdapter(object):
             subdomain = self.subdomain
         else:
             subdomain = to_unicode(subdomain, 'ascii')
-        return (subdomain and subdomain + u'.' or u'') + self.server_name
+        return (subdomain + u'.' if subdomain else u'') + self.server_name
 
     def get_default_redirect(self, rule, method, values, query_args):
         """A helper that returns the URL to redirect to if it finds one.

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -191,7 +191,7 @@ def generate_password_hash(password, method='pbkdf2:sha256', salt_length=8):
                    to enable PBKDF2.
     :param salt_length: the length of the salt in letters.
     """
-    salt = method != 'plain' and gen_salt(salt_length) or ''
+    salt = gen_salt(salt_length) if method != 'plain' else ''
     h, actual_method = _hash_internal(method, salt, password)
     return '%s$%s$%s' % (actual_method, salt, h)
 

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -165,7 +165,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         def shutdown_server():
             self.server.shutdown_signal = True
 
-        url_scheme = self.server.ssl_context is None and 'http' or 'https'
+        url_scheme = 'http' if self.server.ssl_context is None else 'https'
         if not self.client_address:
             self.client_address = '<local>'
         if isinstance(self.client_address, str):
@@ -818,7 +818,7 @@ def run_simple(hostname, port, application, use_reloader=False,
         application = SharedDataMiddleware(application, static_files)
 
     def log_startup(sock):
-        display_hostname = hostname not in ('', '*') and hostname or 'localhost'
+        display_hostname = hostname if hostname not in ('', '*') else 'localhost'
         quit_msg = '(Press CTRL+C to quit)'
         if sock.family is socket.AF_UNIX:
             _log('info', ' * Running on %s %s', display_hostname, quit_msg)
@@ -827,7 +827,7 @@ def run_simple(hostname, port, application, use_reloader=False,
                 display_hostname = '[%s]' % display_hostname
             port = sock.getsockname()[1]
             _log('info', ' * Running on %s://%s:%d/ %s',
-                 ssl_context is None and 'http' or 'https',
+                 'http' if ssl_context is None else 'https',
                  display_hostname, port, quit_msg)
 
     def inner():

--- a/werkzeug/testapp.py
+++ b/werkzeug/testapp.py
@@ -186,7 +186,7 @@ def render_testapp(req):
         if expanded:
             class_.append('exp')
         sys_path.append('<li%s>%s' % (
-            class_ and ' class="%s"' % ' '.join(class_) or '',
+            ' class="%s"' % ' '.join(class_) if class_ else '',
             escape(item)
         ))
 

--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -445,7 +445,7 @@ def url_parse(url, scheme=None, allow_fragments=True):
     if s('?') in url:
         url, query = url.split(s('?'), 1)
 
-    result_type = is_text_based and URL or BytesURL
+    result_type = URL if is_text_based else BytesURL
     return result_type(scheme, netloc, url, query, fragment)
 
 

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -226,7 +226,7 @@ def get_input_stream(environ, safe_fallback=True):
     # potentially dangerous because it could be infinite, malicious or not. If
     # safe_fallback is true, return an empty stream instead for safety.
     if content_length is None:
-        return safe_fallback and BytesIO() or stream
+        return BytesIO() if safe_fallback else stream
 
     # Otherwise limit the stream to the content length
     return LimitedStream(stream, content_length)


### PR DESCRIPTION
1. In many cases, ``and or`` expression act like ``if else`` expression:
* If **bool(B)** is always True, `A and B or C` is equivalent to `B if A else C` 
* While **bool(B)** is False, **B** is equivalent to **C**， then `A and B or C` is equivalent to `B if A else C` 

2. In the equivalent case，``if else`` expression is more readable than ``and or`` expression. The logic of ``and or`` expression is a little more complicated.

3. In the equivalent case, ``if else`` expression is a little faster than ``and or`` expression.

I think ``if else`` expression should be used preferentially in the equivalent case.