### PR TITLE
Remove future with_statement imports

### DIFF
--- a/examples/cupoftee/db.py
+++ b/examples/cupoftee/db.py
@@ -9,7 +9,6 @@
     :copyright: (c) 2009 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import with_statement
 import gdbm
 from threading import Lock
 from pickle import dumps, loads

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import print_function, with_statement
+from __future__ import print_function
 
 from itertools import count
 

--- a/tests/contrib/test_wrappers.py
+++ b/tests/contrib/test_wrappers.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from __future__ import with_statement
-
 from werkzeug.contrib import wrappers
 from werkzeug import routing
 from werkzeug.wrappers import Request, Response

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -19,8 +19,6 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from __future__ import with_statement
-
 import io
 import pytest
 import tempfile

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -8,8 +8,6 @@
     :copyright: (c) 2014 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import with_statement
-
 import csv
 import io
 import pytest

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -9,8 +9,6 @@
     :license: BSD, see LICENSE for more details.
 """
 
-from __future__ import with_statement
-
 import json
 import pytest
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,6 @@
     :copyright: (c) 2014 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import with_statement
-
 import pytest
 
 from datetime import datetime

--- a/werkzeug-import-rewrite.py
+++ b/werkzeug-import-rewrite.py
@@ -10,7 +10,6 @@
     :copyright: (c) 2014 by the Werkzeug Team.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import with_statement
 import sys
 import os
 import re

--- a/werkzeug/serving.py
+++ b/werkzeug/serving.py
@@ -35,8 +35,6 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from __future__ import with_statement
-
 import io
 import os
 import socket


### PR DESCRIPTION
``with`` as a statement has been mandatory since Python 2.6, yet
Werkzeug supports Python 2.7 as the minimal version. Therefore this is
safe to remove and leads to clearer code.