### PR TITLE
function build using the ast

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -8,6 +8,7 @@
     :copyright: 2007 Pallets
     :license: BSD-3-Clause
 """
+import gc
 import uuid
 
 import pytest
@@ -1069,3 +1070,36 @@ def test_error_message_suggestion():
     with pytest.raises(r.BuildError) as excinfo:
         adapter.build("world", {"id": 2}, method="POST")
     assert "Did you mean to use methods ['GET', 'HEAD']?" in str(excinfo.value)
+
+
+def test_no_memory_leak_from_Rule_builder():
+    """See #1520"""
+
+    # generate a bunch of objects that *should* get collected
+    for _ in range(100):
+        r.Map([r.Rule("/a/<string:b>")])
+
+    # ensure that the garbage collection has had a chance to collect cyclic
+    # objects
+    for _ in range(5):
+        gc.collect()
+
+    # assert they got collected!
+    count = sum(1 for obj in gc.get_objects() if isinstance(obj, r.Rule))
+    assert count == 0
+
+
+def test_build_url_with_arg_self():
+    map = r.Map([r.Rule("/foo/<string:self>", endpoint="foo")])
+    adapter = map.bind("example.org", "/", subdomain="blah")
+
+    ret = adapter.build("foo", {"self": "bar"})
+    assert ret == "http://example.org/foo/bar"
+
+
+def test_build_url_with_arg_keyword():
+    map = r.Map([r.Rule("/foo/<string:class>", endpoint="foo")])
+    adapter = map.bind("example.org", "/", subdomain="blah")
+
+    ret = adapter.build("foo", {"class": "bar"})
+    assert ret == "http://example.org/foo/bar"


### PR DESCRIPTION
Resolves #1520

This is based on the same approach that #1521 took, however I converted it from bytecode generation to ast building to hopefully make it a little easier to understand / maintain.

This approach is slightly slower than the existing approach but fixes the memory leak -- more on the speed later.

The core problem of the memory leak is as follows, I'll be using the disassembler to explain this, hopefully this explanation is somewhat accessible ;)

Here's an example disassembly from the original functions before I changed them:

The rule I'm using throughout is `Rule('/a/<string:b>')`

```
dis.dis(rule._build)
  1           0 LOAD_CONST               0 ('')
              2 LOAD_CONST               1 ('/a/')
              4 LOAD_CONST               2 (<bound method BaseConverter.to_url of <werkzeug.routing.UnicodeConverter object at 0x7f48f0359320>>)
              6 LOAD_FAST                0 (b)
              8 CALL_FUNCTION            1
             10 BUILD_STRING             2
             12 BUILD_TUPLE              2
             14 RETURN_VALUE
(Pdb) dis.dis(rule._build_unknown)
  1           0 LOAD_CONST               0 ('')
              2 LOAD_CONST               1 ('/a/')
              4 LOAD_CONST               2 (<bound method BaseConverter.to_url of <werkzeug.routing.UnicodeConverter object at 0x7f48f0359320>>)
              6 LOAD_FAST                0 (b)
              8 CALL_FUNCTION            1
             10 LOAD_FAST                1 (.keyword_arguments)
             12 JUMP_IF_TRUE_OR_POP     20
             14 LOAD_CONST               0 ('')
             16 DUP_TOP
             18 JUMP_FORWARD            10 (to 30)
        >>   20 LOAD_CONST               3 (functools.partial(<function url_encode at 0x7f48f0618730>, charset='utf-8', sort=False, key=None))
             22 ROT_TWO
             24 CALL_FUNCTION            1
             26 LOAD_CONST               4 ('?')
             28 ROT_TWO
        >>   30 BUILD_STRING             4
             32 BUILD_TUPLE              2
             34 RETURN_VALUE
```

This ~roughly equates to the following functions (I'm using python3.6, the output is slightly different before that due to f-strings but it's not important for this discussion)

```python
def f(b):  # _build
    return ('', f'{"/a/"}{to_url(b)}')   # to_url is loaded from `co_consts`

def f(b, **kwargs):  # _build_unknown
    if kwargs:
        q, params = '?', url_encode(kwargs)  # url_encode is loaded from `co_consts`
    else:
        q, params = '', ''

    return ('', f'{"/a/"}{to_url(b)}{q}{params}')  # to_url is loaded from `co_consts`
```

(in fact, here's the disassembly of those function(s) -- you can mostly ignore the `FORMAT_VALUE` opcodes, those are used to prepare f-strings and are noops for strings (which is what we're dealing with!)):

```pycon
>>> dis.dis(f)  # _build
  9           0 LOAD_CONST               1 ('')
              2 LOAD_CONST               2 ('/a/')
              4 FORMAT_VALUE             0
              6 LOAD_GLOBAL              0 (to_url)
              8 LOAD_FAST                0 (b)
             10 CALL_FUNCTION            1
             12 FORMAT_VALUE             0
             14 BUILD_STRING             2
             16 BUILD_TUPLE              2
             18 RETURN_VALUE
```

