### PR TITLE
Fix get_machine_id in docker and implement in lipbod containers

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -52,7 +52,7 @@ def get_machine_id():
         return rv
 
     def _generate():
-        # docker containers share the same machine id, get the
+        # containers share the same machine id, get the
         # container id instead
         try:
             with open("/proc/self/cgroup") as f:
@@ -60,10 +60,11 @@ def get_machine_id():
         except IOError:
             pass
         else:
-            value = value.strip().partition("docker")[2]
-
-            if value:
-                return value
+            # Different container technology uses different patterns in
+            # cgroups names.
+            for pattern in ["docker", "libpod"]:
+                if pattern in value:
+                    return value.strip().partition(pattern)[2]
 
         # Potential sources of secret information on linux.  The machine-id
         # is stable across boots, the boot id is not

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -60,7 +60,7 @@ def get_machine_id():
         except IOError:
             pass
         else:
-            value = value.strip().partition("/docker/")[2]
+            value = value.strip().partition("docker")[2]
 
             if value:
                 return value


### PR DESCRIPTION
After [1], get_machine_id is returning empty when running in docker as
it has some extra slashes in separator.

This patch removes the extra slashes.

Closes: #1661

[1] https://github.com/pallets/werkzeug/commit/00bc43b1672e662e5e3b8cecd79e67fc968fa246