### PR TITLE
mutable CombinedMultiDict.copy()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,6 +189,10 @@ Unreleased
     path before it was percent-decoded. This is non-standard, but many
     WSGI servers add them. Middleware could replace ``PATH_INFO`` with
     this to route based on the raw value. (`#1419`_)
+-   :meth:`CombinedMultiDict.copy() <datastructures.CombinedMultiDict
+    .copy>` returns a shallow mutable copy as a :class:`~datastructures.
+    MultiDict`. The copy no longer reflects changes to the combined
+    dicts, but is more generally useful. (`#1420`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -251,6 +255,7 @@ Unreleased
 .. _#1417: https://github.com/pallets/werkzeug/pull/1417
 .. _#1418: https://github.com/pallets/werkzeug/pull/1418
 .. _#1419: https://github.com/pallets/werkzeug/pull/1419
+.. _#1420: https://github.com/pallets/werkzeug/pull/1420
 
 
 Version 0.14.1

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -613,10 +613,9 @@ class TestCombinedMultiDict(object):
         with pytest.raises(TypeError):
             d['foo'] = 'blub'
 
-        # copies are immutable
+        # copies are mutable
         d = d.copy()
-        with pytest.raises(TypeError):
-            d['foo'] = 'blub'
+        d['foo'] = 'blub'
 
         # make sure lists merges
         md1 = datastructures.MultiDict((("foo", "bar"),))

--- a/werkzeug/datastructures.py
+++ b/werkzeug/datastructures.py
@@ -1478,8 +1478,16 @@ class CombinedMultiDict(ImmutableMultiDictMixin, MultiDict):
         return (x[1] for x in self.lists())
 
     def copy(self):
-        """Return a shallow copy of this object."""
-        return self.__class__(self.dicts[:])
+        """Return a shallow mutable copy of this object.
+
+        This returns a :class:`MultiDict` representing the data at the
+        time of copying. The copy will no longer reflect changes to the
+        wrapped dicts.
+
+        .. versionchanged:: 0.15
+            Return a mutable :class:`MultiDict`.
+        """
+        return MultiDict(self)
 
     def to_dict(self, flat=True):
         """Return the contents as regular dict.  If `flat` is `True` the


### PR DESCRIPTION
`CombinedMultiDict` is immutable, and its `copy` returns another `CombinedMultiDict` wrapping the same dicts. However, other immutable multi-dicts return mutable copies. And a copy is generally not expected to stay in sync with its original. This changes `CombinedMultiDict.copy` to return a `MultiDict`.

Closes #951 