### PR TITLE
 Increase the number of PBKDF2 iterations to 100000

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ Unreleased
     (`#1340`_)
 -   The version of jQuery used by the debugger is updated to 3.3.1.
     (`#1390`_)
+-   In :func:`~security.generate_password_hash`, PBKDF2 uses 150000
+    iterations by default, increased from 50000. (`#1377`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -112,6 +114,7 @@ Unreleased
 .. _`#1318`: https://github.com/pallets/werkzeug/pull/1318
 .. _`#1338`: https://github.com/pallets/werkzeug/pull/1338
 .. _`#1340`: https://github.com/pallets/werkzeug/pull/1340
+.. _`#1377`: https://github.com/pallets/werkzeug/pull/1377
 .. _`#1390`: https://github.com/pallets/werkzeug/pull/1390
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -40,7 +40,7 @@ def test_safe_str_cmp_no_builtin():
 def test_password_hashing():
     hash0 = generate_password_hash('default')
     assert check_password_hash(hash0, 'default')
-    assert hash0.startswith('pbkdf2:sha256:100000$')
+    assert hash0.startswith('pbkdf2:sha256:150000$')
 
     hash1 = generate_password_hash('default', 'sha1')
     hash2 = generate_password_hash(u'default', method='sha1')

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -40,7 +40,7 @@ def test_safe_str_cmp_no_builtin():
 def test_password_hashing():
     hash0 = generate_password_hash('default')
     assert check_password_hash(hash0, 'default')
-    assert hash0.startswith('pbkdf2:sha256:50000$')
+    assert hash0.startswith('pbkdf2:sha256:100000$')
 
     hash1 = generate_password_hash('default', 'sha1')
     hash2 = generate_password_hash(u'default', method='sha1')

--- a/werkzeug/security.py
+++ b/werkzeug/security.py
@@ -21,7 +21,7 @@ from werkzeug._compat import range_type, PY2, text_type, izip, to_bytes, \
 
 
 SALT_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
-DEFAULT_PBKDF2_ITERATIONS = 50000
+DEFAULT_PBKDF2_ITERATIONS = 150000
 
 
 _pack_int = Struct('>I').pack


### PR DESCRIPTION
The number has not been changed for more than 3 years.

I propose the same number as Django uses now - 100000.