### PR TITLE
Handle setting invalid status on response consistently

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
     ``EnvironBuilder``, multiple values for a key are joined into one
     comma separated value. This matches the HTTP spec on multi-value
     headers. :issue:`1655`
+-   Setting ``Response.status`` and ``status_code`` uses identical
+    parsing and error checking. :issue:`1658`, :pr:`1728`
 
 
 Version 1.0.1

--- a/src/werkzeug/wrappers/base_response.py
+++ b/src/werkzeug/wrappers/base_response.py
@@ -193,10 +193,7 @@ class BaseResponse:
             self.headers["Content-Type"] = content_type
         if status is None:
             status = self.default_status
-        if isinstance(status, int):
-            self.status_code = status
-        else:
-            self.status = status
+        self.status = status
 
         self.direct_passthrough = direct_passthrough
         self._on_close = []
@@ -290,11 +287,7 @@ class BaseResponse:
 
     @status_code.setter
     def status_code(self, code):
-        self._status_code = code
-        try:
-            self._status = f"{code} {HTTP_STATUS_CODES[code].upper()}"
-        except KeyError:
-            self._status = f"{code} UNKNOWN"
+        self.status = code
 
     @property
     def status(self):
@@ -303,18 +296,48 @@ class BaseResponse:
 
     @status.setter
     def status(self, value):
-        if not isinstance(value, (str, bytes)):
+        self._check_status_is_valid(value)
+        self._status, self._status_code = self._clean_status(value)
+
+    @staticmethod
+    def _check_status_is_valid(value):
+        if not isinstance(value, (str, bytes, int)):
             raise TypeError("Invalid status argument")
 
-        self._status = _to_str(value)
+    def _clean_status(self, value):
+        status = _to_str(value, self.charset)
+        split_status = status.split(None, 1)
 
-        try:
-            self._status_code = int(self._status.split(None, 1)[0])
-        except ValueError:
-            self._status_code = 0
-            self._status = f"0 {self._status}"
-        except IndexError:
+        if len(split_status) == 0:
             raise ValueError("Empty status argument")
+
+        if len(split_status) > 1:
+            if split_status[0].isdigit():
+                return self._clean_custom_status(status, split_status)
+
+            return self._clean_status_with_no_code_provided(status)
+
+        if split_status[0].isdigit():
+            return self._clean_status_with_only_code_provided(split_status)
+
+        return self._clean_status_with_no_code_provided(status)
+
+    @staticmethod
+    def _clean_custom_status(status, split_status):
+        return status, int(split_status[0])
+
+    @staticmethod
+    def _clean_status_with_no_code_provided(status):
+        return f"0 {status}", 0
+
+    @staticmethod
+    def _clean_status_with_only_code_provided(split_status):
+        status_code = int(split_status[0])
+        try:
+            status = f"{status_code} {HTTP_STATUS_CODES[status_code].upper()}"
+        except KeyError:
+            status = f"{status_code} UNKNOWN"
+        return status, status_code
 
     def get_data(self, as_text=False):
         """The string representation of the request body.  Whenever you call

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -355,27 +355,56 @@ def test_base_response():
     assert len(closed) == 1
 
 
-def test_response_status_codes():
+@pytest.mark.parametrize(
+    ("status_code", "expected_status"),
+    [
+        (200, "200 OK"),
+        (404, "404 NOT FOUND"),
+        (588, "588 UNKNOWN"),
+        (999, "999 UNKNOWN"),
+    ],
+)
+def test_response_set_status_code(status_code, expected_status):
     response = wrappers.BaseResponse()
-    response.status_code = 404
-    assert response.status == "404 NOT FOUND"
-    response.status = "200 OK"
-    assert response.status_code == 200
-    response.status = "999 WTF"
-    assert response.status_code == 999
-    response.status_code = 588
-    assert response.status_code == 588
-    assert response.status == "588 UNKNOWN"
-    response.status = "wtf"
-    assert response.status_code == 0
-    assert response.status == "0 wtf"
+    response.status_code = status_code
+    assert response.status_code == status_code
+    assert response.status == expected_status
 
+
+@pytest.mark.parametrize(
+    ("status", "expected_status_code", "expected_status"),
+    [
+        ("404", 404, "404 NOT FOUND"),
+        ("588", 588, "588 UNKNOWN"),
+        ("999", 999, "999 UNKNOWN"),
+        ("200 OK", 200, "200 OK"),
+        ("999 WTF", 999, "999 WTF"),
+        ("wtf", 0, "0 wtf"),
+        ("200 TEA POT", 200, "200 TEA POT"),
+        (200, 200, "200 OK"),
+        (400, 400, "400 BAD REQUEST"),
+    ],
+)
+def test_response_set_status(status, expected_status_code, expected_status):
+    response = wrappers.BaseResponse()
+    response.status = status
+    assert response.status_code == expected_status_code
+    assert response.status == expected_status
+
+    response = wrappers.Response(status=status)
+    assert response.status_code == expected_status_code
+    assert response.status == expected_status
+
+
+def test_response_init_status_empty_string():
     # invalid status codes
     with pytest.raises(ValueError) as info:
         wrappers.BaseResponse(None, "")
 
     assert "Empty status argument" in str(info.value)
 
+
+def test_response_init_status_tuple():
     with pytest.raises(TypeError) as info:
         wrappers.BaseResponse(None, tuple())
 


### PR DESCRIPTION
Status setter now properly calls status code setter instead of setting status code directly.

fixes #1658 