### PR TITLE
Use parse_list_header to parse X-Forwarded-For headers

### DIFF
--- a/src/werkzeug/wrappers/base_request.py
+++ b/src/werkzeug/wrappers/base_request.py
@@ -14,6 +14,7 @@ from ..datastructures import MultiDict
 from ..formparser import default_stream_factory
 from ..formparser import FormDataParser
 from ..http import parse_cookie
+from ..http import parse_list_header
 from ..http import parse_options_header
 from ..urls import url_decode
 from ..utils import cached_property
@@ -616,8 +617,9 @@ class BaseRequest(object):
         from the client ip to the last proxy server.
         """
         if "HTTP_X_FORWARDED_FOR" in self.environ:
-            addr = self.environ["HTTP_X_FORWARDED_FOR"].split(",")
-            return self.list_storage_class([x.strip() for x in addr])
+            return self.list_storage_class(
+                parse_list_header(self.environ["HTTP_X_FORWARDED_FOR"])
+            )
         elif "REMOTE_ADDR" in self.environ:
             return self.list_storage_class([self.environ["REMOTE_ADDR"]])
         return self.list_storage_class()


### PR DESCRIPTION
This is a minor change to use the standardised and more robust parser
rather than splitting on `,`. In practice it may not matter as quotes
aren't meant to be present in the X-Forwarded-For header, and I can't
find reference to a bug. However there is no RFC and this seems the
more consistent way to parse this header.

This is quite minor, I think on balance it is a worthwhile change.