### PR TITLE
Adds missing RFC HTTP status codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Unreleased
 -   ``Map`` and ``Rule`` have a ``merge_slashes`` option to collapse
     multiple slashes into one, similar to how many HTTP servers behave.
     This is enabled by default. :pr:`1286`
+-   Add HTTP 103, 208, 306, 425, 506, 508, and 511 to the list of status
+    codes. :pr:`1678`
 
 
 Version 0.16.1

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -140,6 +140,7 @@ HTTP_STATUS_CODES = {
     100: "Continue",
     101: "Switching Protocols",
     102: "Processing",
+    103: "Early Hints",  # see RFC 8297
     200: "OK",
     201: "Created",
     202: "Accepted",
@@ -148,6 +149,7 @@ HTTP_STATUS_CODES = {
     205: "Reset Content",
     206: "Partial Content",
     207: "Multi Status",
+    208: "Already Reported",  # see RFC 5842
     226: "IM Used",  # see RFC 3229
     300: "Multiple Choices",
     301: "Moved Permanently",
@@ -155,6 +157,7 @@ HTTP_STATUS_CODES = {
     303: "See Other",
     304: "Not Modified",
     305: "Use Proxy",
+    306: "Switch Proxy",  # unused
     307: "Temporary Redirect",
     308: "Permanent Redirect",
     400: "Bad Request",
@@ -180,6 +183,7 @@ HTTP_STATUS_CODES = {
     422: "Unprocessable Entity",
     423: "Locked",
     424: "Failed Dependency",
+    425: "Too Early",  # see RFC 8470
     426: "Upgrade Required",
     428: "Precondition Required",  # see RFC 6585
     429: "Too Many Requests",
@@ -192,8 +196,11 @@ HTTP_STATUS_CODES = {
     503: "Service Unavailable",
     504: "Gateway Timeout",
     505: "HTTP Version Not Supported",
+    506: "Variant Also Negotiates",  # see RFC 2295
     507: "Insufficient Storage",
+    508: "Loop Detected",  # see RFC 5842
     510: "Not Extended",
+    511: "Network Authentication Failed",  # see RFC 6585
 }
 
 


### PR DESCRIPTION
I haven't created an issue on the repo since this is actually not an issue, but more of a completion work.

I have added RFC HTTP status codes 103, 208, 306, 425, 506, 508 and 511 with the respective comments to the corresponding RFC documents for completion (except the 306 status code, which is unused, but I have added it for compatibility purposes).

Hope I'm contributing the right way to the project!