### PR TITLE
get_machine_id unique for podman

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Unreleased
     by cryptography instead of pyOpenSSL. :pr:`1555`
 -   ``FileStorage.save()`` supports ``pathlib`` and :pep:`519`
     ``PathLike`` objects. :issue:`1653`
+-   The debugger security pin is unique in containers managed by Podman.
+    :issue:`1661`
 
 
 Version 0.16.0


### PR DESCRIPTION
closes #1661 
closes #1662 

Rather than detecting a growing list of "docker", "podman", etc., always appends cgroup data to the Linux id. Verified that this creates unique ids in Docker and Podman. Outside containers, at least on my Arch + systemd machine, the id remains stable as there is actually no data after the "/" in the first line of the cgroup info, so nothing is appended.