### PR TITLE
range request always returns 206 status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,9 @@ Unreleased
     implementations. :pr:`1702`
 -   Support matching and building WebSocket rules in the routing system,
     for use by async frameworks. :pr:`1709`
+-   Range requests that span an entire file respond with 206 instead of
+    200, to be more compliant with :rfc:`7233`. This may help serving
+    media to older browsers. :issue:`410, 1704`
 
 
 Version 0.16.1

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -878,9 +878,9 @@ def test_range_request_with_complete_file():
         response = wrappers.Response(wrap_file(env, f))
         env["HTTP_RANGE"] = "bytes=0-%d" % (fsize - 1)
         response.make_conditional(env, accept_ranges=True, complete_length=fsize)
-        assert response.status_code == 200
+        assert response.status_code == 206
         assert response.headers["Accept-Ranges"] == "bytes"
-        assert "Content-Range" not in response.headers
+        assert response.headers["Content-Range"] == "bytes 0-%d/%d" % (fsize - 1, fsize)
         assert response.headers["Content-Length"] == str(fsize)
         assert response.data == fcontent
 


### PR DESCRIPTION
closes #410 
closes #1704 

I had trouble finding anyone who could reproduce this on modern Safari, Firefox, or Chrome, desktop or mobile. But #1704 reports that this fixed their issue, and it's more compliant with the RFC. The range headers themselves are parsed and produced correctly, so this is the only other explanation for #410 as far as I could tell.