### PR TITLE
Fix ast compile in old debug builds of python2.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Fix a ``TypeError`` due to changes to ``ast.Module`` in Python 3.8.
     :issue:`1551`
+-   Fix a C assertion failure in debug builds of some Python 2.7
+    releases. :issue:`1553`
 
 
 Version 0.15.4

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -939,9 +939,9 @@ class Rule(RuleFactory):
                 func_ast.args.args.append(ast.arg(arg, None))
             func_ast.args.kwarg = ast.arg(".kwargs", None)
         else:
-            func_ast.args.args.append(ast.Name(".self", ast.Load()))
+            func_ast.args.args.append(ast.Name(".self", ast.Param()))
             for arg in pargs + kargs:
-                func_ast.args.args.append(ast.Name(arg, ast.Load()))
+                func_ast.args.args.append(ast.Name(arg, ast.Param()))
             func_ast.args.kwarg = ".kwargs"
         for _ in kargs:
             func_ast.args.defaults.append(ast.Str(""))
@@ -951,7 +951,16 @@ class Rule(RuleFactory):
         # python3.8 changes the signature of `ast.Module`
         module = ast.parse("")
         module.body = [func_ast]
-        module = ast.fix_missing_locations(module)
+
+        # mark everything as on line 1, offset 0
+        # less error-prone than `ast.fix_missing_locations`
+        # bad line numbers cause an assert to fail in debug builds
+        for node in ast.walk(module):
+            if "lineno" in node._attributes:
+                node.lineno = 1
+            if "col_offset" in node._attributes:
+                node.col_offset = 0
+
         code = compile(module, "<werkzeug routing>", "exec")
         return self._get_func_code(code, func_ast.name)
 


### PR DESCRIPTION
Resolves #1553 

Reproducing this was difficult, the original post mentioned 2.7.9 which I could not reproduce on -- I was however able to reproduce using 2.7.8

I used docker to do this:

(to start the container)

```bash
docker run -v $PWD:/code:ro --rm -ti ubuntu:utopic bash
```

Once inside, I had to fix up apt so it would download using:

```bash
sed -i 's/archive\.ubuntu\.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
```

Then I did:

```bash
apt update && apt install python-dbg nano curl
curl https://asottile.github.io/get-virtualenv.py | python-dbg - /venv
```

And from there I was able to reproduce the issue(s) pretty easily.

Note that if you want to use `gdb` in docker, you'll need to run the container with `--privileged` so gdb can attach to a process