### PR TITLE
validate dynamic charset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -193,6 +193,11 @@ Unreleased
     version 1.0. (`#1141`_)
 -   :class:`werkzeug.wrappers.json.JSONMixin` has been replaced with
     Flask's implementation. Check the docs for the full API. (`#1445`_)
+-   :class:`werkzeug.wrappers.charset.DynamicCharsetRequestMixin`
+    attempts to validate that a charset is a safe, text-based charset. A
+    strong warning about understanding the safety of this is added to
+    the docs. The default and fallback charsets are changed to UTF-8 to
+    match :class:`~werkzeug.wrappers.BaseRequest`. (`#1446`_)
 -   The :doc:`contrib modules </contrib/index>` are deprecated and will
     either be moved into ``werkzeug`` core or removed completely in
     version 1.0. Some modules that already issued deprecation warnings
@@ -299,6 +304,7 @@ Unreleased
 .. _#1433: https://github.com/pallets/werkzeug/pull/1433
 .. _#1439: https://github.com/pallets/werkzeug/pull/1439
 .. _#1445: https://github.com/pallets/werkzeug/pull/1445
+.. _#1446: https://github.com/pallets/werkzeug/pull/1446
 
 
 Version 0.14.1

--- a/werkzeug/contrib/wrappers.py
+++ b/werkzeug/contrib/wrappers.py
@@ -20,6 +20,7 @@
     :copyright: (c) 2014 by the Werkzeug Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
+import codecs
 import warnings
 
 from werkzeug.exceptions import BadRequest
@@ -32,13 +33,16 @@ from werkzeug.wrappers import charset as _charset
 def is_known_charset(charset):
     """Checks if the given charset is known to Python."""
     warnings.warn(
-        "'werkzeug.contrib.wrappers.is_known_charset' has moved to"
-        " 'werkzeug.wrappers.charset.is_known_charset'. This old import"
-        " will be removed in version 1.0.",
+        "'werkzeug.contrib.wrappers.is_known_charset' is deprecated as"
+        " of version 0.15 and will be removed in version 1.0.",
         DeprecationWarning,
         stacklevel=2,
     )
-    return _charset.is_known_charset(charset)
+    try:
+        codecs.lookup(charset)
+    except LookupError:
+        return False
+    return True
 
 
 class JSONRequestMixin(_JSONMixin):

--- a/werkzeug/wrappers/json.py
+++ b/werkzeug/wrappers/json.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 import datetime
 import uuid
 
-from werkzeug.utils import detect_utf_encoding
 from .._compat import text_type
 from ..exceptions import BadRequest
+from ..utils import detect_utf_encoding
 
 try:
     import simplejson as _json


### PR DESCRIPTION
Rather than just checking if the codec exists, `DynamicCharsetRequestMixin` checks `CodecInfo._is_text_encoding` to only allow text encodings, not ones like "zip". A comment in the Python source suggests there was a better API planned for 3.5, but it never got implemented. It points to http://bugs.python.org/issue19619.

However, this is still not 100% secure because other Python libraries may have registered binary codecs and not set that undocumented variable. A strongly worded warning is added to the docs about this.

I kept this when deprecating `werkzeug.contrib`, but I'm not sure we should be including it even with this improvement due to the security implications. It does provide a better API than what most devs would probably naively implement, but it also encourages unsafe behavior.

The `ResponseMixin` isn't a security issue, but it just doesn't seem that worthwhile. Setting a charset doesn't re-encode data, a dev would still need to call `set_data(text)` afterwards. It seems like if you know the charset you want, you should be passing that to the constructor rather than setting it later.

closes #1444 