### PR TITLE
is_resource_modified works for all methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Unreleased
     configured to verify client certificates, the certificate in PEM
     format will be available as ``environ["SSL_CLIENT_CERT"]``.
     :pr:`1469`
+-   ``is_resource_modified`` will run for methods other than ``GET`` and
+    ``HEAD``, rather than always returning ``False``. :issue:`409`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
 -   Optional ad-hoc TLS support for the development server is handled

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -967,13 +967,14 @@ def is_resource_modified(
     :param ignore_if_range: If `False`, `If-Range` header will be taken into
                             account.
     :return: `True` if the resource was modified, otherwise `False`.
+
+    .. versionchanged:: 1.0.0
+        The check is run for methods other than ``GET`` and ``HEAD``.
     """
     if etag is None and data is not None:
         etag = generate_etag(data)
     elif data is not None:
         raise TypeError("both data and etag given")
-    if environ["REQUEST_METHOD"] not in ("GET", "HEAD"):
-        return False
 
     unmodified = False
     if isinstance(last_modified, string_types):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -386,9 +386,9 @@ class TestHTTPUtility(object):
     def test_is_resource_modified(self):
         env = create_environ()
 
-        # ignore POST
+        # any method is allowed
         env["REQUEST_METHOD"] = "POST"
-        assert not http.is_resource_modified(env, etag="testing")
+        assert http.is_resource_modified(env, etag="testing")
         env["REQUEST_METHOD"] = "GET"
 
         # etagify from data


### PR DESCRIPTION
closes #409 

Based on discussion in the issue and a reading of RFC 7232, `is_resource_modified` can be run for any method, not just `GET` and `HEAD`.