### PR TITLE
merge slashes at the end of a URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,7 +80,7 @@ Unreleased
     ``Retry-After`` header. :issue:`1657`
 -   ``Map`` and ``Rule`` have a ``merge_slashes`` option to collapse
     multiple slashes into one, similar to how many HTTP servers behave.
-    This is enabled by default. :pr:`1286`
+    This is enabled by default. :pr:`1286, 1694`
 -   Add HTTP 103, 208, 306, 425, 506, 508, and 511 to the list of status
     codes. :pr:`1678`
 -   Add an ``update`` method to the ``Headers`` data structure.

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -820,12 +820,14 @@ class Rule(RuleFactory):
 
         if self.build_only:
             return
-        regex = r"^%s%s$" % (
-            u"".join(regex_parts),
-            (not self.is_leaf or not self.strict_slashes)
-            and "(?<!/)(?P<__suffix__>/?)"
-            or "",
-        )
+
+        if not (self.is_leaf and self.strict_slashes):
+            reps = u"*" if self.merge_slashes else u"?"
+            tail = u"(?<!/)(?P<__suffix__>/%s)" % reps
+        else:
+            tail = u""
+
+        regex = u"^%s%s$" % (u"".join(regex_parts), tail)
         self._regex = re.compile(regex, re.UNICODE)
 
     def match(self, path, method=None):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -83,6 +83,11 @@ def test_merge_slashes_match():
 
     assert excinfo.value.new_url.endswith("/yes/tail/")
 
+    with pytest.raises(r.RequestRedirect) as excinfo:
+        adapter.match("/yes/tail//")
+
+    assert excinfo.value.new_url.endswith("/yes/tail/")
+
     assert adapter.match("/no/tail")[0] == "no_tail"
     assert adapter.match("/yes/tail/")[0] == "yes_tail"
 


### PR DESCRIPTION
fixes #1688 

Extends #1286 `merge_slashes` to also merge trailing slashes.

cc @edk0 