### PR TITLE
Minor bugfix to CacheControl datastructure

### DIFF
--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1940,7 +1940,7 @@ class _CacheControl(UpdateDictMixin, dict):
                 self.pop(key, None)
         else:
             if value is None:
-                self.pop(key)
+                self.pop(key, None)
             elif value is True:
                 self[key] = None
             else:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -978,6 +978,12 @@ class TestCacheControl(object):
         cc = datastructures.RequestCacheControl([("max-age", "0"), ("private", "True")])
         assert repr(cc) == "<RequestCacheControl max-age='0' private='True'>"
 
+    def test_set_none(self):
+        cc = datastructures.ResponseCacheControl([("max-age", "0")])
+        assert cc.no_cache is None
+        cc.no_cache = None
+        assert cc.no_cache is None
+
 
 class TestAccept(object):
     storage_class = datastructures.Accept


### PR DESCRIPTION
This ensures that CacheControl directives can be set to None (removed)
multiple times without erroring i.e.,

    cc = CacheControl()
    cc.no_cache = None
    cc.no_cache = None  # Previously this would raise a KeyError