### PR TITLE
Fix spooled temporary file exceptions on file upload

### DIFF
--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -144,7 +144,6 @@ class TestFormParser(object):
         assert hasattr(foo, u'fileno')
         # make sure the file object has the bellow attributes as described in
         # https://github.com/pallets/werkzeug/issues/1344
-        assert hasattr(foo, u'writable')
         assert hasattr(foo, u'readable')
         assert hasattr(foo, u'seekable')
 
@@ -160,7 +159,6 @@ class TestFormParser(object):
         foo = req.files['foo'].stream
         # Make sure the file object has the bellow attributes as described in
         # https://github.com/pallets/werkzeug/issues/1344
-        assert hasattr(foo, u'writable')
         assert hasattr(foo, u'readable')
         assert hasattr(foo, u'seekable')
         # close file to prevent fds from leaking

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -152,7 +152,7 @@ class TestFormParser(object):
         req.files['foo'].close()
 
     def test_small_file(self):
-        # when the file object size is below the "max_size", this will implement
+        # when the data's length is below the "max_size", this will implement
         # an in-memory buffer
         data = b'x' * 256
         req = Request.from_values(data={'foo': (BytesIO(data), 'test.txt')},

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -138,9 +138,16 @@ class TestFormParser(object):
         data = b'x' * (1024 * 600)
         req = Request.from_values(data={'foo': (BytesIO(data), 'test.txt')},
                                   method='POST')
+        foo = req.files['foo'].stream
         # make sure we have a real file here, because we expect to be
         # on the disk.  > 1024 * 500
-        assert hasattr(req.files['foo'].stream, u'fileno')
+        assert hasattr(foo, u'fileno')
+        # make sure the file object has the bellow attributes as described in
+        # https://github.com/pallets/werkzeug/issues/1344
+        assert hasattr(foo, u'writable')
+        assert hasattr(foo, u'readable')
+        assert hasattr(foo, u'seekable')
+
         # close file to prevent fds from leaking
         req.files['foo'].close()
 

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -151,6 +151,21 @@ class TestFormParser(object):
         # close file to prevent fds from leaking
         req.files['foo'].close()
 
+    def test_small_file(self):
+        # when the file object size is below the "max_size", this will implement
+        # an in-memory buffer
+        data = b'x' * 256
+        req = Request.from_values(data={'foo': (BytesIO(data), 'test.txt')},
+                                  method='POST')
+        foo = req.files['foo'].stream
+        # Make sure the file object has the bellow attributes as described in
+        # https://github.com/pallets/werkzeug/issues/1344
+        assert hasattr(foo, u'writable')
+        assert hasattr(foo, u'readable')
+        assert hasattr(foo, u'seekable')
+        # close file to prevent fds from leaking
+        req.files['foo'].close()
+
     def test_streaming_parse(self):
         data = b'x' * (1024 * 600)
 

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -12,13 +12,7 @@
 import re
 import codecs
 
-# there are some platforms where SpooledTemporaryFile is not available.
-# In that case we need to provide a fallback.
-try:
-    from tempfile import SpooledTemporaryFile
-except ImportError:
-    from tempfile import TemporaryFile
-    SpooledTemporaryFile = None
+from tempfile import TemporaryFile
 
 from itertools import chain, repeat, tee
 from functools import update_wrapper
@@ -45,9 +39,10 @@ _supported_multipart_encodings = frozenset(['base64', 'quoted-printable'])
 def default_stream_factory(total_content_length, filename, content_type,
                            content_length=None):
     """The stream factory that is used per default."""
+
+    # Would be nice to implement `SpooledTemporaryFile`, however as of python 3.7,
+    # it has a bug as described - https://github.com/pallets/werkzeug/issues/1344
     max_size = 1024 * 500
-    if SpooledTemporaryFile is not None:
-        return SpooledTemporaryFile(max_size=max_size, mode='wb+')
     if total_content_length is None or total_content_length > max_size:
         return TemporaryFile('wb+')
     return BytesIO()


### PR DESCRIPTION
Reverted implementation of [SpooledTemporaryFile](https://docs.python.org/3/library/tempfile.html#tempfile.SpooledTemporaryFile) to prior behaviour due to bug as described in https://bugs.python.org/issue26175

Resolves: #1344 