### PR TITLE
Add a setlist method to the Headers datastructure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,8 +83,9 @@ Unreleased
     This is enabled by default. :pr:`1286, 1694`
 -   Add HTTP 103, 208, 306, 425, 506, 508, and 511 to the list of status
     codes. :pr:`1678`
--   Add an ``update`` method to the ``Headers`` data structure.
-    :pr:`1687`
+-   Add ``update``, ``setlist``, and ``setlistdefault`` methods to the
+    ``Headers`` data structure. ``extend`` method can take ``MultiDict``
+    and kwargs. :pr:`1687, 1697`
 -   The development server accepts paths that start with two slashes,
     rather than stripping off the first path segment. :issue:`491`
 

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1080,20 +1080,29 @@ class Headers(object):
         for _, value in iteritems(self):
             yield value
 
-    def extend(self, iterable):
-        """Extend the headers with a dict or an iterable yielding keys and
-        values.
+    def extend(self, *args, **kwargs):
+        """Extend headers in this object with items from another object
+        containing header items as well as keyword arguments.
+
+        To replace existing keys instead of extending, use
+        :meth:`update` instead.
+
+        If provided, the first argument can be another :class:`Headers`
+        object, a :class:`MultiDict`, :class:`dict`, or iterable of
+        pairs.
+
+        .. versionchanged:: 1.0
+            Support :class:`MultiDict`. Allow passing ``kwargs``.
         """
-        if isinstance(iterable, dict):
-            for key, value in iteritems(iterable):
-                if isinstance(value, (tuple, list)):
-                    for v in value:
-                        self.add(key, v)
-                else:
-                    self.add(key, value)
-        else:
-            for key, value in iterable:
+        if len(args) > 1:
+            raise TypeError("update expected at most 1 arguments, got %d" % len(args))
+
+        if args:
+            for key, value in iter_multi_items(args[0]):
                 self.add(key, value)
+
+        for key, value in iter_multi_items(kwargs):
+            self.add(key, value)
 
     def __delitem__(self, key, _index_operation=True):
         if _index_operation and isinstance(key, (integer_types, slice)):
@@ -1236,30 +1245,55 @@ class Headers(object):
         self._list[idx + 1 :] = [t for t in listiter if t[0].lower() != ikey]
 
     def setlist(self, key, values):
-        """Set multiple header values at once.
+        """Remove any existing values for a header and add new ones.
 
-        The `values` argument should be iterable. This will replace
-        any existing values for the key with the values passed. It is
-        the inverse of the getlist method.
+        :param key: The header key to set.
+        :param values: An iterable of values to set for the key.
 
         .. versionadded:: 1.0
         """
-        self.set(key, values[0])
-        for value in values[1:]:
-            self.add(key, value)
+        if values:
+            values_iter = iter(values)
+            self.set(key, next(values_iter))
+
+            for value in values_iter:
+                self.add(key, value)
+        else:
+            self.remove(key)
 
     def setdefault(self, key, default):
-        """Returns the value for the key if it is in the dict, otherwise it
-        returns `default` and sets that value for `key`.
+        """Return the first value for the key if it is in the headers,
+        otherwise set the header to the value given by ``default`` and
+        return that.
 
