### PR TITLE
Fix Markup object repr in debug console

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ Unreleased
     (`#1340`_)
 -   The version of jQuery used by the debugger is updated to 3.3.1.
     (`#1390`_)
+-   The debugger correctly renders long ``markupsafe.Markup`` instances.
+    (`#1393`_)
 -   In :func:`~security.generate_password_hash`, PBKDF2 uses 150000
     iterations by default, increased from 50000. (`#1377`_)
 -   ``werkzeug.contrib.cache`` issues a deprecation warning. If you are
@@ -127,6 +129,7 @@ Unreleased
 .. _`#1340`: https://github.com/pallets/werkzeug/pull/1340
 .. _`#1377`: https://github.com/pallets/werkzeug/pull/1377
 .. _`#1390`: https://github.com/pallets/werkzeug/pull/1390
+.. _`#1393`: https://github.com/pallets/werkzeug/pull/1393
 
 
 Version 0.14.1

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -38,11 +38,28 @@ class TestDebugRepr(object):
         assert debug_repr('') == u'<span class="string">\'\'</span>'
         assert debug_repr('foo') == u'<span class="string">\'foo\'</span>'
         assert debug_repr('s' * 80) == u'<span class="string">\''\
-            + 's' * 70 + '<span class="extended">'\
-            + 's' * 10 + '\'</span></span>'
+            + 's' * 69 + '<span class="extended">'\
+            + 's' * 11 + '\'</span></span>'
         assert debug_repr('<' * 80) == u'<span class="string">\''\
-            + '&lt;' * 70 + '<span class="extended">'\
-            + '&lt;' * 10 + '\'</span></span>'
+            + '&lt;' * 69 + '<span class="extended">'\
+            + '&lt;' * 11 + '\'</span></span>'
+
+    def test_string_subclass_repr(self):
+        class Test(str):
+            pass
+
+        assert debug_repr(Test("foo")) == (
+            u'<span class="module">tests.test_debug.</span>'
+            u'Test(<span class="string">\'foo\'</span>)'
+        )
+
+    @pytest.mark.skipif(not PY2, reason="u prefix on py2 only")
+    def test_unicode_repr(self):
+        assert debug_repr(u"foo") == u'<span class="string">u\'foo\'</span>'
+
+    @pytest.mark.skipif(PY2, reason="b prefix on py3 only")
+    def test_bytes_repr(self):
+        assert debug_repr(b"foo") == u'<span class="string">b\'foo\'</span>'
 
     def test_sequence_repr(self):
         assert debug_repr(list(range(20))) == (

--- a/werkzeug/debug/repr.py
+++ b/werkzeug/debug/repr.py
@@ -197,7 +197,7 @@ class DebugReprGenerator(object):
             return u'<span class="help">%r</span>' % helper
         if isinstance(obj, (integer_types, float, complex)):
             return u'<span class="number">%r</span>' % obj
-        if isinstance(obj, string_types):
+        if type(obj) in string_types:
             return self.string_repr(obj)
         if isinstance(obj, RegexType):
             return self.regex_repr(obj)


### PR DESCRIPTION
The console was assuming that all objects of string type would only return a string in repr(). This meant that objects that gave response of its object type along with a string in repr were breaking parts of the code that removed the parenthesis. By verifying that an object is a string type instead of a string instance this bug can be fixed.

Fixes #1129