### PR TITLE
Added charset to HTTPException header content-type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 -   Directive keys for the ``Set-Cookie`` response header are not
     ignored when parsing the ``Cookie`` request header. This allows
     cookies with names such as "expires" and "version". (:issue:`1495`)
+-   Add ``charset=utf-8`` to an HTTP exception response's
+    ``CONTENT_TYPE`` header. (:pr:`1526`)
 
 
 Version 0.15.2

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -153,7 +153,7 @@ class HTTPException(Exception):
 
     def get_headers(self, environ=None):
         """Get a list of headers."""
-        return [("Content-Type", "text/html")]
+        return [("Content-Type", "text/html; charset=utf-8")]
 
     def get_response(self, environ=None):
         """Get a response object.  If one was passed to the exception

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -110,3 +110,9 @@ def test_unauthorized_www_authenticate():
     exc = exceptions.Unauthorized(www_authenticate=[digest, basic])
     h = dict(exc.get_headers({}))
     assert h["WWW-Authenticate"] == ", ".join((str(digest), str(basic)))
+
+
+def test_response_header_content_type_should_contain_charset():
+    exc = exceptions.HTTPException("An error message")
+    h = exc.get_response({})
+    assert h.headers["Content-Type"] == "text/html; charset=utf-8"


### PR DESCRIPTION
Adds `charset=utf-8` to Header['Content-Type'] for HTTPException's response.

It looks like the template HTML body is in unicode, so we should set the charset explicitly so that Browsers will pick the correct one. 