### PR TITLE
highlight user frames in interactive debugger

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,10 @@ Unreleased
     .copy>` returns a shallow mutable copy as a :class:`~datastructures.
     MultiDict`. The copy no longer reflects changes to the combined
     dicts, but is more generally useful. (`#1420`_)
+-   The interactive debugger highlights frames that come from user code
+    to make them easy to pick out in a long stack trace. Note that if an
+    env was created with virtualenv instead of venv, the debugger may
+    incorrectly classify some frames. (`#1421`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -256,6 +260,7 @@ Unreleased
 .. _#1418: https://github.com/pallets/werkzeug/pull/1418
 .. _#1419: https://github.com/pallets/werkzeug/pull/1419
 .. _#1420: https://github.com/pallets/werkzeug/pull/1420
+.. _#1421: https://github.com/pallets/werkzeug/pull/1421
 
 
 Version 0.14.1

--- a/werkzeug/debug/shared/style.css
+++ b/werkzeug/debug/shared/style.css
@@ -45,6 +45,8 @@ div.traceback ul { list-style: none; margin: 0; padding: 0 0 0 1em; }
 div.traceback h4 { font-size: 13px; font-weight: normal; margin: 0.7em 0 0.1em 0; }
 div.traceback pre { margin: 0; padding: 5px 0 3px 15px;
                     background-color: #E8EFF0; border: 1px solid #D3E7E9; }
+div.traceback .library .current { background: white; color: #555; }
+div.traceback .expanded .current { background: #E8EFF0; color: black; }
 div.traceback pre:hover { background-color: #DDECEE; color: black; cursor: pointer; }
 div.traceback div.source.expanded pre + pre { border-top: none; }
 


### PR DESCRIPTION
Adds a new `library` CSS class to frames that look like they are from built-in or installed library code. This removes the blue background from those frames, emphasizing the frames that come from the user's code. Clicking to expand the line will add the background color back so that it's easy to pick out from the surrounding context.

![screen shot 2018-12-10 at 12 24 30](https://user-images.githubusercontent.com/1242887/49760548-98d2e300-fc79-11e8-86f0-2c7e45f2b16a.png)

![screen shot 2018-12-10 at 12 25 04](https://user-images.githubusercontent.com/1242887/49760526-8c4e8a80-fc79-11e8-9572-733920babcc0.png)

Library frames are detected by comparing their filename to all paths returned by `sysconfig.get_paths()`. Other projects like [tbvaccine](https://github.com/skorokithakis/tbvaccine) check against the current working directory, but for the common setup where the env is a directory under the project, this would identify installed packages as user code.

If the detection thinks all or no frames are library code, it reverts to the old behavior of highlighting everything. This could happen, for example, if a project is installed in its virtualenv without using `-e`.

Unfortunately, virtualenv ships its own `site.py` which does not set these correctly, so code that was not installed to the env's site-packages dir (built-ins, system packages) will look like user code. This doesn't happen with venv or tools like Poetry and Pipenv which use it.

Due to the issue with virtualenv, which is what tox uses, I couldn't think of a reliable test for this, so this remains "untested" for now, although manual testing showed it working as expected.

Closes #1165 