### PR TITLE
Add a default argument (None) the the RequestRedirect get_response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: werkzeug
 
+Version 1.0.1
+-------------
+
+Unreleased
+
+-   Make the argument to ``RequestRedirect.get_response`` optional.
+    :issue:`1718`
+
+
 Version 1.0.0
 -------------
 

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -250,7 +250,7 @@ class RequestRedirect(HTTPException, RoutingException):
         RoutingException.__init__(self, new_url)
         self.new_url = new_url
 
-    def get_response(self, environ):
+    def get_response(self, environ=None):
         return redirect(self.new_url, self.code)
 
 


### PR DESCRIPTION
The base class supplies the default and is documented to do so, this
matches that API. It also helps as the environ argument isn't used.

Fixes #1718

(No changelog as this is very minor, happy to change if requested).