### PR TITLE
[Don't Merge] Debug str repr alternatives

### DIFF
--- a/werkzeug/debug/repr.py
+++ b/werkzeug/debug/repr.py
@@ -154,26 +154,23 @@ class DebugReprGenerator(object):
 
     def string_repr(self, obj, limit=70):
         buf = ['<span class="string">']
-        a = repr(obj[:limit])
-        b = repr(obj[limit:])
+        r = repr(obj)
 
-        for prefix, suffix_len in (("u", None), ("b", None), ("Markup(", -1)):
-            if a.startswith(prefix):
-                if suffix_len is None:
-                    buf.append(prefix)
-                a = a[len(prefix):suffix_len]
-                b = b[len(prefix):suffix_len]
-                break
-
-        if b != "''":
-            buf.extend(
-                (escape(a[:-1]), '<span class="extended">', escape(b[1:]), '</span>')
-            )
+        if len(r) - limit > 2:
+            buf.extend((
+                escape(r[:limit]),
+                '<span class="extended">', escape(r[limit:]), '</span>',
+            ))
         else:
-            buf.append(escape(a))
+            buf.append(escape(r))
 
         buf.append('</span>')
-        return _add_subclass_info(u''.join(buf), obj, (bytes, text_type))
+        out = u"".join(buf)
+
+        if out.startswith(("'", '"', "u", "b")):
+            return _add_subclass_info(out, obj, (bytes, text_type))
+
+        return out
 
     def dict_repr(self, d, recursive, limit=5):
         if recursive:

--- a/werkzeug/debug/repr.py
+++ b/werkzeug/debug/repr.py
@@ -197,7 +197,7 @@ class DebugReprGenerator(object):
             return u'<span class="help">%r</span>' % helper
         if isinstance(obj, (integer_types, float, complex)):
             return u'<span class="number">%r</span>' % obj
-        if isinstance(obj, string_types):
+        if type(obj) in string_types:
             return self.string_repr(obj)
         if isinstance(obj, RegexType):
             return self.regex_repr(obj)


### PR DESCRIPTION
This offers two alternatives to #1393. The solution there was to restrict string repr to strictly the string types, excluding subclasses. Making a separate PR for discussion, if we decide on one of these I'll add it to the original PR.

https://github.com/pallets/werkzeug/pull/1397/commits/5685cd6ab4268a97b7608c36aaf74efb2b8f3d7d adds "Markup(" as a recognized prefix. The debugger will remove it and not append it, since it will be handled by the subclass info. The downside is that this doesn't really solve the issue, any other string subclasses that have a non-standard repr will still look weird.

![screen shot 2018-11-16 at 07 19 01](https://user-images.githubusercontent.com/1242887/48630008-eeb0b580-e96f-11e8-89d8-2c943856559b.png)

https://github.com/pallets/werkzeug/pull/1397/commits/76320cb201c59f8f588a78bb0988cf2680c04bbb takes a different approach. Rather than truncating the obj then taking the repr, it truncates the repr. Then it only adds subclass info if the start of the repr looks like Python's standard repr, with the assumption that a non-standard prefix already distinguishes the subclass.

![screen shot 2018-11-16 at 07 18 19](https://user-images.githubusercontent.com/1242887/48630012-f2dcd300-e96f-11e8-9332-307a51e56d04.png)

Both options add support for the Python 3 "b" prefix.