### PR TITLE
validate ranges passed to Range datastructure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,8 @@ Unreleased
 -   ``int`` and ``float`` converters in URL rules will handle negative
     values if passed the ``signed=True`` parameter. For example,
     ``/jump/<int(signed=True):count>``. (`#1355`_)
+-   :class:`~datastructures.Range` validates that list of range tuples
+    passed to it would produce a valid ``Range`` header. (`#1412`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -191,6 +193,7 @@ Unreleased
 .. _`#1401`: https://github.com/pallets/werkzeug/pull/1401
 .. _`#1402`: https://github.com/pallets/werkzeug/pull/1402
 .. _#1404: https://github.com/pallets/werkzeug/pull/1404
+.. _#1412: https://github.com/pallets/werkzeug/pull/1412
 
 
 Version 0.14.1

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -551,16 +551,16 @@ class TestRange(object):
         rv = http.parse_range_header('bytes=-')
         assert rv is None
 
-        rv = http.parse_range_header('bytes=bullshit')
+        rv = http.parse_range_header('bytes=bad')
         assert rv is None
 
-        rv = http.parse_range_header('bytes=bullshit-1')
+        rv = http.parse_range_header('bytes=bad-1')
         assert rv is None
 
-        rv = http.parse_range_header('bytes=-bullshit')
+        rv = http.parse_range_header('bytes=-bad')
         assert rv is None
 
-        rv = http.parse_range_header('bytes=52-99, bullshit')
+        rv = http.parse_range_header('bytes=52-99, bad')
         assert rv is None
 
     def test_content_range_parsing(self):

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -2296,10 +2296,14 @@ class IfRange(object):
 
 
 class Range(object):
-
-    """Represents a range header.  All the methods are only supporting bytes
-    as unit.  It does store multiple ranges but :meth:`range_for_length` will
+    """Represents a ``Range`` header. All methods only support only
+    bytes as the unit. Stores a list of ranges if given, but the methods
     only work if only one range is provided.
+
+    :raise ValueError: If the ranges provided are invalid.
+
+    .. versionchanged:: 0.15
+        The ranges passed in are validated.
 
     .. versionadded:: 0.7
     """
@@ -2310,6 +2314,10 @@ class Range(object):
         #: A list of ``(begin, end)`` tuples for the range header provided.
         #: The ranges are non-inclusive.
         self.ranges = ranges
+
+        for start, end in ranges:
+            if start is None or (end is not None and (start < 0 or start >= end)):
+                raise ValueError("{} is not a valid range.".format((start, end)))
 
     def range_for_length(self, length):
         """If the range is for bytes, the length is not None and there is


### PR DESCRIPTION
Closes #1103 

Does some simple validation to ensure the ranges passed to `Range` will produce a valid header.