### PR TITLE
Add utils.invalidate_cached_property()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Drop support for Python 3.4. (:issue:`1478`)
 -   Remove code that issued deprecation warnings in version 0.15.
     (:issue:`1477`)
+-   Added ``utils.invalidate_cached_property()`` to invalidate cached
+    properties. (:pr:`1474`)
 
 
 Version 0.15.0

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -23,6 +23,8 @@ General Helpers
 .. autoclass:: cached_property
    :members:
 
+.. autofunction:: invalidate_cached_property
+
 .. autoclass:: environ_property
 
 .. autoclass:: header_property

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -92,6 +92,31 @@ class cached_property(property):
         return value
 
 
+def invalidate_cached_property(obj, name):
+    """Invalidates the cache for a :class:`cached_property`:
+
+    >>> class Test(object):
+    ...     @cached_property
+    ...     def magic_number(self):
+    ...         print("recalculating...")
+    ...         return 42
+    ...
+    >>> var = Test()
+    >>> var.magic_number
+    recalculating...
+    42
+    >>> var.magic_number
+    42
+    >>> invalidate_cached_property(var, "magic_number")
+    >>> var.magic_number
+    recalculating...
+    42
+
+    You must pass the name of the cached property as the second argument.
+    """
+    obj.__dict__[name] = _missing
+
+
 class environ_property(_DictAccessorProperty):
     """Maps request attributes to environment variables. This works not only
     for the Werzeug request object, but also any other class with an

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,6 +105,32 @@ def test_can_set_cached_property():
     assert a._prop == "value"
 
 
+def test_can_invalidate_cached_property():
+    foo = []
+
+    class A(object):
+        def prop(self):
+            foo.append(42)
+            return 42
+
+        prop = utils.cached_property(prop)
+
+    a = A()
+    p = a.prop
+    q = a.prop
+    assert p == q == 42
+    assert foo == [42]
+
+    utils.invalidate_cached_property(a, "prop")
+    r = a.prop
+    assert r == 42
+    assert foo == [42, 42]
+
+    s = a.prop
+    assert s == 42
+    assert foo == [42, 42]
+
+
 def test_inspect_treats_cached_property_as_property():
     class A(object):
         @utils.cached_property


### PR DESCRIPTION
Sometimes you need to invalidate your cached properties. This makes it possible.