### PR TITLE
_dump_date zfills years < 4 digits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 -   Only allow a single access control allow origin value. :pr:`1723`
 -   Fix crash when trying to parse a non-existent Content Security
     Policy header. :pr:`1731`
+-   ``http_date`` zero fills years < 1000 to always output four digits.
+    :issue:`1739`
 
 
 Version 1.0.0

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -865,7 +865,7 @@ def _dump_date(d, delim):
         d = d.utctimetuple()
     elif isinstance(d, (integer_types, float)):
         d = gmtime(d)
-    return "%s, %02d%s%s%s%s %02d:%02d:%02d GMT" % (
+    return "%s, %02d%s%s%s%04d %02d:%02d:%02d GMT" % (
         ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")[d.tm_wday],
         d.tm_mday,
         delim,
@@ -884,7 +884,7 @@ def _dump_date(d, delim):
             "Dec",
         )[d.tm_mon - 1],
         delim,
-        str(d.tm_year),
+        d.tm_year,
         d.tm_hour,
         d.tm_min,
         d.tm_sec,

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -668,6 +668,18 @@ class TestRange(object):
         assert rv.length == 100
         assert rv.units == "bytes"
 
+    @pytest.mark.parametrize(
+        ("args", "expected"),
+        (
+            ((1, 1, 1), "Mon, 01 Jan 0001 00:00:00 GMT"),
+            ((999, 1, 1), "Tue, 01 Jan 0999 00:00:00 GMT"),
+            ((1000, 1, 1), "Wed, 01 Jan 1000 00:00:00 GMT"),
+            ((2020, 1, 1), "Wed, 01 Jan 2020 00:00:00 GMT"),
+        ),
+    )
+    def test_http_date_lt_1000(self, args, expected):
+        assert http.http_date(datetime(*args)) == expected
+
 
 class TestRegression(object):
     def test_best_match_works(self):


### PR DESCRIPTION
fixes #1739

Added a zfill to correctly display year on dates before year 1000.