### PR TITLE
Deprecate utils.format_string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 2.0.0
 Unreleased
 
 -   Drop support for Python 2 and 3.5. :pr:`1693`
+-   Deprecate :func:`utils.format_string`, use :class:`string.Template`
+    instead. :issue:`1756`
 -   Add a ``url_scheme`` argument to :meth:`~routing.MapAdapter.build`
     to override the bound scheme. :pr:`1721`
 -   When passing a ``Headers`` object to a test client method or

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -101,6 +101,7 @@ import re
 import uuid
 import warnings
 from pprint import pformat
+from string import Template
 from threading import Lock
 
 from ._internal import _encode_idna
@@ -120,7 +121,6 @@ from .urls import url_encode
 from .urls import url_join
 from .urls import url_quote
 from .utils import cached_property
-from .utils import format_string
 from .utils import redirect
 from .wsgi import get_host
 
@@ -473,15 +473,15 @@ class RuleTemplateFactory(RuleFactory):
                     new_defaults = {}
                     for key, value in rule.defaults.items():
                         if isinstance(value, str):
-                            value = format_string(value, self.context)
+                            value = Template(value).substitute(self.context)
                         new_defaults[key] = value
                 if rule.subdomain is not None:
-                    subdomain = format_string(rule.subdomain, self.context)
+                    subdomain = Template(rule.subdomain).substitute(self.context)
                 new_endpoint = rule.endpoint
                 if isinstance(new_endpoint, str):
-                    new_endpoint = format_string(new_endpoint, self.context)
+                    new_endpoint = Template(new_endpoint).substitute(self.context)
                 yield Rule(
-                    format_string(rule.rule, self.context),
+                    Template(rule.rule).substitute(self.context),
                     new_defaults,
                     subdomain,
                     rule.methods,

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -21,7 +21,6 @@ from ._internal import _DictAccessorProperty
 from ._internal import _missing
 from ._internal import _parse_signature
 
-_format_re = re.compile(r"\$(?:([a-zA-Z_][a-zA-Z0-9_]*)|\{([a-zA-Z_][a-zA-Z0-9_]*)\})")
 _entity_re = re.compile(r"&([^;]+);")
 _filename_ascii_strip_re = re.compile(r"[^A-Za-z0-9_.-]")
 _windows_device_files = (
@@ -356,28 +355,23 @@ def format_string(string, context):
     >>> format_string('$foo and ${foo}s', dict(foo=42))
     '42 and 42s'
 
-    This does not do any attribute lookup etc.  For more advanced string
-    formattings have a look at the `werkzeug.template` module.
+    This does not do any attribute lookup.
 
     :param string: the format string.
     :param context: a dict with the variables to insert.
+
+    .. deprecated:: 2.0
+        Will be removed in 2.1. Use :class:`string.Template` instead.
     """
+    from string import Template
 
     warnings.warn(
-        "'utils.format_string' is deprecated"
-        " and will be removed in 2.1. Use "
-        "'string.Template' instead.",
+        "'utils.format_string' is deprecated and will be removed in"
+        " 2.1. Use 'string.Template' instead.",
         DeprecationWarning,
         stacklevel=2,
     )
-
-    def lookup_arg(match):
-        x = context[match.group(1) or match.group(2)]
-        if not isinstance(x, str):
-            x = type(string)(x)
-        return x
-
-    return _format_re.sub(lookup_arg, string)
+    return Template(string).substitute(context)
 
 
 def secure_filename(filename):

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -14,6 +14,7 @@ import os
 import pkgutil
 import re
 import sys
+import warnings
 from html.entities import name2codepoint
 
 from ._internal import _DictAccessorProperty
@@ -361,6 +362,14 @@ def format_string(string, context):
     :param string: the format string.
     :param context: a dict with the variables to insert.
     """
+
+    warnings.warn(
+        "'utils.format_string' is deprecated"
+        " and will be removed in 2.1. Use "
+        "'string.Template' instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     def lookup_arg(match):
         x = context[match.group(1) or match.group(2)]


### PR DESCRIPTION
Replaces `util.format_string` calls with `string.Template` and adds a deprecation warning to `util.format_string`.

fixes #1756