### PR TITLE
Fix csp parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Make the argument to ``RequestRedirect.get_response`` optional.
     :issue:`1718`
 -   Only allow a single access control allow origin value. :pr:`1723`
+-   Fix crash when trying to parse a non-existent Content Security
+    Policy header. :pr:`1731`
 
 
 Version 1.0.0

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -540,6 +540,8 @@ def parse_csp_header(value, on_update=None, cls=None):
 
     if cls is None:
         cls = ContentSecurityPolicy
+    if value is None:
+        return cls(None, on_update)
     items = []
     for policy in value.split(";"):
         policy = policy.strip()


### PR DESCRIPTION
There may not be a content security policy header to parse, in which
case the value by default is None. Therefore rather than erroring this
change returns an empty ContentSecurityPolicy datastructure.

(This is the same logic as for Cache Control headers).