### PR TITLE
add REQUEST_URI and RAW_REQUEST to environ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,10 @@ Unreleased
 -   The development server recognizes ``ConnectionError`` on Python 3 to
     silence client disconnects, and does not silence other ``OSErrors``
     that may have been raised inside the application. (`#1418`_)
+-   The environ keys ``REQUEST_URI`` and ``RAW_URI`` contain the raw
+    path before it was percent-decoded. This is non-standard, but many
+    WSGI servers add them. Middleware could replace ``PATH_INFO`` with
+    this to route based on the raw value. (`#1419`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -241,6 +245,7 @@ Unreleased
 .. _#1416: https://github.com/pallets/werkzeug/pull/1416
 .. _#1417: https://github.com/pallets/werkzeug/pull/1417
 .. _#1418: https://github.com/pallets/werkzeug/pull/1418
+.. _#1419: https://github.com/pallets/werkzeug/pull/1419
 
 
 Version 0.14.1

--- a/docs/wsgi.rst
+++ b/docs/wsgi.rst
@@ -96,3 +96,26 @@ step. All high level interfaces in Werkzeug will apply the encoding and
 decoding as necessary.
 
 .. _PEP 3333: https://www.python.org/dev/peps/pep-3333/#unicode-issues
+
+
+Raw Request URI and Path Encoding
+---------------------------------
+
+The ``PATH_INFO`` in the environ is the path value after
+percent-decoding. For example, the raw path ``/hello%2fworld`` would
+show up from the WSGI server to Werkzeug as ``/hello/world``. This loses
+the information that the slash was a raw character as opposed to a path
+separator.
+
+The WSGI specification (`PEP 3333`_) does not provide a way to get the
+original value, so it is impossible to route some types of data in the
+path. The most compatible way to work around this is to send problematic
+data in the query string instead of the path.
+
+However, many WSGI servers add a non-standard environ key with the raw
+path. To match this behavior, Werkzeug's test client and development
+server will add the raw value to both the ``REQUEST_URI`` and
+``RAW_URI`` keys. If you want to route based on this value, you can use
+middleware to replace ``PATH_INFO`` in the environ before it reaches the
+application. However, keep in mind that these keys are non-standard and
+not guaranteed to be present.

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -756,3 +756,16 @@ def test_content_type():
 
     resp = client.get('/', data=b'testing', mimetype='application/octet-stream')
     strict_eq(resp.data, b'application/octet-stream')
+
+
+def test_raw_request_uri():
+    @Request.application
+    def app(request):
+        path_info = request.path
+        request_uri = request.environ["REQUEST_URI"]
+        return Response("\n".join((path_info, request_uri)))
+
+    client = Client(app, Response)
+    response = client.get("/hello%2fworld")
+    data = response.get_data(as_text=True)
+    assert data == "/hello/world\n/hello%2fworld"

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -202,6 +202,10 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             'SCRIPT_NAME':          '',
             'PATH_INFO':            wsgi_encoding_dance(path_info),
             'QUERY_STRING':         wsgi_encoding_dance(request_url.query),
+            # Non-standard, added by mod_wsgi, uWSGI
+            "REQUEST_URI": wsgi_encoding_dance(self.path),
+            # Non-standard, added by gunicorn
+            "RAW_URI": wsgi_encoding_dance(self.path),
             'REMOTE_ADDR':          self.address_string(),
             'REMOTE_PORT':          self.port_integer(),
             'SERVER_NAME':          self.server.server_address[0],

--- a/werkzeug/test.py
+++ b/werkzeug/test.py
@@ -288,6 +288,11 @@ class EnvironBuilder(object):
     .. versionadded:: 0.15
         The ``json`` param and :meth:`json_dumps` method.
 
+    .. versionadded:: 0.15
+        The environ has keys ``REQUEST_URI`` and ``RAW_URI`` containing
+        the path before perecent-decoding. This is not part of the WSGI
+        PEP, but many WSGI servers include it.
+
     .. versionchanged:: 0.6
        ``path`` and ``base_url`` can now be unicode strings that are
        encoded with :func:`iri_to_uri`.
@@ -676,6 +681,10 @@ class EnvironBuilder(object):
             'SCRIPT_NAME':          _path_encode(self.script_root),
             'PATH_INFO':            _path_encode(self.path),
             'QUERY_STRING':         qs,
+            # Non-standard, added by mod_wsgi, uWSGI
+            "REQUEST_URI": wsgi_encoding_dance(self.path),
+            # Non-standard, added by gunicorn
+            "RAW_URI": wsgi_encoding_dance(self.path),
             'SERVER_NAME':          self.server_name,
             'SERVER_PORT':          str(self.server_port),
             'HTTP_HOST':            self.host,


### PR DESCRIPTION
These non-standard but commonly implemented keys contain the raw request URI before percent-decoding. Gunicorn adds `RAW_URI`, mod_wsgi and uWSGI add `REQUEST_URI`. The development server and test client will add these keys, but nothing else is done with it. If you want to route based on this, you'll need to write some middleware to replace `PATH_INFO`.

Closes #766 