### PR TITLE
User getattr for getting reloader package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
     :pr:`1592`
 -   Work around an issue in some external debuggers that caused the
     reloader to fail. :issue:`1607`
+-   Work around an issue where the reloader couldn't introspect a
+    setuptools script installed as an egg. :issue:`1600`
 
 
 Version 0.15.4

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -73,7 +73,7 @@ def _get_args_for_reloading():
     # Need to look at main module to determine how it was executed.
     __main__ = sys.modules["__main__"]
 
-    if __main__.__package__ is None:
+    if getattr(__main__, "__package__", None) is None:
         # Executed a file, like "python app.py".
         py_script = os.path.abspath(py_script)
 

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -73,6 +73,8 @@ def _get_args_for_reloading():
     # Need to look at main module to determine how it was executed.
     __main__ = sys.modules["__main__"]
 
+    # The value of __package__ indicates how Python was called. It may
+    # not exist if a setuptools script is installed as an egg.
     if getattr(__main__, "__package__", None) is None:
         # Executed a file, like "python app.py".
         py_script = os.path.abspath(py_script)


### PR DESCRIPTION
The main `__script__` may not have a package when running as setup
scripts

Closes #1600