### PR TITLE
fix: Parse Crosswalk UA as Android not ChromeOS (#1024)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     :pr:`1532`
 -   The user agent for Opera 60 on Mac is correctly reported as
     "opera" instead of "chrome". :issue:`1556`
+-   The platform for Crosswalk on Android is correctly reported as
+    "android" instead of "chromeos". (:pr:`1572`)
 
 
 Version 0.15.5

--- a/src/werkzeug/useragents.py
+++ b/src/werkzeug/useragents.py
@@ -18,7 +18,7 @@ class UserAgentParser(object):
     """A simple user agent parser.  Used by the `UserAgent`."""
 
     platforms = (
-        ("cros", "chromeos"),
+        (" cros ", "chromeos"),
         ("iphone|ios", "iphone"),
         ("ipad", "ipad"),
         (r"darwin|mac|os\s*x", "macos"),

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -624,6 +624,15 @@ def test_user_agent_mixin():
             "60.0.3255.95",
             None,
         ),
+        (
+            "Mozilla/5.0 (Linux; Android 4.4.4; Google Nexus 7 2013 - 4.4.4 - "
+            "API 19 - 1200x1920 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/51.0.2704.106 Crosswalk/21.51.546.7 Safari/537.36",
+            "chrome",
+            "android",
+            "51.0.2704.106",
+            None,
+        ),
     ]
     for ua, browser, platform, version, lang in user_agents:
         request = wrappers.Request({"HTTP_USER_AGENT": ua})


### PR DESCRIPTION
In #1024, it was shown that when using the [Crosswalk Webview](crosswalk-project/crosswalk), the user agent parsing in Werkzeug would categorize `Crosswalk` as `ChromeOS` rather than `Android` although it was running on Android.

This occurred as we rely on matching `cros` anywhere in the UA string to determine if a UA is from `ChromeOS`. Upon reviewing `ChromeOS` [UA strings](http://www.webapps-online.com/online-tools/user-agent-strings/dv/operatingsystem52026/chrome-os), it became clear that `CrOS` is always surrounded by a space on either side. As such, this change makes us check for ` cros ` instead of `cros` and adds test coverage for this case.

It should be noted that on #1024, @alexpantyukhin proposes ensuring we check all strings as separate words (e.g. expecting a space on either side or the beginning or end of line). This may be reasonable but I'm unclear of how it might affect parsing other UA strings that aren't covered in the test cases.