### PR TITLE
ProxyFix may trust wrong number of values for X-Forwarded-Prefix

### DIFF
--- a/tests/contrib/test_fixers.py
+++ b/tests/contrib/test_fixers.py
@@ -121,7 +121,13 @@ class TestServerFixer(object):
             'REMOTE_ADDR': '192.168.0.1',
             'HTTP_HOST': 'spam',
             'HTTP_X_FORWARDED_FOR': ', 192.168.0.3'
-        }, 'http://spam/', id='ignore empty')
+        }, 'http://spam/', id='ignore empty'),
+        pytest.param({'x_for': 2, 'x_prefix': 1}, {
+            'REMOTE_ADDR': '192.168.0.2',
+            'HTTP_HOST': 'spam',
+            'HTTP_X_FORWARDED_FOR': '192.168.0.1, 192.168.0.3',
+            'HTTP_X_FORWARDED_PREFIX': '/ham, /eggs',
+        }, 'http://spam/eggs/', id='prefix < for')
     ))
     def test_proxy_fix_new(self, kwargs, base, url_root):
         @Request.application

--- a/werkzeug/contrib/fixers.py
+++ b/werkzeug/contrib/fixers.py
@@ -269,7 +269,7 @@ class ProxyFix(object):
             environ['SERVER_PORT'] = x_port
 
         x_prefix = self._get_trusted_comma(
-            self.x_for, environ_get('HTTP_X_FORWARDED_PREFIX'))
+            self.x_prefix, environ_get('HTTP_X_FORWARDED_PREFIX'))
         if x_prefix:
             environ['SCRIPT_NAME'] = x_prefix
 


### PR DESCRIPTION
Fixes #1414 and adds a test.