### PR TITLE
fix filename for generated routing code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 0.15.2
 
 Unreleased
 
+-   ``Rule`` code generation uses a filename that coverage will ignore.
+    The previous value, "generated", was causing coverage to fail.
+    (:issue:`1487`)
+
 
 Version 0.15.1
 --------------


### PR DESCRIPTION
`Rule` generated code with the filename `"generated"`, which coverage would fail to find. Instead, use the invalid name `"<werkzeug routing>"`, which coverage will ignore.

closes #1487 