### PR TITLE
remove lazy importer, fix circular imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@ Unreleased
 -   Drop support for Python 3.4. (:issue:`1478`)
 -   Remove code that issued deprecation warnings in version 0.15.
     (:issue:`1477`)
+-   Deprecate most top-level attributes provided by the ``werkzeug``
+    module in favor of direct imports. For example, instead of
+    ``import werkzeug; werkzeug.url_quote``, do
+    ``from werkzeug.urls import url_quote. A deprecation warning will
+    show the correct import to use. ``werkzeug.exceptions`` and
+    ``werkzeug.routing`` should also be imported instead of accessed,
+    but for technical reasons can't show a warning.
+    :issue:`2`, :pr:`1640`
 -   Added ``utils.invalidate_cached_property()`` to invalidate cached
     properties. (:pr:`1474`)
 -   Directive keys for the ``Set-Cookie`` response header are not

--- a/src/werkzeug/__init__.py
+++ b/src/werkzeug/__init__.py
@@ -5,137 +5,213 @@ werkzeug
 Werkzeug is the Swiss Army knife of Python web development.
 
 It provides useful classes and functions for any WSGI application to
-make the life of a python web developer much easier. All of the provided
+make the life of a Python web developer much easier. All of the provided
 classes are independent from each other so you can mix it with any other
 library.
 
 :copyright: 2007 Pallets
 :license: BSD-3-Clause
 """
-from . import exceptions
-from . import routing
-from ._internal import _easteregg
-from .datastructures import Accept
-from .datastructures import Authorization
-from .datastructures import CallbackDict
-from .datastructures import CharsetAccept
-from .datastructures import CombinedMultiDict
-from .datastructures import EnvironHeaders
-from .datastructures import ETags
-from .datastructures import FileMultiDict
-from .datastructures import FileStorage
-from .datastructures import Headers
-from .datastructures import HeaderSet
-from .datastructures import ImmutableDict
-from .datastructures import ImmutableList
-from .datastructures import ImmutableMultiDict
-from .datastructures import ImmutableOrderedMultiDict
-from .datastructures import ImmutableTypeConversionDict
-from .datastructures import LanguageAccept
-from .datastructures import MIMEAccept
-from .datastructures import MultiDict
-from .datastructures import OrderedMultiDict
-from .datastructures import RequestCacheControl
-from .datastructures import ResponseCacheControl
-from .datastructures import TypeConversionDict
-from .datastructures import WWWAuthenticate
-from .debug import DebuggedApplication
-from .exceptions import abort
-from .exceptions import Aborter
-from .formparser import parse_form_data
-from .http import cookie_date
-from .http import dump_cookie
-from .http import dump_header
-from .http import dump_options_header
-from .http import generate_etag
-from .http import http_date
-from .http import HTTP_STATUS_CODES
-from .http import is_entity_header
-from .http import is_hop_by_hop_header
-from .http import is_resource_modified
-from .http import parse_accept_header
-from .http import parse_authorization_header
-from .http import parse_cache_control_header
-from .http import parse_cookie
-from .http import parse_date
-from .http import parse_dict_header
-from .http import parse_etags
-from .http import parse_list_header
-from .http import parse_options_header
-from .http import parse_set_header
-from .http import parse_www_authenticate_header
-from .http import quote_etag
-from .http import quote_header_value
-from .http import remove_entity_headers
-from .http import remove_hop_by_hop_headers
-from .http import unquote_etag
-from .http import unquote_header_value
-from .local import Local
-from .local import LocalManager
-from .local import LocalProxy
-from .local import LocalStack
-from .local import release_local
-from .middleware.dispatcher import DispatcherMiddleware
-from .middleware.shared_data import SharedDataMiddleware
-from .security import check_password_hash
-from .security import generate_password_hash
+import sys
+from types import ModuleType
+
 from .serving import run_simple
 from .test import Client
-from .test import create_environ
-from .test import EnvironBuilder
-from .test import run_wsgi_app
-from .testapp import test_app
-from .urls import Href
-from .urls import iri_to_uri
-from .urls import uri_to_iri
-from .urls import url_decode
-from .urls import url_encode
-from .urls import url_fix
-from .urls import url_quote
-from .urls import url_quote_plus
-from .urls import url_unquote
-from .urls import url_unquote_plus
-from .useragents import UserAgent
-from .utils import append_slash_redirect
-from .utils import ArgumentValidationError
-from .utils import bind_arguments
-from .utils import cached_property
-from .utils import environ_property
-from .utils import escape
-from .utils import find_modules
-from .utils import format_string
-from .utils import header_property
-from .utils import html
-from .utils import HTMLBuilder
-from .utils import import_string
-from .utils import redirect
-from .utils import secure_filename
-from .utils import unescape
-from .utils import validate_arguments
-from .utils import xhtml
-from .wrappers import AcceptMixin
-from .wrappers import AuthorizationMixin
-from .wrappers import BaseRequest
-from .wrappers import BaseResponse
-from .wrappers import CommonRequestDescriptorsMixin
-from .wrappers import CommonResponseDescriptorsMixin
-from .wrappers import ETagRequestMixin
-from .wrappers import ETagResponseMixin
 from .wrappers import Request
 from .wrappers import Response
-from .wrappers import ResponseStreamMixin
-from .wrappers import UserAgentMixin
-from .wrappers import WWWAuthenticateMixin
-from .wsgi import ClosingIterator
-from .wsgi import extract_path_info
-from .wsgi import FileWrapper
-from .wsgi import get_current_url
-from .wsgi import get_host
-from .wsgi import LimitedStream
-from .wsgi import make_line_iter
-from .wsgi import peek_path_info
-from .wsgi import pop_path_info
-from .wsgi import responder
-from .wsgi import wrap_file
 
 __version__ = "1.0.0.dev0"
+
+__all__ = ["run_simple", "Client", "Request", "Response", "__version__"]
+
+
+class DeprecatedImportModule(ModuleType):
+    """Wrap a module in order to raise """
+
+    def __init__(self, name, available, removed_in):
+        super(DeprecatedImportModule, self).__init__(name)  # noqa F821
+        self._real_module = sys.modules[name]  # noqa F821
+        self._removed_in = removed_in
+        self._origin = {item: mod for mod, items in available.items() for item in items}
+        self.__all__ = sorted(self._real_module.__all__ + list(self._origin))
+
+    def __getattr__(self, item):
+        # Don't export internal variables.
+        if item in {"_real_module", "_origin", "_removed_in"}:
+            raise AttributeError(item)
+
+        if item in self._origin:
+            from importlib import import_module
+
+            origin = self._origin[item]
+
+            if origin == ".":
+                # No warning for the "submodule as attribute" case, it's way too messy
+                # and unreliable to try to distinguish 'from werkzueug import
+                # exceptions' and 'import werkzeug; werkzeug.exceptions'.
+                value = import_module(origin + item, self.__name__)
+            else:
+                from warnings import warn
+
+                # Import the module, get the attribute, and show a warning about where
+                # to correctly import it from.
+                mod = import_module(origin, self.__name__)
+                value = getattr(mod, item)
+                warn(
+                    "The top-level '{name}.{item}' is deprecated and will be removed in"
+                    " {removed_in}. Use 'from {name}{origin} import {item}'"
+                    " instead.".format(
+                        name=self.__name__,
+                        item=item,
+                        removed_in=self._removed_in,
+                        origin=origin,
+                    ),
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        else:
+            value = getattr(self._real_module, item)
+
+        # Cache the value so it won't go through this process on subsequent accesses.
+        setattr(self, item, value)
+        return value
+
+    def __dir__(self):
+        return sorted(dir(self._real_module) + list(self._origin))
+
+
+sys.modules["werkzeug"] = DeprecatedImportModule(
+    "werkzeug",
+    {
+        ".": ["exceptions", "routing"],
+        "._internal": ["_easteregg"],
+        ".datastructures": [
+            "Accept",
+            "Authorization",
+            "CallbackDict",
+            "CharsetAccept",
+            "CombinedMultiDict",
+            "EnvironHeaders",
+            "ETags",
+            "FileMultiDict",
+            "FileStorage",
+            "Headers",
+            "HeaderSet",
+            "ImmutableDict",
+            "ImmutableList",
+            "ImmutableMultiDict",
+            "ImmutableOrderedMultiDict",
+            "ImmutableTypeConversionDict",
+            "LanguageAccept",
+            "MIMEAccept",
+            "MultiDict",
+            "OrderedMultiDict",
+            "RequestCacheControl",
+            "ResponseCacheControl",
+            "TypeConversionDict",
+            "WWWAuthenticate",
+        ],
+        ".debug": ["DebuggedApplication"],
+        ".exceptions": ["abort", "Aborter"],
+        ".formparser": ["parse_form_data"],
+        ".http": [
+            "cookie_date",
+            "dump_cookie",
+            "dump_header",
+            "dump_options_header",
+            "generate_etag",
+            "http_date",
+            "HTTP_STATUS_CODES",
+            "is_entity_header",
+            "is_hop_by_hop_header",
+            "is_resource_modified",
+            "parse_accept_header",
+            "parse_authorization_header",
+            "parse_cache_control_header",
+            "parse_cookie",
+            "parse_date",
+            "parse_dict_header",
+            "parse_etags",
+            "parse_list_header",
+            "parse_options_header",
+            "parse_set_header",
+            "parse_www_authenticate_header",
+            "quote_etag",
+            "quote_header_value",
+            "remove_entity_headers",
+            "remove_hop_by_hop_headers",
+            "unquote_etag",
+            "unquote_header_value",
+        ],
+        ".local": [
+            "Local",
+            "LocalManager",
+            "LocalProxy",
+            "LocalStack",
+            "release_local",
+        ],
+        ".middleware.dispatcher": ["DispatcherMiddleware"],
+        ".middleware.shared_data": ["SharedDataMiddleware"],
+        ".security": ["check_password_hash", "generate_password_hash"],
+        ".test": ["create_environ", "EnvironBuilder", "run_wsgi_app"],
+        ".testapp": ["test_app"],
+        ".urls": [
+            "Href",
+            "iri_to_uri",
+            "uri_to_iri",
+            "url_decode",
+            "url_encode",
+            "url_fix",
+            "url_quote",
+            "url_quote_plus",
+            "url_unquote",
+            "url_unquote_plus",
+        ],
+        ".useragents": ["UserAgent"],
+        ".utils": [
+            "append_slash_redirect",
+            "ArgumentValidationError",
+            "bind_arguments",
+            "cached_property",
+            "environ_property",
+            "escape",
+            "find_modules",
+            "format_string",
+            "header_property",
+            "html",
+            "HTMLBuilder",
+            "import_string",
+            "redirect",
+            "secure_filename",
+            "unescape",
+            "validate_arguments",
+            "xhtml",
+        ],
+        ".wrappers.accept": ["AcceptMixin"],
+        ".wrappers.auth": ["AuthorizationMixin", "WWWAuthenticateMixin"],
+        ".wrappers.base_request": ["BaseRequest"],
+        ".wrappers.base_response": ["BaseResponse"],
+        ".wrappers.common_descriptors": [
+            "CommonRequestDescriptorsMixin",
+            "CommonResponseDescriptorsMixin",
+        ],
+        ".wrappers.etag": ["ETagRequestMixin", "ETagResponseMixin"],
+        ".wrappers.response": ["ResponseStreamMixin"],
+        ".wrappers.user_agent": ["UserAgentMixin"],
+        ".wsgi": [
+            "ClosingIterator",
+            "extract_path_info",
+            "FileWrapper",
+            "get_current_url",
+            "get_host",
+            "LimitedStream",
+            "make_line_iter",
+            "peek_path_info",
+            "pop_path_info",
+            "responder",
+            "wrap_file",
+        ],
+    },
+    "Werkzeug 2.0",
+)
+del sys, ModuleType, DeprecatedImportModule

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -14,6 +14,7 @@ import re
 from copy import deepcopy
 from itertools import repeat
 
+from . import exceptions
 from ._compat import BytesIO
 from ._compat import collections_abc
 from ._compat import integer_types
@@ -2995,7 +2996,6 @@ class FileStorage(object):
 
 
 # circular dependencies
-from . import exceptions
 from .http import dump_csp_header
 from .http import dump_header
 from .http import dump_options_header

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -59,18 +59,12 @@
 """
 import sys
 
