### PR TITLE
ProxyFix.x_proto defaults to 1, num_proxies sets x_host and x_proto

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Unreleased
     Windows when the script was an entry point. This fixes the issue
     with Flask's `flask run` command failing with "No module named
     Scripts\flask". :issue:`1614`
+-   ``ProxyFix`` trusts the ``X-Forwarded-Proto`` header by default.
+    :issue:`1630`
+-   The deprecated ``num_proxies`` argument to ``ProxyFix`` sets
+    ``x_for``, ``x_proto``, and ``x_host`` to match 0.14 behavior. This
+    is intended to make intermediate upgrades less disruptive, but the
+    argument will still be removed in 1.0. :issue:`1630`
 
 
 Version 0.15.5

--- a/src/werkzeug/middleware/proxy_fix.py
+++ b/src/werkzeug/middleware/proxy_fix.py
@@ -77,7 +77,7 @@ class ProxyFix(object):
     """
 
     def __init__(
-        self, app, num_proxies=None, x_for=1, x_proto=0, x_host=0, x_port=0, x_prefix=0
+        self, app, num_proxies=None, x_for=1, x_proto=1, x_host=0, x_port=0, x_prefix=0
     ):
         self.app = app
         self.x_for = x_for
@@ -112,11 +112,15 @@ class ProxyFix(object):
         if value is not None:
             warnings.warn(
                 "'num_proxies' is deprecated as of version 0.15 and"
-                " will be removed in version 1.0. Use 'x_for' instead.",
+                " will be removed in version 1.0. Use"
+                " 'x_for={value}, x_proto={value}, x_host={value}'"
+                " instead.".format(value=value),
                 DeprecationWarning,
                 stacklevel=2,
             )
             self.x_for = value
+            self.x_proto = value
+            self.x_host = value
 
     def get_remote_addr(self, forwarded_for):
         """Get the real ``remote_addr`` by looking backwards ``x_for``

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -18,8 +18,9 @@ from werkzeug.wrappers import Response
                 "REMOTE_ADDR": "192.168.0.2",
                 "HTTP_HOST": "spam",
                 "HTTP_X_FORWARDED_FOR": "192.168.0.1",
+                "HTTP_X_FORWARDED_PROTO": "https",
             },
-            "http://spam/",
+            "https://spam/",
             id="for",
         ),
         pytest.param(
@@ -178,6 +179,8 @@ def test_proxy_fix(kwargs, base, url_root):
 def test_proxy_fix_deprecations():
     app = pytest.deprecated_call(ProxyFix, None, 2)
     assert app.x_for == 2
+    assert app.x_proto == 2
+    assert app.x_host == 2
 
     with pytest.deprecated_call():
         assert app.num_proxies == 2


### PR DESCRIPTION
fixes #1630 

If the deprecated `num_proxies` argument is used, it will set `x_for`, `x_proto`, and `x_host` to match 0.14 behavior. This should make the upgrade path nicer, although the argument will still be removed (making the first argument `x_for`) in 1.0.

`x_proto` now defaults to 1, since it doesn't seem like there's any significant impact if server doesn't set it and the client can control what scheme is used. The most I can think of is that they cause `http` links to be generated, but that should be handled by other browser security like HSTS.

`x_host` continues to default to 0 for security. If the server does not set it and a client can control the `Host` header with it, there are too many behaviors they may gain control of. Therefore users should be deliberate in both configuring their server to set the header, and configuring their application to expect it.