### PR TITLE
rm superfluous return None

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -321,9 +321,8 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
 
     def handle(self):
         """Handles a request ignoring dropped connections."""
-        rv = None
         try:
-            rv = BaseHTTPRequestHandler.handle(self)
+            BaseHTTPRequestHandler.handle(self)
         except (_ConnectionError, socket.timeout) as e:
             self.connection_dropped(e)
         except Exception as e:
@@ -331,7 +330,6 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                 raise
         if self.server.shutdown_signal:
             self.initiate_shutdown()
-        return rv
 
     def initiate_shutdown(self):
         """A horrible, horrible way to kill the server for Python 2.6 and


### PR DESCRIPTION
BaseHTTPRequestHandler.handle() returns None, so there is no need to capture and return its return value.

ref:
* https://docs.python.org/3/library/http.server.html#http.server.BaseHTTPRequestHandler.handle
* https://github.com/python/cpython/blob/f289084c83190cc72db4a70c58f007ec62e75247/Lib/http/server.py#L422