### PR TITLE
break cycle in chained exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Unreleased
     float values. (:issue:`1511`)
 -   Update :class:`~middleware.lint.LintMiddleware` to work on Python 3.
     (:issue:`1510`)
+-   The debugger detects cycles in chained exceptions and does not time
+    out in that case. (:issue:`1536`)
 
 
 Version 0.15.2

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -245,12 +245,14 @@ class Traceback(object):
         self.exception_type = exception_type
 
         self.groups = []
+        memo = set()
         while True:
             self.groups.append(Group(exc_type, exc_value, tb))
+            memo.add(exc_value)
             if PY2:
                 break
             exc_value = exc_value.__cause__ or exc_value.__context__
-            if exc_value is None:
+            if exc_value is None or exc_value in memo:
                 break
             exc_type = type(exc_value)
             tb = exc_value.__traceback__

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ skip_missing_interpreters = true
 deps =
     coverage
     pytest
+    pytest-timeout
     pytest-xprocess
     requests
     requests_unixsocket


### PR DESCRIPTION
closes #1536 

The traceback formatter followed `exc_value.__context__` infinitely, even if there was a cycle. Add a memo set to track what's been seen already and break when it detects a cycle. 