### PR TITLE
[WIP] use towncrier for changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ htmlcov
 test_uwsgi_failed
 .idea
 .pytest_cache/
+pip-wheel-metadata/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,18 +1,6 @@
 .. currentmodule:: werkzeug
 
-Version 1.0.0
--------------
-
-Unreleased
-
--   Drop support for Python 3.4. (:issue:`1478`)
--   Remove code that issued deprecation warnings in version 0.15.
-    (:issue:`1477`)
--   Added ``utils.invalidate_cached_property()`` to invalidate cached
-    properties. (:pr:`1474`)
--   Directive keys for the ``Set-Cookie`` response header are not
-    ignored when parsing the ``Cookie`` request header. This allows
-    cookies with names such as "expires" and "version". (:issue:`1495`)
+.. towncrier release notes start
 
 
 Version 0.15.2

--- a/changes.d/1474.feature.rst
+++ b/changes.d/1474.feature.rst
@@ -1,0 +1,1 @@
+Added ``utils.invalidate_cached_property()`` to invalidate cached properties.

--- a/changes.d/1477.removal.rst
+++ b/changes.d/1477.removal.rst
@@ -1,0 +1,1 @@
+Remove code that issued deprecation warnings in version 0.15.

--- a/changes.d/1487.removal.rst
+++ b/changes.d/1487.removal.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.4.

--- a/changes.d/1495.bugfix.rst
+++ b/changes.d/1495.bugfix.rst
@@ -1,0 +1,3 @@
+Directive keys for the ``Set-Cookie`` response header are not ignored when parsing the
+``Cookie`` request header. This allows cookies with names such as "expires" and
+"version".

--- a/changes.d/towncrier_template.rst
+++ b/changes.d/towncrier_template.rst
@@ -1,0 +1,33 @@
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+-   {{ text }}
+    {{ values|join(',\n  ') }}
+{% endfor %}
+
+{% else %}
+-   {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% endif %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}

--- a/changes.d/x.misc.rst
+++ b/changes.d/x.misc.rst
@@ -1,0 +1,1 @@
+Use towncrier to manage entries in ``CHANGES.rst``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.towncrier]
+    package = "werkzeug"
+    package_dir = "src"
+    filename = "CHANGES.rst"
+    directory = "changes.d"
+    issue_format = ":issue:`{issue}`"
+    title_format = "Version {version}"
+    template = "changes.d/towncrier_template.rst"


### PR DESCRIPTION
https://pypi.org/project/towncrier/

Each PR adds a file with the format `changes.d/{issue}.{type}.rst`. Set the version for release, then run `towncrier`, which will merge all the files into `CHANGES.rst`. `towncrier --draft` shows what would be rendered. Keeps each `{type}` in its own section, and links to `{issue}`, so the changelog is more oganized.

We don't require an issue for PRs, so that makes the filename tricky. Either create an issue first (good idea) and use that number, guess the next PR number, or create `x.{type}.rst`then rename it after creating the PR.

Requires `pyproject.toml` for configuration. Unfortunately, pip is currently figuring out PEP 517 support, and the presence of this file has caused issue in the past.