### PR TITLE
Only write body when there is a body to write.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,12 @@
 Version 0.16.1
 --------------
 
+Unreleased
+
 -   Fix import location in deprecation messages for subpackages.
     :issue:`1663`
+-   Fix an SSL error on Python 3.5 when the dev server responds with no
+    content. :issue:`1659`
 
 
 Version 0.16.0

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -273,7 +273,9 @@ class WSGIRequestHandler(BaseHTTPRequestHandler, object):
                 self.end_headers()
 
             assert isinstance(data, bytes), "applications must write bytes"
-            self.wfile.write(data)
+            if data:
+                # Only write data if there is any to avoid Python 3.5 SSL bug
+                self.wfile.write(data)
             self.wfile.flush()
 
         def start_response(status, response_headers, exc_info=None):


### PR DESCRIPTION
Solves #1659 which is a serving bug that only exists in Python 3.5.
There was no good way to write a reliable test to reproduce the issue.
As such, not tests were added at this time.