### PR TITLE
Decorrelate Werkzeug's logger level setup from the presence of existing handlers

### DIFF
--- a/werkzeug/_internal.py
+++ b/werkzeug/_internal.py
@@ -78,10 +78,11 @@ def _log(type, message, *args, **kwargs):
     if _logger is None:
         import logging
         _logger = logging.getLogger('werkzeug')
+        if _logger.level == logging.NOTSET:
+            _logger.setLevel(logging.INFO)
         # Only set up a default log handler if the
         # end-user application didn't set anything up.
-        if not logging.root.handlers and _logger.level == logging.NOTSET:
-            _logger.setLevel(logging.INFO)
+        if not logging.root.handlers:
             handler = logging.StreamHandler()
             _logger.addHandler(handler)
     getattr(_logger, type)(message.rstrip(), *args, **kwargs)


### PR DESCRIPTION
For the rationale, see: https://github.com/pallets/flask/issues/2998