### PR TITLE
Import abc classes from collections.abc

### DIFF
--- a/werkzeug/_compat.py
+++ b/werkzeug/_compat.py
@@ -33,6 +33,8 @@ if PY2:
     int_to_byte = chr
     iter_bytes = iter
 
+    import collections as collections_abc
+
     exec('def reraise(tp, value, tb=None):\n raise tp, value, tb')
 
     def fix_tuple_repr(obj):
@@ -131,6 +133,8 @@ else:
 
     int_to_byte = operator.methodcaller('to_bytes', 1, 'big')
     iter_bytes = functools.partial(map, int_to_byte)
+
+    import collections.abc as collections_abc
 
     def reraise(tp, value, tb=None):
         if value.__traceback__ is not tb:

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -13,11 +13,10 @@ import codecs
 import mimetypes
 from copy import deepcopy
 from itertools import repeat
-from collections import Container, Iterable, MutableSet
 
 from werkzeug._internal import _missing
-from werkzeug._compat import BytesIO, iterkeys, itervalues, iteritems, \
-    iterlists, PY2, text_type, integer_types, string_types, \
+from werkzeug._compat import BytesIO, collections_abc, iterkeys, itervalues, \
+    iteritems, iterlists, PY2, text_type, integer_types, string_types, \
     make_literal_wrapper, to_native
 from werkzeug.filesystem import get_filesystem_encoding
 
@@ -2020,7 +2019,7 @@ class CallbackDict(UpdateDictMixin, dict):
         )
 
 
-class HeaderSet(MutableSet):
+class HeaderSet(collections_abc.MutableSet):
 
     """Similar to the :class:`ETags` class this implements a set-like structure.
     Unlike :class:`ETags` this is case insensitive and used for vary, allow, and
@@ -2174,7 +2173,7 @@ class HeaderSet(MutableSet):
         )
 
 
-class ETags(Container, Iterable):
+class ETags(collections_abc.Container, collections_abc.Iterable):
 
     """A set that can be used to check if one etag is present in a collection
     of etags.


### PR DESCRIPTION
Fixes warnings that look like this:

```
werkzeug/datastructures.py:16: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

You can replicate these warnings by running
`python -Wonce -m werkzeug.datastructures`