### PR TITLE
Fix mispelled `rooute` var in test

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -607,7 +607,7 @@ def test_default_converters():
 def test_uuid_converter():
     m = r.Map([r.Rule("/a/<uuid:a_uuid>", endpoint="a")])
     a = m.bind("example.org", "/")
-    rooute, kwargs = a.match("/a/a8098c1a-f86e-11da-bd1a-00112444be1e")
+    route, kwargs = a.match("/a/a8098c1a-f86e-11da-bd1a-00112444be1e")
     assert type(kwargs["a_uuid"]) == uuid.UUID
 
 


### PR DESCRIPTION
Minor typo fix for unused variable in multiple assignment within a test. `rooute` -> `route`