### PR TITLE
Include charset in Content-Type header for all applicable standard types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,6 +210,10 @@ Unreleased
 -   The development server logs the unquoted IRI rather than the raw
     request line, to make it easier to work with Unicode in request
     paths during development. (`#1115`_)
+-   ``get_content_type`` appends a charset for any mimetype that ends
+    with ``+xml``, not just those that start with ``application/``.
+    Known text types such as ``application/javascript`` are also given
+    charsets. (`#1439`_)
 
 .. _#4: https://github.com/pallets/werkzeug/issues/4
 .. _`#209`: https://github.com/pallets/werkzeug/pull/209
@@ -278,6 +282,7 @@ Unreleased
 .. _#1422: https://github.com/pallets/werkzeug/pull/1422
 .. _#1430: https://github.com/pallets/werkzeug/pull/1430
 .. _#1433: https://github.com/pallets/werkzeug/pull/1433
+.. _#1439: https://github.com/pallets/werkzeug/pull/1439
 
 
 Version 0.14.1

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -31,15 +31,6 @@ _filename_ascii_strip_re = re.compile(r'[^A-Za-z0-9_.-]')
 _windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4', 'LPT1',
                          'LPT2', 'LPT3', 'PRN', 'NUL')
 
-_charset_mimetypes = set([
-    'application/ecmascript',
-    'application/javascript',
-    'application/news-checkgroups',
-    'application/news-groupinfo',
-    'application/sql',
-    'application/xml',
-])
-
 
 class cached_property(property):
 
@@ -220,21 +211,41 @@ class HTMLBuilder(object):
 html = HTMLBuilder('html')
 xhtml = HTMLBuilder('xhtml')
 
+# https://cgit.freedesktop.org/xdg/shared-mime-info/tree/freedesktop.org.xml.in
+# https://www.iana.org/assignments/media-types/media-types.xhtml
+# Types listed in the XDG mime info that have a charset in the IANA registration.
+_charset_mimetypes = {
+    "application/ecmascript",
+    "application/javascript",
+    "application/sql",
+    "application/xml",
+    "application/xml-dtd",
+    "application/xml-external-parsed-entity",
+}
+
 
 def get_content_type(mimetype, charset):
     """Returns the full content type string with charset for a mimetype.
 
-    If the mimetype represents text the charset will be appended as charset
-    parameter, otherwise the mimetype is returned unchanged.
+    If the mimetype represents text, the charset parameter will be
+    appended, otherwise the mimetype is returned unchanged.
 
-    :param mimetype: the mimetype to be used as content type.
-    :param charset: the charset to be appended in case it was a text mimetype.
-    :return: the content type.
+    :param mimetype: The mimetype to be used as content type.
+    :param charset: The charset to be appended for text mimetypes.
+    :return: The content type.
+
+    .. verionchanged:: 0.15
+        Any type that ends with ``+xml`` gets a charset, not just those
+        that start with ``application/``. Known text types such as
+        ``application/javascript`` are also given charsets.
     """
-    if mimetype.startswith('text/') or \
-       mimetype in _charset_mimetypes or \
-       mimetype.endswith('+xml'):
+    if (
+        mimetype.startswith('text/')
+        or mimetype in _charset_mimetypes
+        or mimetype.endswith('+xml')
+    ):
         mimetype += '; charset=' + charset
+
     return mimetype
 
 

--- a/werkzeug/utils.py
+++ b/werkzeug/utils.py
@@ -31,6 +31,15 @@ _filename_ascii_strip_re = re.compile(r'[^A-Za-z0-9_.-]')
 _windows_device_files = ('CON', 'AUX', 'COM1', 'COM2', 'COM3', 'COM4', 'LPT1',
                          'LPT2', 'LPT3', 'PRN', 'NUL')
 
+_charset_mimetypes = set([
+    'application/ecmascript',
+    'application/javascript',
+    'application/news-checkgroups',
+    'application/news-groupinfo',
+    'application/sql',
+    'application/xml',
+])
+
 
 class cached_property(property):
 
@@ -223,9 +232,8 @@ def get_content_type(mimetype, charset):
     :return: the content type.
     """
     if mimetype.startswith('text/') or \
-       mimetype == 'application/xml' or \
-       (mimetype.startswith('application/')
-            and mimetype.endswith('+xml')):
+       mimetype in _charset_mimetypes or \
+       mimetype.endswith('+xml'):
         mimetype += '; charset=' + charset
     return mimetype
 


### PR DESCRIPTION
The charset parameter is valid for 6 standard MIME types plus any type ending in +xml (whether or not it is an application type). Inclusion of this parameter is necessary to look at non-ASCII text files in a web browser.

See https://www.iana.org/assignments/media-types/media-types.xhtml for more information.