### PR TITLE
Fix SyntaxError on python 2.7.5

### DIFF
--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -852,6 +852,12 @@ class Rule(RuleFactory):
 
                 return result
 
+    @staticmethod
+    def _get_func_code(code, name):
+        globs, locs = {}, {}
+        exec(code, globs, locs)
+        return locs[name]
+
     def _compile_builder(self, append_unknown=True):
         defaults = self.defaults or {}
         dom_ops = []
@@ -943,11 +949,7 @@ class Rule(RuleFactory):
 
         module = ast.fix_missing_locations(ast.Module([func_ast]))
         code = compile(module, "<werkzeug routing>", "exec")
-
-        globs, locs = {}, {}
-        exec(code, globs, locs)
-
-        return locs[func_ast.name]
+        return self._get_func_code(code, func_ast.name)
 
     def build(self, values, append_unknown=True):
         """Assembles the relative url for that rule and the subdomain.


### PR DESCRIPTION
Resolves #1544

Here's the test plan I used, since we can't install 2.7.5 in CI this'll have to do:

```console
$ docker run --rm -ti -v "$PWD:/code:ro" centos:7
...
[root@9b75ddb7a51a code]# python -m compileall src/werkzeug/routing.py 
Compiling src/werkzeug/routing.py ...
SyntaxError: unqualified exec is not allowed in function '_compile_builder' it contains a nested function with free variables (routing.py, line 948)

    # outside of docker, I did `git apply patch` to get to the code you see in this PR

[root@9b75ddb7a51a code]# python -m compileall src/werkzeug/routing.py 
Compiling src/werkzeug/routing.py ...
Sorry [Errno 30] Read-only file system: 'src/werkzeug/routing.pyc'
```