### PR TITLE
click error message to jump to bottom of traceback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -197,6 +197,8 @@ Unreleased
     to make them easy to pick out in a long stack trace. Note that if an
     env was created with virtualenv instead of venv, the debugger may
     incorrectly classify some frames. (`#1421`_)
+-   Clicking the error message at the top of the interactive debugger
+    will jump down to the bottom of the traceback. (`#1422`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -261,6 +263,7 @@ Unreleased
 .. _#1419: https://github.com/pallets/werkzeug/pull/1419
 .. _#1420: https://github.com/pallets/werkzeug/pull/1420
 .. _#1421: https://github.com/pallets/werkzeug/pull/1421
+.. _#1422: https://github.com/pallets/werkzeug/pull/1422
 
 
 Version 0.14.1

--- a/docs/debug.rst
+++ b/docs/debug.rst
@@ -1,43 +1,57 @@
-======================
 Debugging Applications
 ======================
 
 .. module:: werkzeug.debug
 
-Depending on the WSGI gateway/server, exceptions are handled differently.
-But most of the time, exceptions go to stderr or the error log.
+Depending on the WSGI gateway/server, exceptions are handled
+differently. Most of the time, exceptions go to stderr or the error log,
+and a generic "500 Internal Server Error" message is displayed.
 
 Since this is not the best debugging environment, Werkzeug provides a
-WSGI middleware that renders nice debugging tracebacks, optionally with an
-AJAX based debugger (which allows to execute code in the context of the
-traceback's frames).
+WSGI middleware that renders nice tracebacks, optionally with an
+interactive debug console to execute code in any frame.
 
-The interactive debugger however does not work in forking environments
-which makes it nearly impossible to use on production servers.  Also the
-debugger allows the execution of arbitrary code which makes it a major
-security risk and **must never be used on production machines** because of
-that.  **We cannot stress this enough.  Do not enable this in
-production.**
+.. danger::
+
+    The debugger allows the execution of arbitrary code which makes it a
+    major security risk. **The debugger must never be used on production
+    machines. We cannot stress this enough. Do not enable the debugger
+    in production.**
+
+.. note::
+
+    The interactive debugger does not work in forking environments, such
+    as a server that starts multiple processes. Most such environments
+    are production servers, where the debugger should not be enabled
+    anyway.
+
 
 Enabling the Debugger
-=====================
+---------------------
 
-You can enable the debugger by wrapping the application in a
-:class:`DebuggedApplication` middleware.  Additionally there are
-parameters to the :func:`run_simple` function to enable it because this
-is a common task during development.
+Enable the debugger by wrapping the application with the
+:class:`DebuggedApplication` middleware. Alternatively, you can pass
+``use_debugger=True`` to :func:`run_simple` and it will do that for you.
 
 .. autoclass:: DebuggedApplication
 
+
 Using the Debugger
-==================
+------------------
 
-Once enabled and an error happens during a request you will see a detailed
-traceback instead of a general "internal server error".  If you have the
-`evalex` feature enabled you can also get a traceback for every frame in
-the traceback by clicking on the console icon.
+Once enabled and an error happens during a request you will see a
+detailed traceback instead of a generic "internal server error". The
+traceback is still output to the terminal as well.
 
-Once clicked a console opens where you can execute Python code in:
+The error message is displayed at the top. Clicking it jumps to the
+bottom of the traceback. Frames that represent user code, as opposed to
+built-ins or installed packages, are highlighted blue. Clicking a
+frame will show more lines for context, clicking again will hide them.
+
+If you have the ``evalex`` feature enabled you can get a console for
+every frame in the traceback by hovering over a frame and clicking the
+console icon that appears at the right. Once clicked a console opens
+where you can execute Python code in:
 
 .. image:: _static/debug-screenshot.png
    :alt: a screenshot of the interactive debugger
@@ -45,45 +59,43 @@ Once clicked a console opens where you can execute Python code in:
 
 Inside the interactive consoles you can execute any kind of Python code.
 Unlike regular Python consoles the output of the object reprs is colored
-and stripped to a reasonable size by default.  If the output is longer
+and stripped to a reasonable size by default. If the output is longer
 than what the console decides to display a small plus sign is added to
 the repr and a click will expand the repr.
 
 To display all variables that are defined in the current frame you can
-use the `dump()` function.  You can call it without arguments to get a
+use the ``dump()`` function. You can call it without arguments to get a
 detailed list of all variables and their values, or with an object as
 argument to get a detailed list of all the attributes it has.
 
+
 Debugger PIN
-============
+------------
 
-Starting with Werkzeug 0.11 the debugger is additionally protected by a
-PIN.  This is a security helper to make it less likely for the debugger to
-be exploited in production as it has happened to people to keep the
-debugger active.  The PIN based authentication is enabled by default.
+Starting with Werkzeug 0.11 the debug console is protected by a PIN.
+This is a security helper to make it less likely for the debugger to be
+exploited if you forget to disable it when deploying to production. The
+PIN based authentication is enabled by default.
 
-When the debugger comes up, on first usage it will prompt for a PIN that
-is printed to the command line.  The PIN is generated in a stable way that
-is specific to the project.  In some situations it might be not possible
-to generate a stable PIN between restarts in which case an explicit PIN
-can be provided through the environment variable ``WERKZEUG_DEBUG_PIN``.
-This can be set to a number and will become the PIN.  This variable can
-also be set to the value ``off`` to disable the PIN check entirely.
+The first time a console is opened, a dialog will prompt for a PIN that
+is printed to the command line. The PIN is generated in a stable way
+that is specific to the project. An explicit PIN can be provided through
+the environment variable ``WERKZEUG_DEBUG_PIN``. This can be set to a
+number and will become the PIN. This variable can also be set to the
+value ``off`` to disable the PIN check entirely.
 
-If the PIN is entered too many times incorrectly the server needs to be
+If an incorrect PIN is entered too many times the server needs to be
 restarted.
 
-**This feature is not supposed to entirely secure the debugger.  It's
-intended to make it harder for an attacker to exploit the debugger.  Never
-enable the debugger in production.**
+**This feature is not meant to entirely secure the debugger. It is
+intended to make it harder for an attacker to exploit the debugger.
+Never enable the debugger in production.**
+
 
 Pasting Errors
-==============
+--------------
 
-If you click on the `Traceback` title, the traceback switches over to a text
-based one.  The text based one can be pasted to `gist.github.com <https://gist.github.com>`_ with one
-click.
-
-
-.. _paste.pocoo.org: https://gist.github.com
-
+If you click on the "Traceback (most recent call last)" header, the
+view switches to a tradition text-based traceback. The text can be
+copied, or automatically pasted to `gist.github.com
+<https://gist.github.com>`_ with one click.

--- a/werkzeug/debug/shared/debugger.js
+++ b/werkzeug/debug/shared/debugger.js
@@ -10,6 +10,10 @@ $(function() {
     openShell(null, $('div.console div.inner').empty(), 0);
   }
 
+  $("div.detail").click(function() {
+    $("div.traceback").get(0).scrollIntoView(false);
+  });
+
   $('div.traceback div.frame').each(function() {
     var
       target = $('pre', this),

--- a/werkzeug/debug/shared/style.css
+++ b/werkzeug/debug/shared/style.css
@@ -24,6 +24,7 @@ textarea     { font-family: 'Consolas', 'Monaco', 'Bitstream Vera Sans Mono',
 div.debugger { text-align: left; padding: 12px; margin: auto;
                background-color: white; }
 h1           { font-size: 36px; margin: 0 0 0.3em 0; }
+div.detail { cursor: pointer; }
 div.detail p { margin: 0 0 8px 13px; font-size: 14px; white-space: pre-wrap;
                font-family: monospace; }
 div.explanation { margin: 20px 13px; font-size: 15px; color: #555; }


### PR DESCRIPTION
Clicking the error message at the top of the interactive debugger will scroll the bottom of the traceback into view. I'm not sure how to make it more obvious that it's clickable without it looking disruptive, so I'm settling for documentation. The debugger docs have been updated to describe more of how to use the interface, and cleaned up in general. This works nicely with #1421 which highlights user code frames.

Closes #116 