### PR TITLE
Only allow a single Allow Origin (Access Control) value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Make the argument to ``RequestRedirect.get_response`` optional.
     :issue:`1718`
+-   Only allow a single access control allow origin value. :pr:`1723`
 
 
 Version 1.0.0

--- a/src/werkzeug/wrappers/cors.py
+++ b/src/werkzeug/wrappers/cors.py
@@ -82,9 +82,7 @@ class CORSResponseMixin(object):
 
     access_control_allow_origin = header_property(
         "Access-Control-Allow-Origin",
-        load_func=parse_set_header,
-        dump_func=dump_header,
-        doc="The origins that may make cross origin requests.",
+        doc="The origin or '*' for any origin that may make cross origin requests.",
     )
 
     access_control_expose_headers = header_property(


### PR DESCRIPTION
The relevant specification text is,

    Rather than allowing a space-separated list of origins, it is
    either a single origin or the string "null".[0]

and

    Note: null should not be used[1]

it is clear that the previous HeaderSet usage was wrong. (Also note
that the value is case sensitive)[0].

0: https://www.w3.org/TR/cors/
1: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin