### PR TITLE
Document Werkzeug's logger + default level/handler

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -76,3 +76,19 @@ Security Helpers
 .. autofunction:: pbkdf2_hex
 
 .. autofunction:: pbkdf2_bin
+
+
+Logging
+=======
+
+Werkzeug uses standard Python :mod:`logging`. The logger is named
+``"werkzeug"``.
+
+.. code-block:: python
+
+    import logging
+    logger = logging.getLogger("werkzeug")
+
+If the logger level is not set, it will be set to :data:`~logging.INFO`
+on first use. If there is no handler for that level, a
+:class:`~logging.StreamHandler` is added.


### PR DESCRIPTION
While logging is handle in `_internal.py`, it is common practice for the logger object itself, plus its default level and handler, to be public-facing.  This commit documents those three components.