### PR TITLE
test client copies environ passed to app

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Unreleased
     cookies. This fixes an issue introduced in 0.15.0 where the cookies
     from the original request were used for redirects, causing functions
     such as logout to fail. (:issue:`1491`)
+-   The test client copies the environ before passing it to the app, to
+    prevent in-place modifications from affecting redirect requests.
+    (:issue:`1498`)
 
 
 Version 0.15.1

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -990,7 +990,7 @@ class Client(object):
             finally:
                 builder.close()
 
-        response = self.run_wsgi_app(environ, buffered=buffered)
+        response = self.run_wsgi_app(environ.copy(), buffered=buffered)
 
         # handle redirects
         redirect_chain = []

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -32,6 +32,7 @@ from werkzeug.utils import redirect
 from werkzeug.wrappers import BaseResponse
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
+from werkzeug.wsgi import pop_path_info
 
 
 def cookie_app(environ, start_response):
@@ -542,6 +543,25 @@ def test_cookie_across_redirect():
     assert c.get("/").data == b"in"
     assert c.get("/out", follow_redirects=True).data == b"out"
     assert c.get("/").data == b"out"
+
+
+def test_redirect_mutate_environ():
+    @Request.application
+    def app(request):
+        if request.path == "/first":
+            return redirect("/prefix/second")
+
+        return Response(request.path)
+
+    def middleware(environ, start_response):
+        # modify the environ in place, shouldn't propagate to redirect request
+        pop_path_info(environ)
+        return app(environ, start_response)
+
+    c = Client(middleware, Response)
+    rv = c.get("/prefix/first", follow_redirects=True)
+    # if modified environ was used by client, this would be /
+    assert rv.data == b"/second"
 
 
 def test_path_info_script_name_unquoting():


### PR DESCRIPTION
This calls `environ.copy()`, isolating any changes the app makes to the environ from the client's original environ.

closes #1498 