### PR TITLE
Stop terminating debug server on reload error

### DIFF
--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -180,9 +180,9 @@ class ReloaderLoop(object):
                 new_environ = os.environ.copy()
 
             new_environ["WERKZEUG_RUN_MAIN"] = "true"
-            exit_code = subprocess.call(args, env=new_environ, close_fds=False)
-            if exit_code != 3:
-                return exit_code
+            subprocess.call(args, env=new_environ, close_fds=False)
+            # used to drop out if exit_code != 3, but this means
+            # constantly restarting server if you make a syntax or other error
 
     def trigger_reload(self, filename):
         self.log_reload(filename)


### PR DESCRIPTION
Apologies that this is slightly rough-and-ready. There are, obviously, no tests yet. My thought was to add to `test_serving.py/test_reloader_broken_imports`, but it wasn't obvious how to detect the survival or otherwise of the subthread. If you can guide me on that, I will be pleased to implement an actual test, since I am obviously a big fan of TDD.

I was finally driven to make this PR by one time too many of making a syntax error and having to restart the server.