### PR TITLE
test client removes cookie header when cookie jar is empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Unreleased
 -   ``Rule`` code generation uses a filename that coverage will ignore.
     The previous value, "generated", was causing coverage to fail.
     (:issue:`1487`)
+-   The test client removes the cookie header if there are no persisted
+    cookies. This fixes an issue introduced in 0.15.0 where the cookies
+    from the original request were used for redirects, causing functions
+    such as logout to fail. (:issue:`1491`)
 
 
 Version 0.15.1

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -208,11 +208,12 @@ class _TestCookieJar(CookieJar):
         """Inject the cookies as client headers into the server's wsgi
         environment.
         """
-        cvals = []
-        for cookie in self:
-            cvals.append("%s=%s" % (cookie.name, cookie.value))
+        cvals = ["%s=%s" % (c.name, c.value) for c in self]
+
         if cvals:
             environ["HTTP_COOKIE"] = "; ".join(cvals)
+        else:
+            environ.pop("HTTP_COOKIE", None)
 
     def extract_wsgi(self, environ, headers):
         """Extract the server's set-cookie headers as cookies into the


### PR DESCRIPTION
closes #1491 

In #1402, the test client was changed to copy the original request for redirects, to preserve headers and other request information like browsers do. This had the side effect of also preserving the original cookie header, rather than whatever was in the client's jar after the response. Now, if the client's jar is empty, the environ's cookie header is removed.

The only downside of this is that if someone was passing the cookie manually with `client.get("/", headers={"COOKIE": "key=value;"})`, this will no longer work because the client doesn't know about that cookie. Instead, they should have used the client's `set_cookie` method before making the request: `client.set_cookie("localhost", "key", "value"); client.get("/")`.