### PR TITLE
simplify BadRequestKeyError.show_exception logic

### DIFF
--- a/src/werkzeug/debug/shared/style.css
+++ b/src/werkzeug/debug/shared/style.css
@@ -62,7 +62,7 @@ div.traceback div.source.expanded span.ws {
     display: inline;
 }
 
-div.traceback blockquote { margin: 1em 0 0 0; padding: 0; }
+div.traceback blockquote { margin: 1em 0 0 0; padding: 0; white-space: pre-line; }
 div.traceback img { float: right; padding: 2px; margin: -3px 2px 0 0; display: none; }
 div.traceback img:hover { background-color: #ddd; cursor: pointer;
                           border-color: #BFDDE0; }

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -109,6 +109,7 @@ class HTTPException(Exception):
         """
 
         class newcls(cls, exception):
+            _description = cls.description
             show_exception = False
 
             def __init__(self, arg=None, *args, **kwargs):
@@ -119,18 +120,22 @@ class HTTPException(Exception):
                 else:
                     exception.__init__(self, arg)
 
-            def get_description(self, environ=None):
-                out = super(cls, self).get_description(environ=environ)
-
-                if self.show_exception and self.args:
-                    out += "<p><pre><code>{}: {}</code></pre></p>".format(
-                        exception.__name__, escape(exception.__str__(self))
+            @property
+            def description(self):
+                if self.show_exception:
+                    return "{}\n{}: {}".format(
+                        self._description, exception.__name__, exception.__str__(self)
                     )
 
-                return out
+                return self._description
+
+            @description.setter
+            def description(self, value):
+                self._description = value
 
         newcls.__module__ = sys._getframe(1).f_globals.get("__name__")
-        newcls.__name__ = name or cls.__name__ + exception.__name__
+        name = name or cls.__name__ + exception.__name__
+        newcls.__name__ = newcls.__qualname__ = name
         return newcls
 
     @property
@@ -140,7 +145,7 @@ class HTTPException(Exception):
 
     def get_description(self, environ=None):
         """Get the description."""
-        return u"<p>%s</p>" % escape(self.description)
+        return u"<p>%s</p>" % escape(self.description).replace("\n", "<br>")
 
     def get_body(self, environ=None):
         """Get the HTML body."""


### PR DESCRIPTION
simplifies the changes from #1592 

Debugger now shows multiline messages on multiple lines at bottom of traceback. The formatted `BadRequestKeyError` message has the correct name rather than `BadRequest.wrap.<locals>.newcls`, by setting `__qualname__` to `__name__`.