### PR TITLE
Improve DebuggedApplication.get_resource so that it can return resource in zipped library.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,9 @@ Unreleased
     will be decoded as Latin-1 like values are. (`#1346`_)
 -   Server uses ``IPPROTO_TCP`` constant instead of ``SOL_TCP`` for
     Jython compatibility. (`#1375`_)
+-   The debugger can serve resources when Werkzeug is installed as a
+    zip file. ``DebuggedApplication.get_resource`` uses
+    ``pkgutil.get_data``. (`#1401`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -148,6 +151,7 @@ Unreleased
 .. _`#1390`: https://github.com/pallets/werkzeug/pull/1390
 .. _`#1393`: https://github.com/pallets/werkzeug/pull/1393
 .. _`#1395`: https://github.com/pallets/werkzeug/pull/1395
+.. _`#1401`: https://github.com/pallets/werkzeug/pull/1401
 
 
 Version 0.14.1


### PR DESCRIPTION
The current implementation is not zip-safe because `DebuggedApplication.get_resource` cannot return binary data in `shared` directory.
This changeset improves `DebuggedApplication.get_resource` so that it can return binary data in `shared` directory even if werkzeug is included in pythonXX.zip.

I know that `setup.py` sets `zip_safe` to false, but I believe that this changeset improves this library.
If you don't like this patch, please ignore it.

Regards,
Murase
