### PR TITLE
skip cache tests since it is currently unmaintained

### DIFF
--- a/tests/contrib/cache/test_cache.py
+++ b/tests/contrib/cache/test_cache.py
@@ -55,6 +55,7 @@ class CacheTestsBase(object):
 
     @pytest.fixture
     def c(self, make_cache):
+        pytest.skip('Caching is currently unmaintained')
         """Return a cache instance."""
         return make_cache()
 


### PR DESCRIPTION
see: #1361 #1268 #1146 #1147 

Disable testing of werkzeug cache tests.