### PR TITLE
rewrite test client redirect handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,6 +116,21 @@ Unreleased
     versions of Lighttpd. ``LighttpdCGIRootFix`` was renamed to
     ``CGIRootFix`` in 0.9. The old name emits a deprecation warning and
     will be removed in the next version. (`#1141`_)
+-   The test :class:`~test.Client` redirect handling is rewritten.
+    (`#1402`_)
+
+    -   The redirect environ is copied from the initial request environ.
+    -   Script root and path are correctly distinguished when
+        redirecting to a path under the root.
+    -   The HEAD method is not changed to GET.
+    -   307 and 308 codes preserve the method and body. All others
+        ignore the body and related headers.
+    -   Headers are passed to the new request for all codes, following
+        what browsers do.
+    -   :class:`~test.EnvironBuilder` sets the content type and length
+        headers in addition to the WSGI keys when detecting them from
+        the data.
+
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -164,6 +179,7 @@ Unreleased
 .. _`#1393`: https://github.com/pallets/werkzeug/pull/1393
 .. _`#1395`: https://github.com/pallets/werkzeug/pull/1395
 .. _`#1401`: https://github.com/pallets/werkzeug/pull/1401
+.. _`#1402`: https://github.com/pallets/werkzeug/pull/1402
 
 
 Version 0.14.1

--- a/werkzeug/http.py
+++ b/werkzeug/http.py
@@ -121,6 +121,7 @@ HTTP_STATUS_CODES = {
     304:    'Not Modified',
     305:    'Use Proxy',
     307:    'Temporary Redirect',
+    308:    'Permanent Redirect',
     400:    'Bad Request',
     401:    'Unauthorized',
     402:    'Payment Required',     # unused


### PR DESCRIPTION
* `EnvironBuilder.from_environ` creates a builder from an existing environ. The previous code was passing `EnvironBuilder(environ)`, but that doesn't mean anything to `__init__`.
* Redirect environ is initialized from initial environ and passed to `open`, rather than passing only some args to `open`.
* Script root and path are correctly distinguished. The root is preserved from the initial environ, stripped from the location, or cleared if the location is not under the root. Fixes #382 
* HEAD method is not changed to GET.
* Headers are passed to new request for all codes. There's nothing for or against passing them in the RFC, but Chrome, Firefox, and Requests all do this. Fixes #1151 
* Body and relevant headers are dropped except for 307 and 308. Previously the client would never pass on the body, it would only preserve the method for 307.
* 1EnvironBuilder.get_environ` sets content type and length headers in addition to WSGI keys when detecting from data.
* Better error message when disallowing domain redirects. Distinguishes between "subdomains aren't enabled" and "can't go to external host."
* Test client recognizes 308 code.
* Add 308 to http codes.