### PR TITLE
don't detect executable file for reloader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ Unreleased
     reloader to fail. :issue:`1607`
 -   Work around an issue where the reloader couldn't introspect a
     setuptools script installed as an egg. :issue:`1600`
+-   The reloader will use ``sys.executable`` even if the script is
+    marked executable, reverting a behavior intended for NixOS
+    introduced in 0.15. The reloader should no longer cause
+    ``OSError: [Errno 8] Exec format error``. :issue:`1482`,
+    :issue:`1580`
 -   ``SharedDataMiddleware`` safely handles paths with Windows drive
     names. :issue:`1589`
 

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -61,11 +61,8 @@ def _find_observable_paths(extra_files=None):
 
 
 def _get_args_for_reloading():
-    """Returns the executable. This contains a workaround for windows
-    if the executable is incorrectly reported to not have the .exe
-    extension which can cause bugs on reloading.  This also contains
-    a workaround for linux where the file is executable (possibly with
-    a program other than python)
+    """Determine how the script was executed, and return the args needed
+    to execute it again in a new process.
     """
     rv = [sys.executable]
     py_script = sys.argv[0]
@@ -90,11 +87,6 @@ def _get_args_for_reloading():
                 and os.path.splitext(py_script)[1] == ".exe"
             ):
                 rv.pop(0)
-
-        elif os.path.isfile(py_script) and os.access(py_script, os.X_OK):
-            # The file is marked as executable. Nix adds a wrapper that
-            # shouldn't be called with the Python executable.
-            rv.pop(0)
 
         rv.append(py_script)
     else:


### PR DESCRIPTION
In order to support NixOS wrappers, the reloader would call an executable script directly. This caused issues with Windows, Docker, and other common development environments, resulting in an "Exec format error". Revert that change until a better workaround can be found.

Reverts #1242 
Fixes #1482 
Fixes #1504
Fixes #1580 
Fixes pallets/flask#3133
Fixes pallets/flask#3189

cc @samdroid-apps 