### PR TITLE
Fixed bug in default redirect with non-ASCII characters

### DIFF
--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -124,6 +124,7 @@ from .urls import _fast_url_quote
 from .urls import url_encode
 from .urls import url_join
 from .urls import url_quote
+from .urls import url_unquote
 from .utils import cached_property
 from .utils import format_string
 from .utils import redirect
@@ -1847,6 +1848,7 @@ class MapAdapter(object):
             if r.provides_defaults_for(rule) and r.suitable_for(values, method):
                 values.update(r.defaults)
                 domain_part, path = r.build(values)
+                path = url_unquote(path, self.map.charset)
                 return self.make_redirect_url(path, query_args, domain_part=domain_part)
 
     def encode_query_args(self, query_args):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -381,10 +381,19 @@ def test_request_direct_charset_bug():
 def test_request_redirect_default():
     map = r.Map([r.Rule(u"/foo", defaults={"bar": 42}), r.Rule(u"/foo/<int:bar>")])
     adapter = map.bind("localhost", "/")
-
+    
     with pytest.raises(r.RequestRedirect) as excinfo:
         adapter.match(u"/foo/42")
     assert excinfo.value.new_url == "http://localhost/foo"
+
+
+def test_request_redirect_default_non_ascii():
+    map = r.Map([r.Rule(u"/bår", defaults={"baz": 42}), r.Rule(u"/bår/<int:baz>")])
+    adapter = map.bind("localhost", "/")
+
+    with pytest.raises(r.RequestRedirect) as excinfo:
+        adapter.match(u"/bår/42")
+    assert excinfo.value.new_url == "http://localhost/bår"
 
 
 def test_request_redirect_default_subdomain():


### PR DESCRIPTION
Fixes #152. Bug caused by two calls to url_quote and solved by unquoting
path after first call.