### PR TITLE
Prevent utils.invalidate_cached_property from deleting attributes

### DIFF
--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -114,6 +114,11 @@ def invalidate_cached_property(obj, name):
 
     You must pass the name of the cached property as the second argument.
     """
+    if not isinstance(getattr(obj.__class__, name, None), cached_property):
+        raise TypeError(
+            "Attribute {} of object {} is not a cached_property, "
+            "cannot be invalidated".format(name, obj)
+        )
     obj.__dict__[name] = _missing
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,6 +131,16 @@ def test_can_invalidate_cached_property():
     assert foo == [42, 42]
 
 
+def test_invalidate_cached_property_on_non_property():
+    class A(object):
+        def __init__(self):
+            self.prop = 42
+
+    a = A()
+    with pytest.raises(TypeError):
+        utils.invalidate_cached_property(a, "prop")
+
+
 def test_inspect_treats_cached_property_as_property():
     class A(object):
         @utils.cached_property


### PR DESCRIPTION
Simple check if given attribute is a `cached_property` could be enough to prevent deleting of other attributes.

Fixes: https://github.com/pallets/werkzeug/issues/1547 
CC @singingwolfboy 