### PR TITLE
Conserve order for equal quality in accept datastructures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ Unreleased
     rather than stripping off the first path segment. :issue:`491`
 -   Add access control (Cross Origin Request Sharing, CORS) header
     properties to the ``Request`` and ``Response`` wrappers. :pr:`1699`
+-   ``Accept`` values are no longer ordered alphabetically for equal
+    quality tags. Instead the initial order is preserved. :issue:`1686`
 
 
 Version 0.16.1

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1743,6 +1743,12 @@ class Accept(ImmutableList):
 
     .. versionchanged:: 0.5
        :class:`Accept` objects are forced immutable now.
+
+    .. versionchanged:: 1.0.0
+       :class:`Accept` internal values are no longer ordered
+       alphabetically for equal quality tags. Instead the initial
+       order is preserved.
+
     """
 
     def __init__(self, values=()):
@@ -1755,9 +1761,7 @@ class Accept(ImmutableList):
         else:
             self.provided = True
             values = sorted(
-                values,
-                key=lambda x: (self._specificity(x[0]), x[1], x[0]),
-                reverse=True,
+                values, key=lambda x: (self._specificity(x[0]), x[1]), reverse=True,
             )
             list.__init__(self, values)
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1126,6 +1126,10 @@ class TestAccept(object):
         assert accept.best_match(["asterisk", "times"], default=None) == "times"
         assert accept.best_match(["asterisk"], default=None) is None
 
+    def test_accept_equal_quality(self):
+        accept = self.storage_class([("a", 1), ("b", 1)])
+        assert accept.best == "a"
+
 
 class TestMIMEAccept(object):
     @pytest.mark.parametrize(

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -438,9 +438,9 @@ def test_accept_mixin():
     assert request.accept_mimetypes == MIMEAccept(
         [
             ("text/xml", 1),
-            ("image/png", 1),
             ("application/xml", 1),
             ("application/xhtml+xml", 1),
+            ("image/png", 1),
             ("text/html", 0.9),
             ("text/plain", 0.8),
             ("*/*", 0.5),


### PR DESCRIPTION
Both RFC4647-2.3 and RFC7231 imply that user agents may put equal
quality tags (especially language tags) in order of their prefered
priority. This means that this would ideally be the case,

    a = parse_accept_header("en-US,fr-FR", LanguageAccept)
    assert a.best == "en-US"

which it previously wasn't as `f` is after `e`.

I've looked back through the commits and found the previous behaviour
(sorting by tag name) was added with Accept in
802a12c0850439088de46ae188c64ab259b16695. I can find no reason for the
previous behaviour to be requirement.

closes #1686