### PR TITLE
Providing different variable types in different routes can cause the …

### DIFF
--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1018,7 +1018,7 @@ class Rule(RuleFactory):
         # skipped or the value is the same as the default value.
         if defaults:
             for key, value in iteritems(defaults):
-                if key in values and value != values[key]:
+                if key in values and (value != values[key] or type(value) != type(values[key])):
                     return False
 
         return True

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -193,6 +193,24 @@ def test_long_build():
         assert "/%d" % v in url
 
 
+def test_defaults_mismatch():
+    map = r.Map(
+        [
+            r.Rule("/foo/", defaults={"page": True}, endpoint="foo"),
+            r.Rule("/foo/<int:page>", endpoint="foo"),
+        ]
+    )
+    adapter = map.bind("example.org", "/")
+
+    assert adapter.match("/foo/") == ("foo", {"page": True})
+    assert adapter.match("/foo/1") == ("foo", {"page": 1})
+    assert adapter.match("/foo/2") == ("foo", {"page": 2})
+    assert adapter.build("foo", {}) == "/foo/"
+    assert adapter.build("foo", {"page": True}) == "/foo/"
+    assert adapter.build("foo", {"page": 1}) == "/foo/1"
+    assert adapter.build("foo", {"page": 2}) == "/foo/2"
+
+
 def test_defaults():
     map = r.Map(
         [


### PR DESCRIPTION
…incorrect route to be chosen, and a redirect occurring instead of serving the requested page

When setting up two similar routes and using `defaults` to differentiate, mixing a boolean and an integer causes confusion as `1 == True`. Example in tests, and fix with type check.