### PR TITLE
Provide a fallback for LanguageAccept under Safari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ htmlcov
 test_uwsgi_failed
 .idea
 .pytest_cache/
+venv/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Unreleased
     ``samesite``. :issue:`1549`
 -   Support the Content Security Policy header through the
     `Response.content_security_policy` data structure. :pr:`1617`
+-   ``AcceptLanguage`` will fall back to matching "en" for "en-US" or
+    "en-US" for "en" to better support clients or translations that
+    only match at the primary language tag. :issue:`450`, :pr:`1507`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
 -   Optional ad-hoc TLS support for the development server is handled

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1840,27 +1840,63 @@ class MIMEAccept(Accept):
         return "application/json" in self
 
 
+def _normalize_lang(value):
+    """Process a language tag for matching."""
+    return _locale_delim_re.split(value.lower())
+
+
 class LanguageAccept(Accept):
-    """Like :class:`Accept` but with normalization for languages."""
+    """Like :class:`Accept` but with normalization for language tags."""
 
     def _value_matches(self, value, item):
-        def _normalize(language):
-            return _locale_delim_re.split(language.lower())
-
-        return item == "*" or _normalize(value) == _normalize(item)
+        return item == "*" or _normalize_lang(value) == _normalize_lang(item)
 
     def best_match(self, matches, default=None):
-        """Calls the super version of `best_match` and if it returns none,
-        attempts to fall back to language only matches.
+        """Given a list of supported values, finds the best match from
+        the list of accepted values.
 
-        :param matches: a list of matches to check for
-        :param default: the value that is returned if none match
+        Language tags are normalized for the purpose of matching, but
+        are returned unchanged.
+
+        If no exact match is found, this will fall back to matching
+        the first subtag (primary language only), first with the
+        accepted values then with the match values. This partial is not
+        applied to any other language subtags.
+
+        The default is returned if no exact or fallback match is found.
+
+        :param matches: A list of supported languages to find a match.
+        :param default: The value that is returned if none match.
         """
+        # Look for an exact match first. If a client accepts "en-US",
+        # "en-US" is a valid match at this point.
         result = super(LanguageAccept, self).best_match(matches)
+
         if result is not None:
             return result
-        fallback = Accept([(item[0][0:2], item[1]) for item in self])
-        return fallback.best_match(matches, default=default)
+
+        # Fall back to accepting primary tags. If a client accepts
+        # "en-US", "en" is a valid match at this point. Need to use
+        # re.split to account for 2 or 3 letter codes.
+        fallback = Accept(
+            [(_locale_delim_re.split(item[0], 1)[0], item[1]) for item in self]
+        )
+        result = fallback.best_match(matches)
+
+        if result is not None:
+            return result
+
+        # Fall back to matching primary tags. If the client accepts
+        # "en", "en-US" is a valid match at this point.
+        fallback_matches = [_locale_delim_re.split(item, 1)[0] for item in matches]
+        result = super(LanguageAccept, self).best_match(fallback_matches)
+
+        # Return a value from the original match list. Find the first
+        # original value that starts with the matched primary tag.
+        if result is not None:
+            return next(item for item in matches if item.startswith(result))
+
+        return default
 
 
 class CharsetAccept(Accept):

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1849,6 +1849,19 @@ class LanguageAccept(Accept):
 
         return item == "*" or _normalize(value) == _normalize(item)
 
+    def best_match(self, matches, default=None):
+        """Calls the super version of `best_match` and if it returns none,
+        attempts to fall back to language only matches.
+
+        :param matches: a list of matches to check for
+        :param default: the value that is returned if none match
+        """
+        result = super(LanguageAccept, self).best_match(matches)
+        if result is not None:
+            return result
+        fallback = Accept([(item[0][0:2], item[1]) for item in self])
+        return fallback.best_match(matches, default=default)
+
 
 class CharsetAccept(Accept):
     """Like :class:`Accept` but with normalization for charsets."""

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -37,6 +37,7 @@ from werkzeug._compat import iterlistvalues
 from werkzeug._compat import itervalues
 from werkzeug._compat import PY2
 from werkzeug._compat import text_type
+from werkzeug.datastructures import LanguageAccept
 from werkzeug.datastructures import Range
 from werkzeug.exceptions import BadRequestKeyError
 
@@ -911,12 +912,12 @@ def make_call_asserter(func=None):
 
     :param func: Additional callback for each function call.
 
-    >>> assert_calls, func = make_call_asserter()
-    >>> with assert_calls(2):
-    ...    func()
-    ...    func()
+    .. code-block:: python
+        assert_calls, func = make_call_asserter()
+        with assert_calls(2):
+            func()
+            func()
     """
