### PR TITLE
Adding support for TLS authentication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,10 @@ Unreleased
     only match at the primary language tag. :issue:`450`, :pr:`1507`
 -   ``MIMEAccept`` uses MIME parameters for specificity when matching.
     :issue:`458`, :pr:`1574`
+-   If the development server is started with an ``SSLContext``
+    configured to verify client certificates, the certificate in PEM
+    format will be available as ``environ["SSL_CLIENT_CERT"]``.
+    :pr:`1469`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
 -   Optional ad-hoc TLS support for the development server is handled


### PR DESCRIPTION
Continuation of PR  #1188.

With this change added, one can use a dict with extra information to be added to socket creation on `load_ssl_context`. 

Adding a more complex set of parameters to `ssl_context`, when using Flask, for example, will be possible through a new valid instance of ssl context, such as:

```
from flask import Flask
app = Flask(__name__)
ssl_context = {
		'cert_file': 'auth/server/crt.crt',
		'pkey_file': 'auth/server/key.key',
		'ca_certs': 'auth/server/ca.crt',
		'cert_reqs': ssl.CERT_REQUIRED
	}
	app.run(debug=True, ssl_context=ssl_context)
```

If possible - and valid, returned values from `SSLSocket.getpeercert`  will be stored into `environ['SSL_CLIENT_CERT']`.