### PR TITLE
rm superfluous `<local_var> = None` last line

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -297,7 +297,6 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
             finally:
                 if hasattr(application_iter, "close"):
                     application_iter.close()
-                application_iter = None
 
         try:
             execute(self.server.app)


### PR DESCRIPTION
...of (nested) function. This statement has no effect.