### PR TITLE
Allow the lock type to be customised in the routing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,8 @@ Unreleased
     properties to the ``Request`` and ``Response`` wrappers. :pr:`1699`
 -   ``Accept`` values are no longer ordered alphabetically for equal
     quality tags. Instead the initial order is preserved. :issue:`1686`
+-   Added ``Map.lock_class`` attribute for alternative
+    implementations. :pr:`1702`
 
 
 Version 0.16.1

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1372,6 +1372,11 @@ class Map(object):
     #: A dict of default converters to be used.
     default_converters = ImmutableDict(DEFAULT_CONVERTERS)
 
+    #: The type of lock to use when updating.
+    #:
+    #: .. versionadded:: 1.0
+    lock_class = Lock
+
     def __init__(
         self,
         rules=None,
@@ -1389,7 +1394,7 @@ class Map(object):
         self._rules = []
         self._rules_by_endpoint = {}
         self._remap = True
-        self._remap_lock = Lock()
+        self._remap_lock = self.lock_class()
 
         self.default_subdomain = default_subdomain
         self.charset = charset


### PR DESCRIPTION
This will allow a subclass to specify a different type of lock,
specifically an asyncio or trio lock in order for the routing to be
used with these event loops. Note that gevent/eventlet monkey patch
Lock so nothing has been or is required for their usage.