### PR TITLE
Fix folding headers in Python 2.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: werkzeug
 
+Version 0.15.3
+--------------
+
+-   Properly handle multi-line header folding in development server in
+    Python 2.7. (:issue:`1080`)
+
+
 Version 0.15.2
 --------------
 

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -455,7 +455,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                     # If header could not be slit with : but starts with white
                     # space and it follows an existing header, it's a folded
                     # header.
-                    if header[0] in ("\t", " ") and len(items) > 0:
+                    if header[0] in ("\t", " ") and items:
                         # Pop off the last header
                         key, value = items.pop()
                         # Append the current header to the value of the last

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -218,6 +218,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
 
         for key, value in self.get_header_items():
             key = key.upper().replace("-", "_")
+            value = value.replace("\r\n", "")
             if key not in ("CONTENT_TYPE", "CONTENT_LENGTH"):
                 key = "HTTP_" + key
                 if key in environ:
@@ -434,7 +435,8 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
         This function provides Python 2/3 compatibility as related to the
         parsing of request headers. Python 2.7 is not compliant with
         RFC 3875 Section 4.1.18 which requires multiple values for headers
-        to be provided. This function will return a matching list regardless
+        to be provided or RFC 2616 which allows for folding of multi-line
+        headers. This function will return a matching list regardless
         of Python version. It can be removed once Python 2.7 support
         is dropped.
 
@@ -445,9 +447,26 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             # W3C RFC 2616 Section 4.2.
             items = []
             for header in self.headers.headers:
-                # Remove "\n\r" from the header and split on ":" to get
+                # Remove "\r\n" from the header and split on ":" to get
                 # the field name and value.
-                key, value = header[0:-2].split(":", 1)
+                try:
+                    key, value = header[0:-2].split(":", 1)
+                except ValueError as e:
+                    # If header could not be slit with : but starts with white
+                    # space and it follows an existing header, it's a folded
+                    # header.
+                    if header[0] in ("\t", " ") and len(items) > 0:
+                        # Pop off the last header
+                        key, value = items.pop()
+                        # Append the current header to the value of the last
+                        # header which will be placed back on the end of the
+                        # list
+                        value = value + header
+                    # Otherwise it's just a bad header and should error
+                    else:
+                        # Re-raise the value error
+                        raise e
+
                 # Add the key and the value once stripped of leading
                 # white space. The specification allows for stripping
                 # trailing white space but the Python 3 code does not

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -451,7 +451,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                 # the field name and value.
                 try:
                     key, value = header[0:-2].split(":", 1)
-                except ValueError as e:
+                except ValueError:
                     # If header could not be slit with : but starts with white
                     # space and it follows an existing header, it's a folded
                     # header.
@@ -465,7 +465,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                     # Otherwise it's just a bad header and should error
                     else:
                         # Re-raise the value error
-                        raise e
+                        raise
 
                 # Add the key and the value once stripped of leading
                 # white space. The specification allows for stripping


### PR DESCRIPTION
Update the request header compatibility code for Python 2.7 to properly fold headers persuant to RFC- 2616.

Resolves #1080