### PR TITLE
SharedDataMiddleware returns 404 for package directory access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Unreleased
     :pr:`1469`
 -   ``is_resource_modified`` will run for methods other than ``GET`` and
     ``HEAD``, rather than always returning ``False``. :issue:`409`
+-   ``SharedDataMiddleware`` returns 404 rather than 500 when trying to
+    access a directory instead of a file with the package loader. The
+    dependency on setuptools and pkg_resources is removed.
+    :issue:`1599`, :pr:`1647`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
 -   Optional ad-hoc TLS support for the development server is handled

--- a/tests/middleware/test_shared_data.py
+++ b/tests/middleware/test_shared_data.py
@@ -61,6 +61,7 @@ def test_shared_data_middleware(tmpdir):
 
         assert b"$(function() {" in contents
 
-        app_iter, status, headers = run_wsgi_app(app, create_environ("/missing"))
-        assert status == "404 NOT FOUND"
-        assert b"".join(app_iter).strip() == b"NOT FOUND"
+        for path in ("/missing", "/pkg", "/pkg/", "/pkg/missing.txt"):
+            app_iter, status, headers = run_wsgi_app(app, create_environ(path))
+            assert status == "404 NOT FOUND"
+            assert b"".join(app_iter).strip() == b"NOT FOUND"


### PR DESCRIPTION
fixes #1599 

The main fix is to catch `IOError` when reading the data. The majority of the code change is removing the dependency on setuptools and `pkg_resources` in favor of the built-in `pkgutils`.

I tried moving to [`importlib_resources`](https://importlib-resources.readthedocs.io/en/latest/) for Python < 3.7, but for some reason that API doesn't support directories of resources unless the directory is also a package. I'm not sure why this restriction is there, give that `ResourceReader.open_resource` supports directories (although `is_resource` doesn't). Instead, we need two versions, using the`loader.get_resource_reader()` API on Python 3, and the package path and `loader.get_data()` method on Python 2.