### PR TITLE
switch to cryptography library

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Unreleased
     ``samesite``. :issue:`1549`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
+-   Optional ad-hoc TLS support for the development server is handled
+    by cryptography instead of pyOpenSSL. :pr:`1555`
 
 
 Version 0.15.5

--- a/docs/serving.rst
+++ b/docs/serving.rst
@@ -229,7 +229,7 @@ certificate each time the server is reloaded.  Adhoc certificates are
 discouraged because modern browsers do a bad job at supporting them for
 security reasons.
 
-This feature requires the pyOpenSSL library to be installed.
+This feature requires the cryptography library to be installed.
 
 
 Unix Sockets

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -24,9 +24,9 @@ from werkzeug import _reloader
 from werkzeug import serving
 
 try:
-    import OpenSSL
+    import cryptography
 except ImportError:
-    OpenSSL = None
+    cryptography = None
 
 try:
     import watchdog
@@ -101,7 +101,9 @@ def test_broken_app(dev_server):
     not hasattr(ssl, "SSLContext"),
     reason="Missing PEP 466 (Python 2.7.9+) or Python 3.",
 )
-@pytest.mark.skipif(OpenSSL is None, reason="OpenSSL is required for cert generation.")
+@pytest.mark.skipif(
+    cryptography is None, reason="cryptography is required for cert generation."
+)
 def test_stdlib_ssl_contexts(dev_server, tmpdir):
     certificate, private_key = serving.make_ssl_devcert(str(tmpdir.mkdir("certs")))
 
@@ -124,7 +126,7 @@ def test_stdlib_ssl_contexts(dev_server, tmpdir):
     assert r.content == b"hello"
 
 
-@pytest.mark.skipif(OpenSSL is None, reason="OpenSSL is not installed.")
+@pytest.mark.skipif(cryptography is None, reason="cryptography is not installed.")
 def test_ssl_context_adhoc(dev_server):
     server = dev_server(
         """
@@ -139,7 +141,7 @@ def test_ssl_context_adhoc(dev_server):
     assert r.content == b"hello"
 
 
-@pytest.mark.skipif(OpenSSL is None, reason="OpenSSL is not installed.")
+@pytest.mark.skipif(cryptography is None, reason="cryptography is not installed.")
 def test_make_ssl_devcert(tmpdir):
     certificate, private_key = serving.make_ssl_devcert(str(tmpdir))
     assert os.path.isfile(certificate)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     pytest-xprocess
     requests
     requests_unixsocket
-    pyopenssl
+    cryptography
     greenlet
     watchdog
 commands = coverage run -p -m pytest --tb=short --basetemp={envtmpdir} {posargs}


### PR DESCRIPTION
pyOpenSSL is now a wrapper around the cryptography library. So why using a wrapper?
This PR switches to the pure cryptography library.
This should not break anything (dependency-wise) as pyOpenSSL depends for versions on cryptography.

Note: there could be some small changes (different company name in the stub certificate).
 