### PR TITLE
fix spooled temporary file exceptions on file upload - 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,6 +141,11 @@ Unreleased
     ``/jump/<int(signed=True):count>``. (`#1355`_)
 -   :class:`~datastructures.Range` validates that list of range tuples
     passed to it would produce a valid ``Range`` header. (`#1412`_)
+-   :class:`~datastructures.FileStorage` looks up attributes on
+    ``stream._file`` if they don't exist on ``stream``, working around
+    an issue where :func:`tempfile.SpooledTemporaryFile` didn't
+    implement all of :class:`io.IOBase`. See
+    https://github.com/python/cpython/pull/3249. (`#1409`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -193,6 +198,7 @@ Unreleased
 .. _`#1401`: https://github.com/pallets/werkzeug/pull/1401
 .. _`#1402`: https://github.com/pallets/werkzeug/pull/1402
 .. _#1404: https://github.com/pallets/werkzeug/pull/1404
+.. _#1409: https://github.com/pallets/werkzeug/pull/1409
 .. _#1412: https://github.com/pallets/werkzeug/pull/1412
 
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -885,8 +885,8 @@ def make_call_asserter(func=None):
 
     >>> assert_calls, func = make_call_asserter()
     >>> with assert_calls(2):
-            func()
-            func()
+    ...    func()
+    ...    func()
     """
 
     calls = [0]
@@ -1067,6 +1067,19 @@ class TestFileStorage(object):
         for idx, line in enumerate(binary_storage):
             assert idx < 2
         assert idx == 1
+
+    @pytest.mark.skipif(PY2, reason='io "File Objects" are only available in PY3.')
+    @pytest.mark.parametrize(
+        "attributes", (
+            # make sure the file object has the bellow attributes as described
+            # in https://github.com/pallets/werkzeug/issues/1344
+            "writable", "readable", "seekable"
+        )
+    )
+    def test_proxy_can_access_stream_attrs(self, attributes):
+        from tempfile import SpooledTemporaryFile
+        file_storage = self.storage_class(stream=SpooledTemporaryFile())
+        assert hasattr(file_storage, attributes)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -10,6 +10,8 @@
 """
 from __future__ import with_statement
 
+import csv
+import io
 import pytest
 
 from os.path import join, dirname
@@ -134,44 +136,32 @@ class TestFormParser(object):
         strict_eq(len(form), 0)
         strict_eq(len(files), 0)
 
-    @pytest.mark.skipif(PY2, reason='io "File Objects" are only available in PY3.')
     @pytest.mark.parametrize(
-        "attributes", (
-            # make sure we have a real file here, because we expect to be
-            # on the disk.  > 1024 * 500
-            "fileno",
-            # Make sure the file object has the bellow attributes as described
-            # in https://github.com/pallets/werkzeug/issues/1344
-            "writable", "readable", "seekable"
-        )
+        ("no_spooled", "size"),
+        ((False, 100), (False, 3000), (True, 100), (True, 3000)),
     )
-    def test_large_file(self, attributes):
-        data = b'x' * (1024 * 600)
-        req = Request.from_values(data={'foo': (BytesIO(data), 'test.txt')},
-                                  method='POST')
-        file_storage = req.files['foo']
-        assert hasattr(file_storage, attributes)
-        # close file to prevent fds from leaking
-        req.files['foo'].close()
+    def test_default_stream_factory(self, no_spooled, size, monkeypatch):
+        if no_spooled:
+            monkeypatch.setattr("werkzeug.formparser.SpooledTemporaryFile", None)
 
-    @pytest.mark.skipif(PY2, reason='io "File Objects" are only available in PY3.')
-    @pytest.mark.parametrize(
-        "attributes", (
-            # Make sure the file object has the bellow attributes as described
-            # in https://github.com/pallets/werkzeug/issues/1344
-            "writable", "readable", "seekable"
+        data = b"a,b,c\n" * size
+        req = Request.from_values(
+            data={"foo": (BytesIO(data), "test.txt")},
+            method="POST"
         )
-    )
-    def test_small_file(self, attributes):
-        # when the data's length is below the "max_size", this will implement
-        # an in-memory buffer
-        data = b'x' * 256
-        req = Request.from_values(data={'foo': (BytesIO(data), 'test.txt')},
-                                  method='POST')
-        file_storage = req.files['foo']
-        assert hasattr(file_storage, attributes)
-        # close file to prevent fds from leaking
-        req.files['foo'].close()
+        file_storage = req.files["foo"]
+
+        try:
+            if PY2:
+                reader = csv.reader(file_storage)
+            else:
+                reader = csv.reader(io.TextIOWrapper(file_storage))
+            # This fails if file_storage doesn't implement IOBase.
+            # https://github.com/pallets/werkzeug/issues/1344
+            # https://github.com/python/cpython/pull/3249
+            assert sum(1 for _ in reader) == size
+        finally:
+            file_storage.close()
 
     def test_streaming_parse(self):
         data = b'x' * (1024 * 600)

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2758,6 +2758,9 @@ class FileStorage(object):
         try:
             return getattr(self.stream, name)
         except AttributeError:
+            # SpooledTemporaryFile doesn't implement IOBase, get the
+            # attribute from its backing file instead.
+            # https://github.com/python/cpython/pull/3249
             if hasattr(self.stream, "_file"):
                 return getattr(self.stream._file, name)
             raise

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2755,7 +2755,12 @@ class FileStorage(object):
     __bool__ = __nonzero__
 
     def __getattr__(self, name):
-        return getattr(self.stream, name)
+        try:
+            return getattr(self.stream, name)
+        except AttributeError:
+            if hasattr(self.stream, "_file"):
+                return getattr(self.stream._file, name)
+            raise
 
     def __iter__(self):
         return iter(self.stream)


### PR DESCRIPTION
Changed behaviour of `FileStorage.__getattr__` so that when there is an exception `AttributeError`  to attempt to call the `FileStorage.stream._file.{attr}` if it exists

Resolves: #1344 