### PR TITLE
dev server accepts two slashes at start of path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,8 @@ Unreleased
     codes. :pr:`1678`
 -   Add an ``update`` method to the ``Headers`` data structure.
     :pr:`1687`
+-   The development server accepts paths that start with two slashes,
+    rather than stripping off the first path segment. :issue:`491`
 
 
 Version 0.16.1


### PR DESCRIPTION
fixes #491 

Due to #253 and the way URLs are parsed, `//test/path` was interpreted to be a schemaless URL with `test` as the netloc and `/path` as the path. Mistakenly navigating to `http://localhost:5000//test/path` would try to route to `/path` instead of `/test/path`.

Instead, if the parsed URL has a netloc but no scheme, consider the netloc part of the path instead. Further down the line, `Request` already strips off leading slashes, so other paths like `///test/path` were already normalized, but double slashes had to be handled at this earlier point. Using "has a scheme" to mean "is an absolute URL" was already introduced in #891 as part of another fix to #253.