### PR TITLE
Issue warning when current server name does not match configured server name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Unreleased
     "opera" instead of "chrome". :issue:`1556`
 -   The platform for Crosswalk on Android is correctly reported as
     "android" instead of "chromeos". (:pr:`1572`)
+-   Issue warning when current server name does not match configured
+    server name. :issue:`760`
 
 
 Version 0.15.5

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -100,6 +100,7 @@ import difflib
 import posixpath
 import re
 import uuid
+import warnings
 from pprint import pformat
 from threading import Lock
 
@@ -1512,10 +1513,15 @@ class Map(object):
             offset = -len(real_server_name)
             if cur_server_name[offset:] != real_server_name:
                 # This can happen even with valid configs if the server was
-                # accesssed directly by IP address under some situations.
+                # accessed directly by IP address under some situations.
                 # Instead of raising an exception like in Werkzeug 0.7 or
                 # earlier we go by an invalid subdomain which will result
                 # in a 404 error on matching.
+                warnings.warn(
+                    "Current server name '{}' doesn't match configured "
+                    "server name '{}'".format(wsgi_server_name, real_server_name),
+                    stacklevel=2,
+                )
                 subdomain = "<invalid>"
             else:
                 subdomain = ".".join(filter(None, cur_server_name[:offset]))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -358,6 +358,16 @@ def test_http_host_before_server_name():
     assert adapter.build("index") == "http://wiki.example.com/"
 
 
+def test_invalid_subdomain_warning():
+    env = create_environ("/foo")
+    env["SERVER_NAME"] = env["HTTP_HOST"] = "foo.example.com"
+    m = r.Map([r.Rule("/foo", endpoint="foo")])
+    with pytest.warns(UserWarning) as record:
+        a = m.bind_to_environ(env, server_name="bar.example.com")
+    assert a.subdomain == "<invalid>"
+    assert len(record) == 1
+
+
 def test_adapter_url_parameter_sorting():
     map = r.Map(
         [r.Rule("/", endpoint="index")], sort_parameters=True, sort_key=lambda x: x[1]


### PR DESCRIPTION
Similar to #793 but issues a warning which only appears once. Fixes #760