### PR TITLE
support Cache-Control: immutable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,7 +60,10 @@ Unreleased
 -   ``SharedDataMiddleware`` returns 404 rather than 500 when trying to
     access a directory instead of a file with the package loader. The
     dependency on setuptools and pkg_resources is removed.
-    :issue:`1599`, :pr:`1647`
+    :issue:`1599`
+-   Add a ``response.cache_control.immutable`` flag. Keep in mind that
+    browser support for this ``Cache-Control`` header option is still
+    experimental and may not be implemented. :issue:`1185`
 -   Optional request log highlighting with the development server is
     handled by Click instead of termcolor. :issue:`1235`
 -   Optional ad-hoc TLS support for the development server is handled

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -2050,7 +2050,6 @@ class RequestCacheControl(ImmutableDictMixin, _CacheControl):
 
     max_stale = cache_property("max-stale", "*", int)
     min_fresh = cache_property("min-fresh", "*", int)
-    no_transform = cache_property("no-transform", None, None)
     only_if_cached = cache_property("only-if-cached", None, bool)
 
 
@@ -2074,6 +2073,7 @@ class ResponseCacheControl(_CacheControl):
     must_revalidate = cache_property("must-revalidate", None, bool)
     proxy_revalidate = cache_property("proxy-revalidate", None, bool)
     s_maxage = cache_property("s-maxage", None, None)
+    immutable = cache_property("immutable", None, bool)
 
 
 # attach cache_property to the _CacheControl as staticmethod


### PR DESCRIPTION
closes #1185 

The option is still experimental. Chromium does not support it, Edge, Firefox, and Safari do. Seems to be supported enough to add in for now.