### PR TITLE
Fix Profiler Docs Incorrect Import Path

### DIFF
--- a/docs/contrib/profiler.rst
+++ b/docs/contrib/profiler.rst
@@ -3,7 +3,7 @@ WSGI Application Profiler
 
 .. warning::
     ``werkzeug.contrib.profiler`` has moved to
-    :mod:`werkzeug.middleware.profile`. The old import is deprecated as
+    :mod:`werkzeug.middleware.profiler`. The old import is deprecated as
     of version 0.15 and will be removed in version 1.0.
 
 .. autoclass:: werkzeug.contrib.profiler.MergeStream


### PR DESCRIPTION
## Motivation
The deprecation warning for `werkzeug.contrib.profiler` points the user to `werkzeug.middleware.profile`. This path should be `werkzeug.middleware.profiler` - [middleware docs](https://werkzeug.palletsprojects.com/en/0.15.x/middleware/profiler/)