-import werkzeug
-
-# Because of bootstrapping reasons we need to manually patch ourselves
-# onto our parent module.
-werkzeug.exceptions = sys.modules[__name__]
-
 from ._compat import implements_to_string
 from ._compat import integer_types
 from ._compat import iteritems
 from ._compat import text_type
 from ._internal import _get_environ
-from .wrappers import Response
+from .utils import escape
 
 
 @implements_to_string
@@ -141,6 +135,8 @@ class HTTPException(Exception):
     @property
     def name(self):
         """The status name."""
+        from .http import HTTP_STATUS_CODES
+
         return HTTP_STATUS_CODES.get(self.code, "Unknown Error")
 
     def get_description(self, environ=None):
@@ -176,6 +172,8 @@ class HTTPException(Exception):
                         on how the request looked like.
         :return: a :class:`Response` object or a subclass thereof.
         """
+        from .wrappers.response import Response
+
         if self.response is not None:
             return self.response
         if environ is not None:
@@ -792,7 +790,3 @@ _aborter = Aborter()
 #: An exception that is used to signal both a :exc:`KeyError` and a
 #: :exc:`BadRequest`. Used by many of the datastructures.
 BadRequestKeyError = BadRequest.wrap(KeyError)
-
-# imported here because of circular dependencies of werkzeug.utils
-from .http import HTTP_STATUS_CODES
-from .utils import escape

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -16,6 +16,7 @@ from itertools import chain
 from itertools import repeat
 from itertools import tee
 
+from . import exceptions
 from ._compat import BytesIO
 from ._compat import text_type
 from ._compat import to_native
@@ -581,6 +582,3 @@ class MultiPartParser(object):
         form = (p[1] for p in formstream if p[0] == "form")
         files = (p[1] for p in filestream if p[0] == "file")
         return self.cls(form), self.cls(files)
-
-
-from . import exceptions

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -1189,6 +1189,8 @@ def dump_cookie(
     value = to_bytes(value, charset)
 
     if path is not None:
+        from .urls import iri_to_uri
+
         path = iri_to_uri(path, charset)
     domain = _make_cookie_domain(domain)
     if isinstance(max_age, timedelta):
@@ -1282,7 +1284,7 @@ def is_byte_range_valid(start, stop, length):
     return 0 <= start < length
 
 
-# circular dependency fun
+# circular dependencies
 from .datastructures import Accept
 from .datastructures import Authorization
 from .datastructures import ContentRange
@@ -1294,4 +1296,3 @@ from .datastructures import MultiDict
 from .datastructures import Range
 from .datastructures import RequestCacheControl
 from .datastructures import WWWAuthenticate
-from .urls import iri_to_uri

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -31,8 +31,6 @@ from ._compat import to_unicode
 from ._compat import try_coerce_native
 from ._internal import _decode_idna
 from ._internal import _encode_idna
-from .datastructures import iter_multi_items
-from .datastructures import MultiDict
 
 # A regular expression for what a valid schema looks like
 _scheme_re = re.compile(r"^[a-zA-Z0-9+-.]+$")
@@ -415,6 +413,8 @@ def _unquote_to_bytes(string, unsafe=""):
 
 
 def _url_encode_impl(obj, charset, encode_keys, sort, key):
+    from .datastructures import iter_multi_items
+
     iterable = iter_multi_items(obj)
     if sort:
         iterable = sorted(iterable, key=key)
@@ -825,6 +825,8 @@ def url_decode(
                        or `None` the default :class:`MultiDict` is used.
     """
     if cls is None:
+        from .datastructures import MultiDict
+
         cls = MultiDict
     if isinstance(s, text_type) and not isinstance(separator, text_type):
         separator = separator.decode(charset or "ascii")
@@ -884,6 +886,8 @@ def url_decode_stream(
         return decoder
 
     if cls is None:
+        from .datastructures import MultiDict
+
         cls = MultiDict
 
     return cls(decoder)


### PR DESCRIPTION
fixes #2 

Given that everything is so circular, importing anything basically resulted in importing everything anyway, so there wasn't really a point to the lazy importer.

Moved some imports into the functions that need them in order to break circular imports. Only `http` and `datastructures` import from each other at the bottom of the modules now, as they both do about the same amount of importing, so making one lazy didn't make sense.

Verified this by doing `subprocess.run(["python", "-c", "import {name}"])` for every module in Werkzeug. None resulted in import errors.