### PR TITLE
[RFC] reloader: wait for finished request

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -234,6 +234,11 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         return environ
 
     def run_wsgi(self):
+        from ._reloader import wait_for_finished_request
+        with wait_for_finished_request:
+            return self._run_wsgi()
+
+    def _run_wsgi(self):
         if self.headers.get("Expect", "").lower().strip() == "100-continue":
             self.wfile.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 


### PR DESCRIPTION
The server should not be restarted while debugging (`pdb.set_trace()`).

Use case:

1. `pdb.set_trace` in the code
2. trigger web request
3. start debugging / messing around, maybe even use `edit` (via pdbpp) to edit files
4. save something being watched

This ends up in garbarge on the screen, and the server process/thread getting killed.

With this patch it waits for wsgi requests to finish before reloading.

Not much tested yet, and could certainly need a revisit/cleanup.