### PR TITLE
Update adhoc cert for macos 10.15 requirements

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -520,10 +520,6 @@ def generate_adhoc_ssl_pair(cn=None):
         .serial_number(x509.random_serial_number())
         .not_valid_before(dt.utcnow())
         .not_valid_after(dt.utcnow() + timedelta(days=365))
-        .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(u"*")]), critical=False
-        )
         .sign(pkey, hashes.SHA256(), default_backend())
     )
     return cert, pkey

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -520,6 +520,10 @@ def generate_adhoc_ssl_pair(cn=None):
         .serial_number(x509.random_serial_number())
         .not_valid_before(dt.utcnow())
         .not_valid_after(dt.utcnow() + timedelta(days=365))
+        .add_extension(
+            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(u'*')]), critical=False)
         .sign(pkey, hashes.SHA256(), default_backend())
     )
     return cert, pkey

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -520,10 +520,10 @@ def generate_adhoc_ssl_pair(cn=None):
         .serial_number(x509.random_serial_number())
         .not_valid_before(dt.utcnow())
         .not_valid_after(dt.utcnow() + timedelta(days=365))
+        .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
         .add_extension(
-            x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
-        .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(u'*')]), critical=False)
+            x509.SubjectAlternativeName([x509.DNSName(u'*')]), critical=False
+        )
         .sign(pkey, hashes.SHA256(), default_backend())
     )
     return cert, pkey

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -520,6 +520,10 @@ def generate_adhoc_ssl_pair(cn=None):
         .serial_number(x509.random_serial_number())
         .not_valid_before(dt.utcnow())
         .not_valid_after(dt.utcnow() + timedelta(days=365))
+        .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(u"*")]), critical=False
+        )
         .sign(pkey, hashes.SHA256(), default_backend())
     )
     return cert, pkey

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -522,7 +522,7 @@ def generate_adhoc_ssl_pair(cn=None):
         .not_valid_after(dt.utcnow() + timedelta(days=365))
         .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
         .add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(u'*')]), critical=False
+            x509.SubjectAlternativeName([x509.DNSName(u"*")]), critical=False
         )
         .sign(pkey, hashes.SHA256(), default_backend())
     )


### PR DESCRIPTION
Update `generate_adhoc_ssl_pair()` to support the new requirements for MacOS 10.15 (Catalina) and iOS 13

Without this (at least) google chrome is unable to load pages with the adhoc self signed certs on OSX giving the error `NET::ERR_CERT_REVOKED`.

The requirements are here: 
https://support.apple.com/en-us/HT210176