### PR TITLE
Don't accidently create relative links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 1.0.0
 
 Unreleased
 
+-   Don't not create unexpected relative links, when creating redirects via
+    append_slash_redirect (:pr: `1538`)
 -   Drop support for Python 3.4. (:issue:`1478`)
 -   Remove code that issued deprecation warnings in version 0.15.
     (:issue:`1477`)

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -534,7 +534,7 @@ def append_slash_redirect(environ, code=301):
                     the redirect.
     :param code: the status code for the redirect.
     """
-    new_path = environ["PATH_INFO"].strip("/") + "/"
+    new_path = environ["PATH_INFO"].rstrip("/") + "/"
     query_string = environ.get("QUERY_STRING")
     if query_string:
         new_path += "?" + query_string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -338,6 +338,9 @@ def test_append_slash_redirect():
     response = client.get("foo", base_url="http://example.org/app")
     assert response.status_code == 301
     assert response.headers["Location"] == "http://example.org/app/foo/"
+    response = client.get("/foo", base_url="http://example.org/app")
+    assert response.status_code == 301
+    assert response.headers["Location"] == "http://example.org/foo/"
 
 
 def test_cached_property_doc():


### PR DESCRIPTION
append_slash_redirect should not change absolute links to relative ones.
That breaks serving applications via nginx.

e.g.
PATH_INFO="/help/test"  -> the Location would be "help/test/" and this is translated correctly by nginx to:
https://example.com/help/help/test