### PR TITLE
Don't ignore Set-Cookie directives when parsing Cookie header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Unreleased
     (:issue:`1477`)
 -   Added ``utils.invalidate_cached_property()`` to invalidate cached
     properties. (:pr:`1474`)
+-   Directive keys for the ``Set-Cookie`` response header are not
+    ignored when parsing the ``Cookie`` request header. This allows
+    cookies with names such as "expires" and "version". (:issue:`1495`)
 
 
 Version 0.15.1

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -26,15 +26,6 @@ from ._compat import text_type
 _logger = None
 _signature_cache = WeakKeyDictionary()
 _epoch_ord = date(1970, 1, 1).toordinal()
-_cookie_params = {
-    b"expires",
-    b"path",
-    b"comment",
-    b"max-age",
-    b"secure",
-    b"httponly",
-    b"version",
-}
 _legal_cookie_chars = (
     string.ascii_letters + string.digits + u"/=!#$%&'*+-.^_`|~:"
 ).encode("ascii")
@@ -310,9 +301,7 @@ def _cookie_parse_impl(b):
         value = match.group("val") or b""
         i = match.end(0)
 
-        # Ignore parameters.  We have no interest in them.
-        if key.lower() not in _cookie_params:
-            yield _cookie_unquote(key), _cookie_unquote(value)
+        yield _cookie_unquote(key), _cookie_unquote(value)
 
 
 def _encode_idna(domain):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -483,9 +483,12 @@ class TestHTTPUtility(object):
     def test_cookie_quoting(self):
         val = http.dump_cookie("foo", "?foo")
         strict_eq(val, 'foo="?foo"; Path=/')
-        strict_eq(dict(http.parse_cookie(val)), {"foo": u"?foo"})
-
+        strict_eq(dict(http.parse_cookie(val)), {"foo": u"?foo", "Path": u"/"})
         strict_eq(dict(http.parse_cookie(r'foo="foo\054bar"')), {"foo": u"foo,bar"})
+
+    def test_parse_set_cookie_directive(self):
+        val = 'foo="?foo"; version="0.1";'
+        strict_eq(dict(http.parse_cookie(val)), {"foo": u"?foo", "version": u"0.1"})
 
     def test_cookie_domain_resolving(self):
         val = http.dump_cookie("foo", "bar", domain=u"\N{SNOWMAN}.com")


### PR DESCRIPTION
fix #1495