### PR TITLE
Suggest venv named "env" instead of "venv"

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,7 @@ First time setup
 
 - Create a virtualenv::
 
-        python3 -m venv venv
+        python3 -m venv env
         . venv/bin/activate
         # or "venv\Scripts\activate" on Windows
 


### PR DESCRIPTION
"env" is already in our `.gitignore` and is the name suggested in
Flask's `CONTRIBUTING.rst`