### PR TITLE
add InternalServerError.original_exception attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Unreleased
 -   A configured server name with the default port for a scheme will
     match the current server name without the port if the current scheme
     matches. :pr:`1584`
+-   :exc:`~exceptions.InternalServerError` has a ``original_exception``
+    attribute that frameworks can use to track the original cause of the
+    error. :pr:`1590`
 
 
 Version 0.15.5

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -53,6 +53,7 @@ The following error classes exist in Werkzeug:
 .. autoexception:: RequestHeaderFieldsTooLarge
 
 .. autoexception:: InternalServerError
+    :members:
 
 .. autoexception:: NotImplemented
 

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -624,6 +624,9 @@ class InternalServerError(HTTPException):
 
     Raise if an internal server error occurred.  This is a good fallback if an
     unknown error occurred in the dispatcher.
+
+    .. versionchanged:: 1.0.0
+        Added the :attr:`original_exception` attribute.
     """
 
     code = 500
@@ -632,6 +635,15 @@ class InternalServerError(HTTPException):
         " complete your request. Either the server is overloaded or"
         " there is an error in the application."
     )
+
+    def __init__(self, description=None, response=None, original_exception=None):
+        #: The original exception that caused this 500 error. Can be
+        #: used by frameworks to provide context when handling
+        #: unexpected errors.
+        self.original_exception = original_exception
+        super(InternalServerError, self).__init__(
+            description=description, response=response
+        )
 
 
 class NotImplemented(HTTPException):


### PR DESCRIPTION
This goes along with pallets/flask#3266. For unhandled errors, Flask will always pass an `InternalServerError` to the handler, and will now set this attribute to the original error.