### PR TITLE
test client accepts multiple values for a header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Unreleased
 
 -   Add a ``url_scheme`` argument to :meth:`~routing.MapAdapter.build`
     to override the bound scheme. :pr:`1721`
+-   When passing a ``Headers`` object to a test client method or
+    ``EnvironBuilder``, multiple values for a key are joined into one
+    comma separated value. This matches the HTTP spec on multi-value
+    headers. :issue:`1655`
 
 
 Version 1.0.1

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -10,6 +10,7 @@
 """
 import mimetypes
 import sys
+from collections import defaultdict
 from io import BytesIO
 from itertools import chain
 from random import random
@@ -740,8 +741,13 @@ class EnvironBuilder(object):
             result["CONTENT_LENGTH"] = str(content_length)
             headers.set("Content-Length", content_length)
 
+        combined_headers = defaultdict(list)
+
         for key, value in headers.to_wsgi_list():
-            result["HTTP_%s" % key.upper().replace("-", "_")] = value
+            combined_headers["HTTP_%s" % key.upper().replace("-", "_")].append(value)
+
+        for key, values in combined_headers.items():
+            result[key] = ", ".join(values)
 
         if self.environ_overrides:
             result.update(self.environ_overrides)

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -20,6 +20,7 @@ from werkzeug._compat import implements_iterator
 from werkzeug._compat import iteritems
 from werkzeug._compat import to_bytes
 from werkzeug.datastructures import FileStorage
+from werkzeug.datastructures import Headers
 from werkzeug.datastructures import MultiDict
 from werkzeug.formparser import parse_form_data
 from werkzeug.test import Client
@@ -222,6 +223,15 @@ def test_environ_builder_headers_content_type():
     b = EnvironBuilder()
     env = b.get_environ()
     assert "CONTENT_TYPE" not in env
+
+
+def test_envrion_builder_multiple_headers():
+    h = Headers()
+    h.add("FOO", "bar")
+    h.add("FOO", "baz")
+    b = EnvironBuilder(headers=h)
+    env = b.get_environ()
+    assert env["HTTP_FOO"] == "bar, baz"
 
 
 def test_environ_builder_paths():


### PR DESCRIPTION
closes #1655 

Multiple lines with the same header key are equivalent to one key with the values comma separated. This assumes the value can be comma separated, but presumably you wouldn't be setting multiple values if they weren't valid, so this doesn't (and can't) validate that.

Thanks @aschuman0 for helping with this at the sprint.