### PR TITLE
Include pytest-timeout in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "watchdog": ["watchdog"],
         "dev": [
             "pytest",
+            "pytest-timeout",
             "coverage",
             "tox",
             "sphinx",


### PR DESCRIPTION
Running 'pytest' fails in the virtualenv, since there is a missing dev dependency: pytest-timeout.  

closes #1727 