### PR TITLE
logger only adds handler if its level isn't handled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Unreleased
 -   The test client copies the environ before passing it to the app, to
     prevent in-place modifications from affecting redirect requests.
     (:issue:`1498`)
+-   The ``"werkzeug"`` logger only adds a handler if there is no handler
+    configured for its level in the logging chain. This avoids double
+    logging if other code configures logging first. (:issue:`1492`)
 
 
 Version 0.15.1


### PR DESCRIPTION
Ports Flask's logging code. A handler is only added if there is no handler in the logging chain for the configured level. This prevents double logging if other code configures logging before Werkzeug does.

closes #1492 