### PR TITLE
Detect opera as browser in user_agent

### DIFF
--- a/src/werkzeug/useragents.py
+++ b/src/werkzeug/useragents.py
@@ -46,7 +46,7 @@ class UserAgentParser(object):
         ("yahoo", "yahoo"),
         ("ask jeeves", "ask"),
         (r"aol|america\s+online\s+browser", "aol"),
-        ("opera", "opera"),
+        (r"opera|opr", "opera"),
         ("edge", "edge"),
         ("chrome|crios", "chrome"),
         ("seamonkey", "seamonkey"),

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -616,6 +616,14 @@ def test_user_agent_mixin():
             "3.5.1",
             "de",
         ),
+        (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36"
+            "(KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36 OPR/60.0.3255.95",
+            "opera",
+            "macos",
+            "60.0.3255.95",
+            None,
+        ),
     ]
     for ua, browser, platform, version, lang in user_agents:
         request = wrappers.Request({"HTTP_USER_AGENT": ua})


### PR DESCRIPTION
Now, we'll recognize `OPR` as "Opera" in a user agent string.

Fixes #1556