### PR TITLE
Fix quoting in uri_to_iri and iri_to_uri

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,7 @@ Unreleased
     -   Intermediate response bodies are iterated over even when
         ``buffered=False`` to ensure iterator middleware can run cleanup
         code safely. Only the last response is not buffered. (`#988`_)
+
 -   :class:`test.EnvironBuilder` and :class:`test.Client` take a
     ``json`` argument instead of manually passing ``data`` and
     ``content_type``. This is serialized using the
@@ -199,6 +200,10 @@ Unreleased
     incorrectly classify some frames. (`#1421`_)
 -   Clicking the error message at the top of the interactive debugger
     will jump down to the bottom of the traceback. (`#1422`_)
+-   :meth:`~urls.uri_to_iri` does not unquote ASCII characters in the
+    unreserved class, such as space, and leaves invalid bytes quoted
+    when decoding. :meth:`~iri_to_uri` does not quote reserved
+    characters. See :rfc:`3987` for these character classes. (`#1433`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -264,6 +269,7 @@ Unreleased
 .. _#1420: https://github.com/pallets/werkzeug/pull/1420
 .. _#1421: https://github.com/pallets/werkzeug/pull/1421
 .. _#1422: https://github.com/pallets/werkzeug/pull/1422
+.. _#1433: https://github.com/pallets/werkzeug/pull/1433
 
 
 Version 0.14.1

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -407,3 +407,7 @@ def test_uri_iri_normalization():
         assert urls.iri_to_uri(urls.uri_to_iri(test)) == uri
         assert urls.uri_to_iri(urls.uri_to_iri(test)) == iri
         assert urls.iri_to_uri(urls.iri_to_uri(test)) == uri
+
+
+def test_iri_to_uri_dont_unquote_space():
+    assert urls.uri_to_iri("abc%20def") == "abc%20def"

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -409,5 +409,9 @@ def test_uri_iri_normalization():
         assert urls.iri_to_uri(urls.iri_to_uri(test)) == uri
 
 
-def test_iri_to_uri_dont_unquote_space():
+def test_uri_to_iri_dont_unquote_space():
     assert urls.uri_to_iri("abc%20def") == "abc%20def"
+
+
+def test_iri_to_uri_dont_quote_reserved():
+    assert urls.iri_to_uri("/path[bracket]?(paren)") == "/path[bracket]?(paren)"

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -349,11 +349,18 @@ def test_get_host_fallback():
 
 
 def test_get_current_url_unicode():
-    env = create_environ()
-    env['QUERY_STRING'] = 'foo=bar&baz=blah&meh=\xcf'
+    env = create_environ(query_string=u"foo=bar&baz=blah&meh=\xcf")
     rv = wsgi.get_current_url(env)
-    strict_eq(rv,
-              u'http://localhost/?foo=bar&baz=blah&meh=\ufffd')
+    strict_eq(rv, u"http://localhost/?foo=bar&baz=blah&meh=\xcf")
+
+
+def test_get_current_url_invalid_utf8():
+    env = create_environ()
+    # set the query string *after* wsgi dance, so \xcf is invalid
+    env["QUERY_STRING"] = "foo=bar&baz=blah&meh=\xcf"
+    rv = wsgi.get_current_url(env)
+    # it remains percent-encoded
+    strict_eq(rv, u"http://localhost/?foo=bar&baz=blah&meh=%CF")
 
 
 def test_multi_part_line_breaks():

--- a/werkzeug/routing.py
+++ b/werkzeug/routing.py
@@ -107,7 +107,7 @@ from functools import partial
 from pprint import pformat
 from threading import Lock
 
-from werkzeug.urls import url_encode, url_quote, url_join, fast_url_quote
+from werkzeug.urls import url_encode, url_quote, url_join, _fast_url_quote
 from werkzeug.utils import redirect, format_string
 from werkzeug.exceptions import HTTPException, NotFound, MethodNotAllowed, \
      BadHost
@@ -1230,7 +1230,7 @@ class BaseConverter(object):
         return value
 
     def to_url(self, value):
-        return fast_url_quote(text_type(value).encode(self.map.charset))
+        return _fast_url_quote(text_type(value).encode(self.map.charset))
 
 
 class UnicodeConverter(BaseConverter):

--- a/werkzeug/wsgi.py
+++ b/werkzeug/wsgi.py
@@ -362,8 +362,13 @@ def peek_path_info(environ, charset='utf-8', errors='replace'):
                           charset, errors, allow_none_charset=True)
 
 
-def extract_path_info(environ_or_baseurl, path_or_url, charset='utf-8',
-                      errors='replace', collapse_http_schemes=True):
+def extract_path_info(
+    environ_or_baseurl,
+    path_or_url,
+    charset='utf-8',
+    errors='werkzeug.url_quote',
+    collapse_http_schemes=True
+):
     """Extracts the path info from the given URL (or WSGI environment) and
     path.  The path info returned is a unicode string, not a bytestring
     suitable for a WSGI environment.  The URLs might also be IRIs.
@@ -384,8 +389,6 @@ def extract_path_info(environ_or_baseurl, path_or_url, charset='utf-8',
 
     Instead of providing a base URL you can also pass a WSGI environment.
 
-    .. versionadded:: 0.6
-
     :param environ_or_baseurl: a WSGI environment dict, a base URL or
                                base IRI.  This is the root of the
                                application.
@@ -399,6 +402,12 @@ def extract_path_info(environ_or_baseurl, path_or_url, charset='utf-8',
                                   not assume that http and https on the
                                   same server point to the same
                                   resource.
+
+    .. versionchanged:: 0.15
+        The ``errors`` parameter defaults to leaving invalid bytes
+        quoted instead of replacing them.
+
+    .. versionadded:: 0.6
     """
     def _normalize_netloc(scheme, netloc):
         parts = netloc.split(u'@', 1)[-1].split(u':', 1)


### PR DESCRIPTION
`uri_to_iri` more closely matches the process in [RFC 3987](https://tools.ietf.org/html/rfc3987). All ASCII bytes that aren't in `unreserved` should remain quoted. Any bytes that do not decode to UTF-8 (or whatever charset is passed in Werkzeug's case) are re-quoted rather than being replaced. Closes #1356.

`iri_to_uri` does not quote any unquoted reserved characters in the URL, rather than just the subset it preserved before. Closes #402. 