### PR TITLE
reloader uses "-m" instead of file if possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,10 @@ Unreleased
     to try ``pickle`` if ``json`` fails. (`#1413`_)
 -   The debugger and server log support Python 3's chained exceptions.
     (`#1396`_)
+-   Fix an issue where ``sys.path`` would change between reloads when
+    running with ``python -m app``. The reloader can detect that a
+    module was run with "-m" and reconstructs that instead of the file
+    path in ``sys.argv`` when reloading. (`#1416`_)
 
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -209,6 +213,7 @@ Unreleased
 .. _#1409: https://github.com/pallets/werkzeug/pull/1409
 .. _#1412: https://github.com/pallets/werkzeug/pull/1412
 .. _#1413: https://github.com/pallets/werkzeug/pull/1413
+.. _#1416: https://github.com/pallets/werkzeug/pull/1416
 
 
 Version 0.14.1

--- a/werkzeug/_reloader.py
+++ b/werkzeug/_reloader.py
@@ -65,22 +65,50 @@ def _get_args_for_reloading():
     """
     rv = [sys.executable]
     py_script = os.path.abspath(sys.argv[0])
+    args = sys.argv[1:]
+    # Need to look at main module to determine how it was executed.
+    __main__ = sys.modules["__main__"]
 
-    if os.name == 'nt' and not os.path.exists(py_script) and \
-       os.path.exists(py_script + '.exe'):
-        py_script += '.exe'
+    if __main__.__package__ is None:
+        # Executed a file, like "python app.py".
+        if (
+            os.name == "nt"
+            and not os.path.exists(py_script)
+            and os.path.exists(py_script + ".exe")
+        ):
+            # Windows entry points have "exe" extension.
+            py_script += ".exe"
 
-    windows_workaround = (
-        os.path.splitext(rv[0])[1] == '.exe'
-        and os.path.splitext(py_script)[1] == '.exe'
-    )
-    nix_workaround = os.path.isfile(py_script) and os.access(py_script, os.X_OK)
+        is_windows_exe = (
+            os.path.splitext(rv[0])[1] == ".exe"
+            and os.path.splitext(py_script)[1] == ".exe"
+        )
+        # The file is marked as executable. Nix adds a wrapper that
+        # needs to be called directly.
+        is_nix_exe = os.path.isfile(py_script) and os.access(py_script, os.X_OK)
 
-    if windows_workaround or nix_workaround:
-        rv.pop(0)
+        if is_windows_exe or is_nix_exe:
+            # The file will be executed without "python ...".
+            rv.pop(0)
 
-    rv.append(py_script)
-    rv.extend(sys.argv[1:])
+        rv.append(py_script)
+    else:
+        # Executed a module, like "python -m werkzeug.serving".
+        if sys.argv[0] == "-m":
+            # Flask works around previous behavior by putting
+            # "-m flask" in sys.argv.
+            # TODO remove this once Flask no longer misbehaves
+            args = sys.argv
+        else:
+            py_module = __main__.__package__
+            name = os.path.splitext(os.path.basename(py_script))[0]
+
+            if name != "__main__":
+                py_module += "." + name
+
+            rv.extend(("-m", py_module))
+
+    rv.extend(args)
     return rv
 
 


### PR DESCRIPTION
Unfortunately, Python doesn't make the fact that it was run as `python -m module` available, it replaces `-m module` with the path to the module in `sys.argv`. However, Python also has different behavior for `python -m module` vs `python file.py`: running a file adds its directory to `sys.path`. When the reloader was run with `python -m werkzeug.serving`, it would end up calling `python /path/to/werkzeug/serving.py` on reload, which added `/path/to/werkzeug` to `sys.path`. This caused import conflicts with module names in Werkzeug shadowing builtins.

To determine if `-m` was used, I looked at `__main__.__package__`. For all the cases I could think of, it seems that if that's not `None`, then it was run as `-m`, otherwise it was run as a file. If we're running as `-m`, then the module name can be reconstructed by appending the name of the file in `sys.argv[0]` to `__main__.__package__`.

This includes a workaround for Flask's workaround of the previous behavior. Flask currently replaces `sys.argv[0:0]` with `["-m", "flask"]`. If Werkzeug sees `"-m"` as the first arg it assumes the command line is already correct. This can be removed once Flask depends on the next version of Werkzeug.

I tested every combination I could think of on Python 3 and 2:

* `python app.py`
* `python -m app`
    * As a module and as a package with `__main__.py`.
* `python -m app.cli`
    * As a module and as a subpackage with `__main__.py`.
* `python -m werkzeug.serving`
    * Also with Werkzeug installed as a zip file (egg). (Yes, it's not supported, but still.)
* `python -m flask run`
* `flask run`