### PR TITLE
port Flask's JSONMixin implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,8 +189,10 @@ Unreleased
     to try ``pickle`` if ``json`` fails. (`#1413`_)
 -   ``CGIRootFix`` no longer modifies ``PATH_INFO`` for very old
     versions of Lighttpd. ``LighttpdCGIRootFix`` was renamed to
-    ``CGIRootFix`` in 0.9. The old name emits a deprecation warning and
-    will be removed in the next version. (`#1141`_)
+    ``CGIRootFix`` in 0.9. Both are deprecated and will be removed in
+    version 1.0. (`#1141`_)
+-   :class:`werkzeug.wrappers.json.JSONMixin` has been replaced with
+    Flask's implementation. Check the docs for the full API. (`#1445`_)
 -   The :doc:`contrib modules </contrib/index>` are deprecated and will
     either be moved into ``werkzeug`` core or removed completely in
     version 1.0. Some modules that already issued deprecation warnings
@@ -296,6 +298,7 @@ Unreleased
 .. _#1430: https://github.com/pallets/werkzeug/pull/1430
 .. _#1433: https://github.com/pallets/werkzeug/pull/1433
 .. _#1439: https://github.com/pallets/werkzeug/pull/1439
+.. _#1445: https://github.com/pallets/werkzeug/pull/1445
 
 
 Version 0.14.1

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -27,10 +27,6 @@ General Helpers
 
 .. autoclass:: header_property
 
-.. autofunction:: parse_cookie
-
-.. autofunction:: dump_cookie
-
 .. autofunction:: redirect
 
 .. autofunction:: append_slash_redirect

--- a/docs/wrappers.rst
+++ b/docs/wrappers.rst
@@ -185,8 +185,9 @@ These mixins are not included in the default :class:`Request` and
 :class:`Response` classes. They provide extra behavior that needs to be
 opted into by creating your own subclasses::
 
-    class Response(JSONMixin, BaseResponse):
+    class JSONRequest(JSONMixin, Request):
         pass
+
 
 .. module:: werkzeug.wrappers.json
 
@@ -195,6 +196,7 @@ JSON
 
 .. autoclass:: JSONMixin
     :members:
+
 
 .. module:: werkzeug.wrappers.charset
 

--- a/werkzeug/wrappers/json.py
+++ b/werkzeug/wrappers/json.py
@@ -1,29 +1,145 @@
 from __future__ import absolute_import
 
-from werkzeug.exceptions import BadRequest
-from werkzeug.utils import cached_property
+import datetime
+import uuid
+
+from werkzeug.utils import detect_utf_encoding
+from .._compat import text_type
+from ..exceptions import BadRequest
 
 try:
-    from simplejson import loads
+    import simplejson as _json
 except ImportError:
-    from json import loads
+    import json as _json
+
+
+class _JSONModule(object):
+    @staticmethod
+    def _default(o):
+        if isinstance(o, datetime.date):
+            return o.isoformat()
+
+        if isinstance(o, uuid.UUID):
+            return str(o)
+
+        if hasattr(o, "__html__"):
+            return text_type(o.__html__())
+
+        raise TypeError()
+
+    @classmethod
+    def dumps(cls, obj, **kw):
+        kw.setdefault("separators", (",", ":"))
+        kw.setdefault("default", cls._default)
+        kw.setdefault("sort_keys", True)
+        return _json.dumps(obj, **kw)
+
+    @staticmethod
+    def loads(s, **kw):
+        if isinstance(s, bytes):
+            # Needed for Python < 3.6
+            encoding = detect_utf_encoding(s)
+            s = s.decode(encoding)
+
+        return _json.loads(s, **kw)
 
 
 class JSONMixin(object):
-    """Add json method to a request object. This will parse the input
-    data through simplejson if possible.
+    """Mixin to parse :attr:`data` as JSON. Can be mixed in for both
+    :class:`~werkzeug.wrappers.Request` and
+    :class:`~werkzeug.wrappers.Response` classes.
 
-    :exc:`~werkzeug.exceptions.BadRequest` will be raised if the
-    content-type is not json or if the data itself cannot be parsed as
-    json.
+    If `simplejson`_ is installed it is preferred over Python's built-in
+    :mod:`json` module.
+
+    .. _simplejson: https://simplejson.readthedocs.io/en/latest/
     """
 
-    @cached_property
+    #: A module or other object that has ``dumps`` and ``loads``
+    #: functions that match the API of the built-in :mod:`json` module.
+    json_module = _JSONModule
+
+    @property
     def json(self):
-        """Get the result of simplejson.loads if possible."""
-        if 'json' not in self.environ.get('CONTENT_TYPE', ''):
-            raise BadRequest('Not a JSON request')
+        """The parsed JSON data if :attr:`mimetype` indicates JSON
+        (:mimetype:`application/json`, see :meth:`is_json`).
+
+        Calls :meth:`get_json` with default arguments.
+        """
+        return self.get_json()
+
+    @property
+    def is_json(self):
+        """Check if the mimetype indicates JSON data, either
+        :mimetype:`application/json` or :mimetype:`application/*+json`.
+        """
+        mt = self.mimetype
+        return (
+            mt == 'application/json'
+            or mt.startswith('application/')
+            and mt.endswith('+json')
+        )
+
+    def _get_data_for_json(self, cache):
         try:
-            return loads(self.data.decode(self.charset, self.encoding_errors))
-        except Exception:
-            raise BadRequest('Unable to read JSON request')
+            return self.get_data(cache=cache)
+        except TypeError:
+            # Response doesn't have cache param.
+            return self.get_data()
+
+    # Cached values for ``(silent=False, silent=True)``. Initialized
+    # with sentinel values.
+    _cached_json = (Ellipsis, Ellipsis)
+
+    def get_json(self, force=False, silent=False, cache=True):
+        """Parse :attr:`data` as JSON.
+
+        If the mimetype does not indicate JSON
+        (:mimetype:`application/json`, see :meth:`is_json`), this
+        returns ``None``.
+
+        If parsing fails, :meth:`on_json_loading_failed` is called and
+        its return value is used as the return value.
+
+        :param force: Ignore the mimetype and always try to parse JSON.
+        :param silent: Silence parsing errors and return ``None``
+            instead.
+        :param cache: Store the parsed JSON to return for subsequent
+            calls.
+        """
+        if cache and self._cached_json[silent] is not Ellipsis:
+            return self._cached_json[silent]
+
+        if not (force or self.is_json):
+            return None
+
+        data = self._get_data_for_json(cache=cache)
+
+        try:
+            rv = self.json_module.loads(data)
+        except ValueError as e:
+            if silent:
+                rv = None
+
+                if cache:
+                    normal_rv, _ = self._cached_json
+                    self._cached_json = (normal_rv, rv)
+            else:
+                rv = self.on_json_loading_failed(e)
+
+                if cache:
+                    _, silent_rv = self._cached_json
+                    self._cached_json = (rv, silent_rv)
+        else:
+            if cache:
+                self._cached_json = (rv, rv)
+
+        return rv
+
+    def on_json_loading_failed(self, e):
+        """Called if :meth:`get_json` parsing fails and isn't silenced.
+        If this method returns a value, it is used as the return value
+        for :meth:`get_json`. The default implementation raises
+        :exc:`~werkzeug.exceptions.BadRequest`.
+        """
+        raise BadRequest('Failed to decode JSON object: {0}'.format(e))


### PR DESCRIPTION
This replaces the very basic implementation that had been in Werkzeug with the well developed one from Flask. This is still moved out of `werkzeug.contrib` into `werkzeug.wrappers.json`.

closes #1443 