```pycon
>>> dis.dis(f)  # _build_unknown
 26           0 LOAD_FAST                1 (kwargs)
              2 POP_JUMP_IF_FALSE       20

 27           4 LOAD_CONST               1 ('?')
              6 LOAD_GLOBAL              0 (url_encode)
              8 LOAD_FAST                1 (kwargs)
             10 CALL_FUNCTION            1
             12 ROT_TWO
             14 STORE_FAST               2 (q)
             16 STORE_FAST               3 (params)
             18 JUMP_FORWARD             8 (to 28)

 29     >>   20 LOAD_CONST               4 (('', ''))
             22 UNPACK_SEQUENCE          2
             24 STORE_FAST               2 (q)
             26 STORE_FAST               3 (params)

 31     >>   28 LOAD_CONST               2 ('')
             30 LOAD_CONST               3 ('/a/')
             32 FORMAT_VALUE             0
             34 LOAD_GLOBAL              1 (to_url)
             36 LOAD_FAST                0 (b)
             38 CALL_FUNCTION            1
             40 FORMAT_VALUE             0
             42 LOAD_FAST                2 (q)
             44 FORMAT_VALUE             0
             46 LOAD_FAST                3 (params)
             48 FORMAT_VALUE             0
             50 BUILD_STRING             4
             52 BUILD_TUPLE              2
             54 RETURN_VALUE
```

Anyway, the issue with the original compiled function are these opcodes:

```
              4 LOAD_CONST               2 (<bound method BaseConverter.to_url of <werkzeug.routing.UnicodeConverter object at 0x7f48f0359320>>)
```

```
        >>   20 LOAD_CONST               3 (functools.partial(<function url_encode at 0x7f48f0618730>, charset='utf-8', sort=False, key=None))
```

In particular, this opcode causes `co_consts` to contain these values:

```
(Pdb) rule._build.__code__.co_consts
('', '/a/', <bound method BaseConverter.to_url of <werkzeug.routing.UnicodeConverter object at 0x7f48f0359320>>)
```

