### PR TITLE
Fix system error: error return without exception set

### DIFF
--- a/werkzeug/urls.py
+++ b/werkzeug/urls.py
@@ -425,7 +425,7 @@ def url_parse(url, scheme=None, allow_fragments=True):
         # make sure "iri" is not actually a port number (in which case
         # "scheme" is really part of the path)
         rest = url[i + 1:]
-        if not rest or any(c not in s('0123456789') for c in rest):
+        if not rest or any([c not in s('0123456789') for c in rest]):
             # not a port number
             scheme, url = url[:i].lower(), rest
 


### PR DESCRIPTION
Added brackets to avoid this exception:

`Exception ignored in: <generator object url_parse.<locals>.<genexpr> at 0x7fabbc9bd990>
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/werkzeug/urls.py", line 425, in <genexpr>
    if not rest or any(c not in s('0123456789') for c in rest):
SystemError: error return without exception set`