### PR TITLE
Add pytest-timeout to dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ test_uwsgi_failed
 .idea
 .pytest_cache/
 venv/
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ test_uwsgi_failed
 .idea
 .pytest_cache/
 venv/
-.vscode

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "watchdog": ["watchdog"],
         "dev": [
             "pytest",
+            "pytest-timeout",
             "coverage",
             "tox",
             "sphinx",


### PR DESCRIPTION
Without that the method of running basic tests suggested in CONTRIBUTING
guide fails with error (pytest config turns all warnings into errors and
there is an unregistered marker).