### PR TITLE
Include host matching if possible when building URLs from mapped routes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Unreleased
     ``PathLike`` objects. :issue:`1653`
 -   The debugger security pin is unique in containers managed by Podman.
     :issue:`1661`
+-   Building a URL when ``host_matching`` is enabled takes into account
+    the current host when there are duplicate endpoints with different
+    hosts. :issue:`488`
 
 
 Version 0.16.0

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1942,10 +1942,13 @@ class MapAdapter(object):
                 rv = rule.build(values, append_unknown)
 
                 if rv is not None:
-                    if rv[0] == self.server_name:
+                    if self.map.host_matching:
+                        if rv[0] == self.server_name:
+                            return rv
+                        elif first_match is None:
+                            first_match = rv
+                    else:
                         return rv
-                    elif first_match is None:
-                        first_match = rv
 
         return first_match
 

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1932,13 +1932,22 @@ class MapAdapter(object):
             if rv is not None:
                 return rv
 
-        # default method did not match or a specific method is passed,
-        # check all and go with first result.
+        # Default method did not match or a specific method is passed.
+        # Check all for first match with matching host. If no matching
+        # host is found, go with first result.
+        first_match = None
+
         for rule in self.map._rules_by_endpoint.get(endpoint, ()):
             if rule.suitable_for(values, method):
                 rv = rule.build(values, append_unknown)
+
                 if rv is not None:
-                    return rv
+                    if rv[0] == self.server_name:
+                        return rv
+                    elif first_match is None:
+                        first_match = rv
+
+        return first_match
 
     def build(
         self,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1131,3 +1131,28 @@ def test_build_url_with_arg_keyword():
 
     ret = adapter.build("foo", {"class": "bar"})
     assert ret == "http://example.org/foo/bar"
+
+
+def test_build_url_same_endpoint_multiple_hosts():
+    m = r.Map(
+        [
+            r.Rule("/", endpoint="index", host="alpha.example.com"),
+            r.Rule("/", endpoint="index", host="beta.example.com"),
+            r.Rule("/", endpoint="gamma", host="gamma.example.com"),
+        ],
+        host_matching=True,
+    )
+
+    alpha = m.bind("alpha.example.com")
+    assert alpha.build("index") == "/"
+    assert alpha.build("gamma") == "http://gamma.example.com/"
+
+    alpha_case = m.bind("AlPhA.ExAmPlE.CoM")
+    assert alpha_case.build("index") == "/"
+    assert alpha_case.build("gamma") == "http://gamma.example.com/"
+
+    beta = m.bind("beta.example.com")
+    assert beta.build("index") == "/"
+
+    beta_case = m.bind("BeTa.ExAmPlE.CoM")
+    assert beta_case.build("index") == "/"


### PR DESCRIPTION
Resolves #488