### PR TITLE
rm spurious use_memcache=False param

### DIFF
--- a/examples/coolmagic/utils.py
+++ b/examples/coolmagic/utils.py
@@ -25,7 +25,7 @@ from werkzeug.wrappers import BaseResponse
 local = Local()
 local_manager = LocalManager([local])
 template_env = Environment(
-    loader=FileSystemLoader(join(dirname(__file__), "templates"), use_memcache=False)
+    loader=FileSystemLoader(join(dirname(__file__), "templates"))
 )
 exported_views = {}
 


### PR DESCRIPTION
`jinja.FileSystemLoader.__init__` does not accept a `use_memcache` param:
https://github.com/pallets/jinja/blob/30685be0896119b3d6cd0f3d5baa8a616cfb8e14/jinja2/loaders.py#L160