### PR TITLE
Fix the bug of reloader with windows path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,7 @@
 .. currentmodule:: werkzeug
 
+-   Fix a bug that the reloader doesn't populate the path correctly on
+    Windows. :issue:`1614`
 Version 0.15.5
 --------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,16 @@
 .. currentmodule:: werkzeug
 
--   Fix a bug that the reloader doesn't populate the path correctly on
-    Windows. :issue:`1614`
+Version 0.15.6
+--------------
+
+Unreleased
+
+-   Work around a bug in pip that caused the reloader to fail on
+    Windows when the script was an entry point. This fixes the issue
+    with Flask's `flask run` command failing with "No module named
+    Scripts\flask". :issue:`1614`
+
+
 Version 0.15.5
 --------------
 

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -72,7 +72,7 @@ def _get_args_for_reloading():
 
     # The value of __package__ indicates how Python was called. It may
     # not exist if a setuptools script is installed as an egg.
-    if getattr(__main__, "__package__", None) is None:
+    if not getattr(__main__, "__package__", None):
         # Executed a file, like "python app.py".
         py_script = os.path.abspath(py_script)
 

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -71,8 +71,14 @@ def _get_args_for_reloading():
     __main__ = sys.modules["__main__"]
 
     # The value of __package__ indicates how Python was called. It may
-    # not exist if a setuptools script is installed as an egg.
-    if not getattr(__main__, "__package__", None):
+    # not exist if a setuptools script is installed as an egg. It may be
+    # set incorrectly for entry points created with pip on Windows.
+    if getattr(__main__, "__package__", None) is None or (
+        os.name == "nt"
+        and __main__.__package__ == ""
+        and not os.path.exists(py_script)
+        and os.path.exists(py_script + ".exe")
+    ):
         # Executed a file, like "python app.py".
         py_script = os.path.abspath(py_script)
 
@@ -83,7 +89,7 @@ def _get_args_for_reloading():
                 py_script += ".exe"
 
             if (
-                os.path.splitext(rv[0])[1] == ".exe"
+                os.path.splitext(sys.executable)[1] == ".exe"
                 and os.path.splitext(py_script)[1] == ".exe"
             ):
                 rv.pop(0)


### PR DESCRIPTION
Fix #1614 

The root cause is that when running as `flask run` the value of `__main__.__package__` is `""`. Modify the condition a little to make it fix the first branch.

Tested `python app.py`, `flask run`, `python -m flask run` on both Windows and WSL Ubuntu. All work fine. I have not got a PyDev running for testing, and it would be great if someone can help, but I think it should work with little risk.