-        :param key: The key to be looked up.
-        :param default: The default value to be returned if the key is not
-                        in the dict.  If not further specified it's `None`.
+        :param key: The header key to get.
+        :param default: The value to set for the key if it is not in the
+            headers.
         """
         if key in self:
             return self[key]
+
         self.set(key, default)
         return default
+
+    def setlistdefault(self, key, default):
+        """Return the list of values for the key if it is in the
+        headers, otherwise set the header to the list of values given
+        by ``default`` and return that.
+
+        Unlike :meth:`MultiDict.setlistdefault`, modifying the returned
+        list will not affect the headers.
+
+        :param key: The header key to get.
+        :param default: An iterable of values to set for the key if it
+            is not in the headers.
+
+        .. versionadded:: 1.0
+        """
+        if key not in self:
+            self.setlist(key, default)
+
+        return self.getlist(key)
 
     def __setitem__(self, key, value):
         """Like :meth:`set` but also supports index/slice based setting."""
@@ -1279,8 +1313,11 @@ class Headers(object):
             self.set(key, value)
 
     def update(self, *args, **kwargs):
-        """Update the headers with the key/value pairs from another
+        """Replace headers in this object with items from another
         headers object and keyword arguments.
+
+        To extend existing keys instead of replacing, use :meth:`extend`
+        instead.
 
         If provided, the first argument can be another :class:`Headers`
         object, a :class:`MultiDict`, :class:`dict`, or iterable of
@@ -1295,19 +1332,23 @@ class Headers(object):
             mapping = args[0]
 
             if isinstance(mapping, (Headers, MultiDict)):
-                for key in iterkeys(mapping):
+                for key in mapping.keys():
                     self.setlist(key, mapping.getlist(key))
             elif isinstance(mapping, dict):
                 for key, value in iteritems(mapping):
-                    if isinstance(value, (tuple, list)):
+                    if isinstance(value, (list, tuple)):
                         self.setlist(key, value)
                     else:
-                        self[key] = value
+                        self.set(key, value)
             else:
-                for item in mapping:
-                    self[key] = item
+                for key, value in mapping:
+                    self.set(key, value)
+
         for key, value in iteritems(kwargs):
-            self[key] = value
+            if isinstance(value, (list, tuple)):
+                self.setlist(key, value)
+            else:
+                self.set(key, value)
 
     def to_wsgi_list(self):
         """Convert the headers into a list suitable for WSGI.
@@ -1355,14 +1396,25 @@ class ImmutableHeadersMixin(object):
     def __setitem__(self, key, value):
         is_immutable(self)
 
-    set = __setitem__
+    def set(self, key, value):
+        is_immutable(self)
+
+    def setlist(self, key, value):
+        is_immutable(self)
 
     def add(self, item):
         is_immutable(self)
 
-    remove = add_header = add
+    def add_header(self, item):
+        is_immutable(self)
 
-    def extend(self, iterable):
+    def remove(self, item):
+        is_immutable(self)
+
+    def extend(self, *args, **kwargs):
+        is_immutable(self)
+
+    def update(self, *args, **kwargs):
         is_immutable(self)
 
     def insert(self, pos, value):
@@ -1375,6 +1427,9 @@ class ImmutableHeadersMixin(object):
         is_immutable(self)
 
     def setdefault(self, key, default):
+        is_immutable(self)
+
+    def setlistdefault(self, key, default):
         is_immutable(self)
 
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -788,8 +788,11 @@ class TestHeaders(object):
         assert h.getlist("y") == ["1"]
         h.update(z="2")
         assert h.getlist("z") == ["2"]
-        h.update(self.storage_class([("a", "b")]))
-        assert h["a"] == "b"
+        h2 = self.storage_class([("a", "b")])
+        h2.add("a", "c")
+        h.update(h2, d="e")
+        assert h.getlist("a") == ["b", "c"]
+        assert h["d"] == "e"
 
     def test_to_wsgi_list(self):
         h = self.storage_class()


### PR DESCRIPTION
The update method added in baa7bdc19bdbf2db66d0f01ffdf98c4ab5a178ab is
meant to replace headers with the mapping passed in. If a MultDict or
Headers object is passed in it would replace headers with the final
iterated value, rather than all the values iterated over. This could
lead to unexpected results, therefore this corrects the functionality
to what I think is expected.

Consider,

    h1 = Headers()
    h1.add("X-Multi", "value")
    h2 = Headers()
    h2.add("X-Multi", "newValue")
    h2.add("X-Multi", "alternativeValue")
    h1.update(h2)

previously `h1.getlist("X-Multi")` would likely equal
`["alternativeValue"]` whereas now it equals `["newValue",
"alternativeValue"]` which is as you'd expect.