### PR TITLE
Catch ConnectionError instead of socket.error on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,6 +178,9 @@ Unreleased
 
 -   :func:`~http.parse_options_header` understands :rfc:`2231` parameter
     continuations. (`#1417`_)
+-   The development server recognizes ``ConnectionError`` on Python 3 to
+    silence client disconnects, and does not silence other ``OSErrors``
+    that may have been raised inside the application. (`#1418`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -237,6 +240,7 @@ Unreleased
 .. _#1413: https://github.com/pallets/werkzeug/pull/1413
 .. _#1416: https://github.com/pallets/werkzeug/pull/1416
 .. _#1417: https://github.com/pallets/werkzeug/pull/1417
+.. _#1418: https://github.com/pallets/werkzeug/pull/1418
 
 
 Version 0.14.1


### PR DESCRIPTION
PEP 3151 made `socket.error` an alias of `OSError` on Python 3. Our server was catching `socket.error` to silence client disconnects (and any other socket-related errors), but on Python 3 this silences all `OSErrors`.

I'm not clear why `socket.error` is an alias for `OSError` instead of `ConnectionError`. If that were the case, the code would have worked correctly without change. [This section in PEP 3151](https://www.python.org/dev/peps/pep-3151/#new-exception-classes) seems to imply the same.

This change catches `ConnectionError` on Python 3, and continues to catch `socket.error` on Python 2. Additionally, `handle_error` also checks for socket errors, since they weren't completely silenced on Python 2.

Closes #1127 