### PR TITLE
Implements case-insensitive header equality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Unreleased
 -   :exc:`~exceptions.InternalServerError` has a ``original_exception``
     attribute that frameworks can use to track the original cause of the
     error. :pr:`1590`
+-   Headers are tested for equality independent of the header key case,
+    such that ``X-Foo`` is the same as ``x-foo``. :pr:`1605`
 
 
 Version 0.15.5

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -977,7 +977,12 @@ class Headers(object):
         raise exceptions.BadRequestKeyError(key)
 
     def __eq__(self, other):
-        return other.__class__ is self.__class__ and set(other._list) == set(self._list)
+        def lowered(item):
+            return (item[0].lower(),) + item[1:]
+
+        return other.__class__ is self.__class__ and set(
+            map(lowered, other._list)
+        ) == set(map(lowered, self._list))
 
     __hash__ = None
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -800,6 +800,20 @@ class TestHeaders(object):
                 strict_eq(key, u"Key")
                 strict_eq(value, u"Value")
 
+    def test_equality(self):
+        # test equality, given keys are case insensitive
+        h1 = self.storage_class()
+        h1.add("X-Foo", "foo")
+        h1.add("X-Bar", "bah")
+        h1.add("X-Bar", "humbug")
+
+        h2 = self.storage_class()
+        h2.add("x-foo", "foo")
+        h2.add("x-bar", "bah")
+        h2.add("x-bar", "humbug")
+
+        assert h1 == h2
+
 
 class TestEnvironHeaders(object):
     storage_class = datastructures.EnvironHeaders


### PR DESCRIPTION
Currently this fails:

```python
assert datastructures.Headers({'X-Foo': 'fu'}) == datastructures.Headers({'x-foo': 'fu'})
```

The `Headers` class otherwise respects the case insensitivity of keys, this patch just extends this to the equality check.