### PR TITLE
Rfc2231 parameter continuation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,6 +176,9 @@ Unreleased
     -   ``testtools`` is removed. It did not offer significant benefit
         over the default test client.
 
+-   :func:`~http.parse_options_header` understands :rfc:`2231` parameter
+    continuations. (`#1417`_)
+
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
 .. _`#609`: https://github.com/pallets/werkzeug/pull/609
@@ -233,6 +236,7 @@ Unreleased
 .. _#1412: https://github.com/pallets/werkzeug/pull/1412
 .. _#1413: https://github.com/pallets/werkzeug/pull/1413
 .. _#1416: https://github.com/pallets/werkzeug/pull/1416
+.. _#1417: https://github.com/pallets/werkzeug/pull/1417
 
 
 Version 0.14.1

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -443,26 +443,23 @@ class TestMultiPartParser(object):
 
     def test_file_rfc2231_filename_continuations(self):
         data = (
-            b'--foo\r\n'
-            b'Content-Type: text/plain; charset=utf-8\r\n'
-            b'Content-Disposition: form-data; name="rfc2231_filename";\r\n'
-            b"	filename*0*=us-ascii'en'word01%20word02%20word03%20;\r\n"
-            b"	filename*1*=word04%20word05%20word06%20word07%20word08%20;\r\n"
-            b"	filename*2*=word09%20word10%20word11%20word12%20word13%20;\r\n"
-            b"	filename*3*=word14%20word15%20word16%20word17.txt\r\n\r\n"
-            b'file contents\r\n--foo--'
+            b"--foo\r\n"
+            b"Content-Type: text/plain; charset=utf-8\r\n"
+            b'Content-Disposition: form-data; name=rfc2231;\r\n'
+            b"	filename*0*=ascii''a%20b%20;\r\n"
+            b"	filename*1*=c%20d%20;\r\n"
+            b'	filename*2="e f.txt"\r\n\r\n'
+            b"file contents\r\n--foo--"
         )
+        request = Request.from_values(
+            input_stream=BytesIO(data),
+            content_length=len(data),
+            content_type="multipart/form-data; boundary=foo",
+            method="POST"
+        )
+        assert request.files["rfc2231"].filename == "a b c d e f.txt"
+        assert request.files["rfc2231"].read() == b"file contents"
 
-        data = Request.from_values(input_stream=BytesIO(data),
-                                   content_length=len(data),
-                                   content_type='multipart/form-data; boundary=foo',
-                                   method='POST')
-        self.assert_equal(data.files['rfc2231_filename'].filename, '"word01'
-                          + ' word02 word03 word04 word05 word06 word07 word08'
-                          + ' word09 word10 word11 word12 word13 word14 word15'
-                          + ' word16 word17.txt"')
-        self.assert_strict_equal(data.files['rfc2231_filename'].read(),
-                                 b'file contents')
 
 class TestInternalFunctions(object):
 

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -441,6 +441,28 @@ class TestMultiPartParser(object):
         assert parser.stream_factory is stream_factory
         assert parser.cls is dict
 
+    def test_file_rfc2231_filename_continuations(self):
+        data = (
+            b'--foo\r\n'
+            b'Content-Type: text/plain; charset=utf-8\r\n'
+            b'Content-Disposition: form-data; name="rfc2231_filename";\r\n'
+            b"	filename*0*=us-ascii'en'word01%20word02%20word03%20;\r\n"
+            b"	filename*1*=word04%20word05%20word06%20word07%20word08%20;\r\n"
+            b"	filename*2*=word09%20word10%20word11%20word12%20word13%20;\r\n"
+            b"	filename*3*=word14%20word15%20word16%20word17.txt\r\n\r\n"
+            b'file contents\r\n--foo--'
+        )
+
+        data = Request.from_values(input_stream=BytesIO(data),
+                                   content_length=len(data),
+                                   content_type='multipart/form-data; boundary=foo',
+                                   method='POST')
+        self.assert_equal(data.files['rfc2231_filename'].filename, '"word01'
+                          + ' word02 word03 word04 word05 word06 word07 word08'
+                          + ' word09 word10 word11 word12 word13 word14 word15'
+                          + ' word16 word17.txt"')
+        self.assert_strict_equal(data.files['rfc2231_filename'].read(),
+                                 b'file contents')
 
 class TestInternalFunctions(object):
 

--- a/werkzeug/formparser.py
+++ b/werkzeug/formparser.py
@@ -415,26 +415,6 @@ class MultiPartParser(object):
             name = extra.get('name')
             filename = extra.get('filename')
 
-            # we can deal with continuation lines for filename
-            # according to RFC 2231.
-            # See <a href="http://tools.ietf.org/html/rfc2231">RFC 2231</a>
-            # for details.
-            if filename is None:
-                rfc2231_filename_continuations = [('form-data', '')]
-                # deal with up to 10 filename continuations.
-                for x in range(10):
-                    filename_part = extra.get('filename*%d*' % x)
-                    if filename_part is not None:
-                        rfc2231_filename_continuations.append(
-                            ('filename*%d*' % x, filename_part))
-                if len(rfc2231_filename_continuations) > 1:
-                    from email.utils import decode_params
-                    # 'decode_params' returns a list of tuples like,
-                    # [('form-data', ''),
-                    #  ('filename', ('us-ascii', '', '"foo.txt"'))]
-                    params = decode_params(rfc2231_filename_continuations)
-                    filename = params[1][1][2]
-
             # if no content type is given we stream into memory.  A list is
             # used as a temporary container.
             if filename is None:


### PR DESCRIPTION
Continues, closes #549

Previous PR only supported a fixed number of continuations in the filename parameter during form parsing. This moves continuation handling to `parse_options_header`, so any header and option will support continuations.

The RFC says that only the first line needs to specify an encoding, and the other lines should inherit it. We keep track of the encoding, but allow any continuation to change it, since it shouldn't really affect anything.

Each continuation has an index, but the RFC says they should only come in sequential order without gaps, so the index is ignored and the values are appended in the order they're seen.