### PR TITLE
Add an update method to the Headers datastructure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ Unreleased
     This is enabled by default. :pr:`1286`
 -   Add HTTP 103, 208, 306, 425, 506, 508, and 511 to the list of status
     codes. :pr:`1678`
+-   Add an ``update`` method to the ``Headers`` data structure.
+    :pr:`1687`
 
 
 Version 0.16.1

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1265,6 +1265,26 @@ class Headers(object):
         else:
             self.set(key, value)
 
+    def update(self, *args, **kwargs):
+        """Update the headers with the key/value pairs from another
+        headers object and keyword arguments.
+
+        If provided, the first argument can be another :class:`Headers`
+        object, a :class:`MultiDict`, :class:`dict`, or iterable of
+        pairs.
+
+        .. versionadded:: 1.0
+        """
+        if len(args) > 1:
+            raise TypeError("update expected at most 1 arguments, got %d" % len(args))
+
+        if args:
+            for key, value in iter_multi_items(args[0]):
+                self[key] = value
+
+        for key, value in iter_multi_items(kwargs):
+            self[key] = value
+
     def to_wsgi_list(self):
         """Convert the headers into a list suitable for WSGI.
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -780,6 +780,17 @@ class TestHeaders(object):
         assert h.get("x-whoops", as_bytes=True) == b"\xff"
         assert h.get("x-bytes") == "something"
 
+    def test_update(self):
+        h = self.storage_class()
+        h["x"] = "1"
+        h.update({"x": "2", "y": "1"})
+        assert h.getlist("x") == ["2"]
+        assert h.getlist("y") == ["1"]
+        h.update(z="2")
+        assert h.getlist("z") == ["2"]
+        h.update(self.storage_class([("a", "b")]))
+        assert h["a"] == "b"
+
     def test_to_wsgi_list(self):
         h = self.storage_class()
         h.set(u"Key", u"Value")


### PR DESCRIPTION
This allows a typical dict action (namely a.update(b)) to be possible
with Headers instances. Notably I think the update action should
emulate that of standard python dictionaries and overwrite rather than
extend (the multi keys). This is the opposite to how the Werkzeug
MultiDict works.

I'm starting to migrate Quart to be based on Werkzeug, and I'm likely to have a few of these differences that ideally I'd like Werkzeug to adopt.