### PR TITLE
SharedDataMiddleware adds utf-8 charset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,11 @@ Unreleased
 -   Range requests that span an entire file respond with 206 instead of
     200, to be more compliant with :rfc:`7233`. This may help serving
     media to older browsers. :issue:`410, 1704`
+-   The :class:`~middleware.shared_data.SharedDataMiddleware` default
+    ``fallback_mimetype`` is ``application/octet-stream``. If a filename
+    looks like a text mimetype, the ``utf-8`` charset is added to it.
+    This matches the behavior of :class:`~wrappers.BaseResponse` and
+    Flask's ``send_file()``. :issue:`1689`
 
 
 Version 0.16.1

--- a/tests/middleware/test_shared_data.py
+++ b/tests/middleware/test_shared_data.py
@@ -47,6 +47,10 @@ def test_shared_data_middleware(tmpdir):
             app_iter, status, headers = run_wsgi_app(app, create_environ(p))
             assert status == "200 OK"
 
+            if p.endswith(".txt"):
+                content_type = next(v for k, v in headers if k == "Content-Type")
+                assert content_type == "text/plain; charset=utf-8"
+
             with closing(app_iter) as app_iter:
                 data = b"".join(app_iter).strip()
 


### PR DESCRIPTION
closes #1689 

Uses `get_content_type` to add the `utf-8` charset if the filename looks like a text mimetype. This matches the behavior of Werkzeug's `Response` and Flask's `send_file`.