### PR TITLE
make header __delitem__ signatures compatible

### DIFF
--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1301,7 +1301,7 @@ class ImmutableHeadersMixin(object):
     :private:
     """
 
-    def __delitem__(self, key):
+    def __delitem__(self, key, **kwargs):
         is_immutable(self)
 
     def __setitem__(self, key, value):


### PR DESCRIPTION
Closes #1051 

`Headers.__delitem__` takes an internal kwargs for switching behavior based on the calling operation. `ImmutableHeadersMixin.__delitem__` signature needs to match, even though it's a no-op.