### PR TITLE
Update Quickstart docs reference code to import StringIO function from io module

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -77,7 +77,7 @@ was transmitted in a POST/PUT request.
 For testing purposes we can create a request object from supplied data
 using the :meth:`~BaseRequest.from_values` method:
 
->>> from cStringIO import StringIO
+>>> from io import StringIO
 >>> data = "name=this+is+encoded+form+data&another_key=another+one"
 >>> request = Request.from_values(query_string='foo=bar&blah=blafasel',
 ...    content_length=len(data), input_stream=StringIO(data),


### PR DESCRIPTION
Hello, just came across another piece of code that could be updated (again, small stuff). From [quickstart docs](https://werkzeug.palletsprojects.com/en/1.0.x/quickstart/#enter-request) we have `from cStringIO import StringIO`, but from python 3 [change logs](https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit):

> The StringIO and cStringIO modules are gone. Instead, import the io module and use io.StringIO or io.BytesIO for text and data respectively.

So, updated import statement should be `from io import StringIO`