### PR TITLE
work around issue using pydevd with the reloader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,9 @@ Unreleased
     message to the description if ``e.show_exception`` is set to
     ``True``. This is a more secure default than the original 0.15.0
     behavior and makes it easier to control without losing information.
-    (:pr:`1592`)
+    :pr:`1592`
+-   Work around an issue in some external debuggers that caused the
+    reloader to fail. :issue:`1607`
 
 
 Version 0.15.4


### PR DESCRIPTION
pydevd incorrectly replaces `sys.argv[0]` with `flask` instead of `/path/to/flask` when running with `python -m flask`. To work around this, assume that the argument is already correct if it does not point to a file. This could potentially fail if a project literally has a file called "flask" in the current directory.

closes #1607 