### PR TITLE
Fix failing style checks

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -156,7 +156,7 @@ def get_pin_and_cookie_name(app):
         else:
             num = pin
 
-    modname = getattr(app, "__module__", getattr(app.__class__, "__module__"))
+    modname = getattr(app, "__module__", app.__class__.__module__)
 
     try:
         # getuser imports the pwd module, which does not exist in Google
@@ -173,7 +173,7 @@ def get_pin_and_cookie_name(app):
     probably_public_bits = [
         username,
         modname,
-        getattr(app, "__name__", getattr(app.__class__, "__name__")),
+        getattr(app, "__name__", app.__class__.__name__),
         getattr(mod, "__file__", None),
     ]
 

--- a/tests/contrib/test_wrappers.py
+++ b/tests/contrib/test_wrappers.py
@@ -85,4 +85,4 @@ def test_dynamic_charset_response_mixin():
     except TypeError:
         pass
     else:
-        assert False, "expected type error on charset setting without ct"
+        raise AssertionError("expected type error on charset setting without ct")

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -56,7 +56,7 @@ def redirect_with_get_app(environ, start_response):
         "http://localhost/first/request",
         "http://localhost/some/redirect/",
     ):
-        assert False, 'redirect_demo_app() did not expect URL "%s"' % req.url
+        raise AssertionError('redirect_demo_app() did not expect URL "%s"' % req.url)
     if "/some/redirect" not in req.url:
         response = redirect("http://localhost/some/redirect/")
     else:


### PR DESCRIPTION
Fix style check errors for new bugbear items in Flake8:
* B009: Do not call getattr(x, 'attr'), instead use normal property access: x.attr. Missing a default to getattr will cause an AttributeError to be raised for non-existent properties. There is no additional safety in using getattr if you know the attribute name ahead of time.
* B011: Do not call assert False since python -O removes these calls. Instead callers should raise AssertionError().

Resolves #1528 