### PR TITLE
Use MIME parameters to match Accept header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Unreleased
     :pr:`1532`
 -   The user agent for Opera 60 on Mac is correctly reported as
     "opera" instead of "chrome". :issue:`1556`
+-   Use MIME parameters to better match Accept header. :issue:`458`
 -   The platform for Crosswalk on Android is correctly reported as
     "android" instead of "chromeos". (:pr:`1572`)
 -   Issue a warning when the current server name does not match the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,6 @@ Unreleased
     :pr:`1532`
 -   The user agent for Opera 60 on Mac is correctly reported as
     "opera" instead of "chrome". :issue:`1556`
--   Use MIME parameters to better match Accept header. :issue:`458`
 -   The platform for Crosswalk on Android is correctly reported as
     "android" instead of "chromeos". (:pr:`1572`)
 -   Issue a warning when the current server name does not match the
@@ -37,9 +36,11 @@ Unreleased
     ``samesite``. :issue:`1549`
 -   Support the Content Security Policy header through the
     `Response.content_security_policy` data structure. :pr:`1617`
--   ``AcceptLanguage`` will fall back to matching "en" for "en-US" or
+-   ``LanguageAccept`` will fall back to matching "en" for "en-US" or
     "en-US" for "en" to better support clients or translations that
     only match at the primary language tag. :issue:`450`, :pr:`1507`
+-   ``MIMEAccept`` uses MIME parameters for specificity when matching.
+    :issue:`458`, :pr:`1574`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
 -   Optional ad-hoc TLS support for the development server is handled

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1099,6 +1099,10 @@ class TestMIMEAccept(object):
         accept = self.storage_class([("*/*", 1), ("text/html", 1), ("image/*", 1)])
         assert accept.best_match(["image/png", "text/html"]) == "text/html"
         assert accept.best_match(["text/plain", "image/png"]) == "image/png"
+        accept = self.storage_class([("text/html", 1), ("text/html; level=1", 1)])
+        assert (
+            accept.best_match(["text/html", "text/html;level=1"]) == "text/html;level=1"
+        )
 
 
 class TestLanguageAccept(object):

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -38,6 +38,7 @@ from werkzeug._compat import itervalues
 from werkzeug._compat import PY2
 from werkzeug._compat import text_type
 from werkzeug.datastructures import LanguageAccept
+from werkzeug.datastructures import MIMEAccept
 from werkzeug.datastructures import Range
 from werkzeug.exceptions import BadRequestKeyError
 
@@ -1084,25 +1085,48 @@ class TestAccept(object):
 
 
 class TestMIMEAccept(object):
-    storage_class = datastructures.MIMEAccept
-
-    def test_accept_wildcard_subtype(self):
-        accept = self.storage_class([("text/*", 1)])
-        assert accept.best_match(["text/html"], default=None) == "text/html"
-        assert accept.best_match(["image/png", "text/plain"]) == "text/plain"
-        assert accept.best_match(["image/png"], default=None) is None
-
-    def test_accept_wildcard_specificity(self):
-        accept = self.storage_class([("*/*", 1), ("text/html", 1)])
-        assert accept.best_match(["image/png", "text/html"]) == "text/html"
-        assert accept.best_match(["image/png", "text/plain"]) == "image/png"
-        accept = self.storage_class([("*/*", 1), ("text/html", 1), ("image/*", 1)])
-        assert accept.best_match(["image/png", "text/html"]) == "text/html"
-        assert accept.best_match(["text/plain", "image/png"]) == "image/png"
-        accept = self.storage_class([("text/html", 1), ("text/html; level=1", 1)])
-        assert (
-            accept.best_match(["text/html", "text/html;level=1"]) == "text/html;level=1"
-        )
+    @pytest.mark.parametrize(
+        ("values", "matches", "default", "expect"),
+        [
+            ([("text/*", 1)], ["text/html"], None, "text/html"),
+            ([("text/*", 1)], ["image/png"], "text/plain", "text/plain"),
+            ([("text/*", 1)], ["image/png"], None, None),
+            (
+                [("*/*", 1), ("text/html", 1)],
+                ["image/png", "text/html"],
+                None,
+                "text/html",
+            ),
+            (
+                [("*/*", 1), ("text/html", 1)],
+                ["image/png", "text/plain"],
+                None,
+                "image/png",
+            ),
+            (
+                [("*/*", 1), ("text/html", 1), ("image/*", 1)],
+                ["image/png", "text/html"],
+                None,
+                "text/html",
+            ),
+            (
+                [("*/*", 1), ("text/html", 1), ("image/*", 1)],
+                ["text/plain", "image/png"],
+                None,
+                "image/png",
+            ),
+            (
+                [("text/html", 1), ("text/html; level=1", 1)],
+                ["text/html;level=1"],
+                None,
+                "text/html;level=1",
+            ),
+        ],
+    )
+    def test_mime_accept(self, values, matches, default, expect):
+        accept = MIMEAccept(values)
+        match = accept.best_match(matches, default=default)
+        assert match == expect
 
 
 class TestLanguageAccept(object):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -61,6 +61,13 @@ class TestHTTPUtility(object):
         assert a.best_match(["foo/bar", "bar/foo"], default="foo/bar") == "foo/bar"
         assert a.best_match(["application/xml", "text/xml"]) == "application/xml"
 
+    def test_accept_mime_specificity(self):
+        a = http.parse_accept_header(
+            "text/*, text/html, text/html;level=1, */*", datastructures.MIMEAccept
+        )
+        assert a.best_match(["text/html; version=1", "text/html"]) == "text/html"
+        assert a.best_match(["text/html", "text/html; level=1"]) == "text/html; level=1"
+
     def test_charset_accept(self):
         a = http.parse_accept_header(
             "ISO-8859-1,utf-8;q=0.7,*;q=0.7", datastructures.CharsetAccept


### PR DESCRIPTION
Previously, we didn't parse MIME parameters or use them to match or
prioritize content types. Now, we'll normalize and compare MIME
parameters and consider a MIME type with parameters higher priority than
one without them.

Fixes #458