### PR TITLE
Add link to official Discord chat server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ Links
     -   Windows: https://ci.appveyor.com/project/pallets/werkzeug
 
 -   Test coverage: https://codecov.io/gh/pallets/werkzeug
+-   Official chat: https://discord.gg/t6rrQZH
 
 .. _WSGI: https://wsgi.readthedocs.io/en/latest/
 .. _Flask: https://www.palletsprojects.com/p/flask/


### PR DESCRIPTION
All Pallets projects should have a link to the official chat server on Discord.