### PR TITLE
Add missing documentation about None return type.

### DIFF
--- a/src/werkzeug/useragents.py
+++ b/src/werkzeug/useragents.py
@@ -112,8 +112,8 @@ class UserAgent(object):
 
     .. attribute:: platform
 
-       the browser platform.  The following platforms are currently
-       recognized:
+       the browser platform. ``None`` if not recognized.
+       The following platforms are currently recognized:
 
        -   `aix`
        -   `amiga`
@@ -139,8 +139,8 @@ class UserAgent(object):
 
     .. attribute:: browser
 
-        the name of the browser.  The following browsers are currently
-        recognized:
+        the name of the browser. ``None`` if not recognized.
+        The following browsers are currently recognized:
 
         -   `aol` *
         -   `ask` *
@@ -170,11 +170,11 @@ class UserAgent(object):
 
     .. attribute:: version
 
-        the version of the browser
+        the version of the browser. ``None`` if not recognized.
 
     .. attribute:: language
 
-        the language of the browser
+        the language of the browser. ``None`` if not recognized.
     """
 
     _parser = UserAgentParser()


### PR DESCRIPTION
The documentation misses valuable information about the default return types for user agent.

From the documentation it is unclear if the attributes exist, are None or are empty strings when the user agent is not recognised.