-
     calls = [0]
 
     @contextmanager
@@ -1101,32 +1102,27 @@ class TestMIMEAccept(object):
 
 
 class TestLanguageAccept(object):
-    storage_class = datastructures.LanguageAccept
-
-    def test_best_match_fallback(self):
-        accept = self.storage_class([("en-us", 1)])
-        assert accept.best_match(["en"]) == "en"
-
-        accept = self.storage_class([("de_AT", 1), ("de", 0.9)])
-        assert accept.best_match(["en"]) is None
-
-        accept = self.storage_class([("de_AT", 1), ("de", 0.9), ("en-US", 0.8)])
-        assert accept.best_match(["de", "en"]) == "de"
-
-        accept = self.storage_class([("de_AT", 0.9), ("en-US", 1)])
-        assert accept.best_match(["en"]) == "en"
-
-        accept = self.storage_class([("en-us", 1)])
-        assert accept.best_match(["en-us"]) == "en-us"
-
-        accept = self.storage_class([("en-us", 1)])
-        assert accept.best_match(["en-us", "en"]) == "en-us"
-
-        accept = self.storage_class([("en-GB", 1)])
-        assert accept.best_match(["en-US", "en"], default="en-US") == "en"
-
-        accept = self.storage_class([("de-AT", 1)])
-        assert accept.best_match(["en-US", "en"], default="en-US") == "en-US"
+    @pytest.mark.parametrize(
+        ("values", "matches", "default", "expect"),
+        (
+            ([("en-us", 1)], ["en"], None, "en"),
+            ([("en", 1)], ["en_US"], None, "en_US"),
+            ([("en-GB", 1)], ["en-US"], None, None),
+            ([("de_AT", 1), ("de", 0.9)], ["en"], None, None),
+            ([("de_AT", 1), ("de", 0.9), ("en-US", 0.8)], ["de", "en"], None, "de"),
+            ([("de_AT", 0.9), ("en-US", 1)], ["en"], None, "en"),
+            ([("en-us", 1)], ["en-us"], None, "en-us"),
+            ([("en-us", 1)], ["en-us", "en"], None, "en-us"),
+            ([("en-GB", 1)], ["en-US", "en"], "en-US", "en"),
+            ([("de_AT", 1)], ["en-US", "en"], "en-US", "en-US"),
+            ([("aus-EN", 1)], ["aus"], None, "aus"),
+            ([("aus", 1)], ["aus-EN"], None, "aus-EN"),
+        ),
+    )
+    def test_best_match_fallback(self, values, matches, default, expect):
+        accept = LanguageAccept(values)
+        best = accept.best_match(matches, default=default)
+        assert best == expect
 
 
 class TestFileStorage(object):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1100,6 +1100,35 @@ class TestMIMEAccept(object):
         assert accept.best_match(["text/plain", "image/png"]) == "image/png"
 
 
+class TestLanguageAccept(object):
+    storage_class = datastructures.LanguageAccept
+
+    def test_best_match_fallback(self):
+        accept = self.storage_class([("en-us", 1)])
+        assert accept.best_match(["en"]) == "en"
+
+        accept = self.storage_class([("de_AT", 1), ("de", 0.9)])
+        assert accept.best_match(["en"]) is None
+
+        accept = self.storage_class([("de_AT", 1), ("de", 0.9), ("en-US", 0.8)])
+        assert accept.best_match(["de", "en"]) == "de"
+
+        accept = self.storage_class([("de_AT", 0.9), ("en-US", 1)])
+        assert accept.best_match(["en"]) == "en"
+
+        accept = self.storage_class([("en-us", 1)])
+        assert accept.best_match(["en-us"]) == "en-us"
+
+        accept = self.storage_class([("en-us", 1)])
+        assert accept.best_match(["en-us", "en"]) == "en-us"
+
+        accept = self.storage_class([("en-GB", 1)])
+        assert accept.best_match(["en-US", "en"], default="en-US") == "en"
+
+        accept = self.storage_class([("de-AT", 1)])
+        assert accept.best_match(["en-US", "en"], default="en-US") == "en-US"
+
+
 class TestFileStorage(object):
     storage_class = datastructures.FileStorage
 


### PR DESCRIPTION
Safari on macOS doesn't provide a language-only option in the header for languages accepted. When `en-US` is the preferred language, Safari only provides an "Accepted Language" of `en-US` without any fallback to `en`. Therefore, if a website is offering an `en` language version but not an `en-US` version, `LanguageAccept.best_match` returns `None`.

This pull request attempts to correct that by checking if `None` is returned and if so, trying again with language-only accepted values.

fixes #450