### PR TITLE
Add ability to set Retry-After header on 429 and 503 exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,9 @@ Unreleased
 -   Building a URL when ``host_matching`` is enabled takes into account
     the current host when there are duplicate endpoints with different
     hosts. :issue:`488`
+-   The ``429 TooManyRequests`` and ``503 ServiceUnavailable`` HTTP
+    exceptions takes a ``retry_after`` parameter to set the
+    ``Retry-After`` header. :issue:`1657`
 
 
 Version 0.16.0

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -600,10 +600,28 @@ class TooManyRequests(HTTPException):
     to identify users and their request rates). The server may include a
     "Retry-After" header to indicate how long the user should wait before
     retrying.
+
+    .. versionchanged:: 0.16.1
+        ``retry_after_secs`` was added as the first argument, ahead of
+        ``description``.
     """
 
     code = 429
     description = "This user has exceeded an allotted request count. Try again later."
+
+    def __init__(self, description=None, retry_after_secs=None):
+        """
+        Use the optional value of retry_after_secs to specify the number of seconds
+        to wait for a retry attempt.
+        """
+        HTTPException.__init__(self, description)
+        self.retry_after_secs = retry_after_secs
+
+    def get_headers(self, environ=None):
+        headers = HTTPException.get_headers(self, environ)
+        if self.retry_after_secs:
+            headers.append(("Retry-After", str(self.retry_after_secs)))
+        return headers
 
 
 class RequestHeaderFieldsTooLarge(HTTPException):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -120,3 +120,13 @@ def test_response_header_content_type_should_contain_charset():
     exc = exceptions.HTTPException("An error message")
     h = exc.get_response({})
     assert h.headers["Content-Type"] == "text/html; charset=utf-8"
+
+
+def test_too_many_requests_retry_after():
+    exc = exceptions.TooManyRequests(retry_after_secs=20)
+    h = dict(exc.get_headers({}))
+    assert h["Retry-After"] == "20"
+    assert (
+        "This user has exceeded an allotted request count. Try again later."
+        in exc.get_description()
+    )


### PR DESCRIPTION
Added optional retry_after_secs to TooManyRequests exception init.
This brings the output in line with the HTTP spec.
Resolves #1657