Usually, `co_consts` should *only* contain **constants**!  In particular, when the garbage collection machinery of cpython considers function objects, it doesn't consider the constants as potential trash because normally they're just constants (I don't have a citation for this, it's mostly based on what I observed while poking around with `gc.get_referrers` as can be seen here: https://github.com/pallets/werkzeug/issues/1520#issuecomment-485980372 -- notably you can see the tuple of the `co_consts` but not that a code object refers to it)

Because of this, it cannot detect the cycle that's introduced:

Map -> Rule -> code object -> co_consts tuple -> to_url method -> UnicodeConverter -> Map

And because it doesn't know about that, it can't collect the cycle during cyclical gc

The fix to this is to take the non-constant constants out of `co_consts` and instead refer to the objects directly.

My new versions of these functions adds a `self` argument to the generated methods, and attaches them as bound methods to the `Rule` class on creation.  The converters are then looked up on the `Rule` instance as they're called.  Here's the replacement disassembly, we can also look at the ast that produces these and the "unparsed" ast (using a modified `astunparse`)

### `rule._build`

```pycon
(Pdb) dis.dis(locs[func_ast.name])
  1           0 LOAD_CONST               1 ('')
              2 LOAD_CONST               2 ('/a/')
              4 LOAD_FAST                0 (.self)
              6 LOAD_ATTR                0 (_converters)
              8 LOAD_CONST               3 ('b')
             10 BINARY_SUBSCR
             12 LOAD_ATTR                1 (to_url)
             14 LOAD_FAST                1 (b)
             16 CALL_FUNCTION            1
             18 BUILD_STRING             2
             20 BUILD_TUPLE              2
             22 RETURN_VALUE
(Pdb) astpretty.pprint(func_ast, show_offsets=False)
FunctionDef(
    name="<builder:'/a/<string:b>'>",
    args=arguments(
        args=[
            arg(arg='.self', annotation=None),
            arg(arg='b', annotation=None),
        ],
        vararg=None,
        kwonlyargs=[],
        kw_defaults=[],
        kwarg=arg(arg='.kwargs', annotation=None),
        defaults=[],
    ),
    body=[
        Return(
            value=Tuple(
                elts=[
                    Str(s=''),
                    JoinedStr(
                        values=[
                            Str(s='/a/'),
                            Call(
                                func=Attribute(
                                    value=Subscript(
                                        value=Attribute(
                                            value=Name(id='.self', ctx=Load()),
                                            attr='_converters',
                                            ctx=Load(),
                                        ),
                                        slice=Index(
                                            value=Str(s='b'),
                                        ),
                                        ctx=Load(),
                                    ),
                                    attr='to_url',
                                    ctx=Load(),
                                ),
                                args=[Name(id='b', ctx=Load())],
                                keywords=[],
                            ),
                        ],
                    ),
                ],
                ctx=Load(),
            ),
        ),
    ],
    decorator_list=[],
    returns=None,
)
(Pdb) print(astunparse.unparse(func_ast))


def <builder:'/a/<string:b>'>(.self, b, **.kwargs):
    return ('', f"/a/{.self._converters['b'].to_url(b)}")
```

### `rule._build_unknown`

```pycon
(Pdb) dis.dis(locs[func_ast.name])
  1           0 LOAD_FAST                2 (.kwargs)
              2 POP_JUMP_IF_FALSE       20

  2           4 LOAD_CONST               1 ('?')
              6 STORE_FAST               3 (.q)

  3           8 LOAD_FAST                0 (.self)
             10 LOAD_ATTR                0 (_encode_query_vars)
             12 LOAD_FAST                2 (.kwargs)
             14 CALL_FUNCTION            1
             16 STORE_FAST               4 (.params)
             18 JUMP_FORWARD             8 (to 28)

  5     >>   20 LOAD_CONST               2 ('')
             22 DUP_TOP
             24 STORE_FAST               3 (.q)
             26 STORE_FAST               4 (.params)

  1     >>   28 LOAD_CONST               2 ('')
             30 LOAD_CONST               3 ('/a/')
             32 LOAD_FAST                0 (.self)
             34 LOAD_ATTR                1 (_converters)
             36 LOAD_CONST               4 ('b')
             38 BINARY_SUBSCR
             40 LOAD_ATTR                2 (to_url)
             42 LOAD_FAST                1 (b)
             44 CALL_FUNCTION            1
             46 LOAD_FAST                3 (.q)
             48 LOAD_FAST                4 (.params)
             50 BUILD_STRING             4
             52 BUILD_TUPLE              2
             54 RETURN_VALUE
(Pdb) astpretty.pprint(func_ast, show_offsets=False)
FunctionDef(
    name="<builder:'/a/<string:b>'>",
    args=arguments(
        args=[
            arg(arg='.self', annotation=None),
            arg(arg='b', annotation=None),
        ],
        vararg=None,
        kwonlyargs=[],
        kw_defaults=[],
        kwarg=arg(arg='.kwargs', annotation=None),
        defaults=[],
    ),
    body=[
        If(
            test=Name(id='.kwargs', ctx=Load()),
            body=[
                Assign(
                    targets=[Name(id='.q', ctx=Store())],
                    value=Str(s='?'),
                ),
                Assign(
                    targets=[Name(id='.params', ctx=Store())],
                    value=Call(
                        func=Attribute(
                            value=Name(id='.self', ctx=Load()),
                            attr='_encode_query_vars',
                            ctx=Load(),
                        ),
                        args=[Name(id='.kwargs', ctx=Load())],
                        keywords=[],
                    ),
                ),
            ],
            orelse=[
                Assign(
                    targets=[
                        Name(id='.q', ctx=Store()),
                        Name(id='.params', ctx=Store()),
                    ],
                    value=Str(s=''),
                ),
            ],
        ),
        Return(
            value=Tuple(
                elts=[
                    Str(s=''),
                    JoinedStr(
                        values=[
                            Str(s='/a/'),
                            Call(
                                func=Attribute(
                                    value=Subscript(
                                        value=Attribute(
                                            value=Name(id='.self', ctx=Load()),
                                            attr='_converters',
                                            ctx=Load(),
                                        ),
                                        slice=Index(
                                            value=Str(s='b'),
                                        ),
                                        ctx=Load(),
                                    ),
                                    attr='to_url',
                                    ctx=Load(),
                                ),
                                args=[Name(id='b', ctx=Load())],
                                keywords=[],
                            ),
                            Name(id='.q', ctx=Load()),
                            Name(id='.params', ctx=Load()),
                        ],
                    ),
                ],
                ctx=Load(),
            ),
        ),
    ],
    decorator_list=[],
    returns=None,
)
(Pdb) print(astunparse.unparse(func_ast))


def <builder:'/a/<string:b>'>(.self, b, **.kwargs):
    if .kwargs:
        .q = '?'
        .params = .self._encode_query_vars(.kwargs)
    else:
        .q = .params = ''
    return ('', f"/a/{.self._converters['b'].to_url(b)}{.q}{.params}")
```

So we basically replaced the illegal `co_consts` lookup with lookups on `self`

___

Running the perf benchmark from the original PR, this seems to make these ever-so-slightly slower.  (I used best-of-5 here)

```console
$ git checkout func_build_ast
...
$ python test.py
0.05178717499074992
```

```console
$ git checkout master
...
$ python test.py
0.04974961299740244
```

~4% slower (might as well be error noise, right?)