### PR TITLE
remove simplejson

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Drop support for Python 2 and 3.5. :pr:`1693`
 -   Deprecate :func:`utils.format_string`, use :class:`string.Template`
     instead. :issue:`1756`
+-   ``JSONMixin`` no longer uses simplejson if it's installed. To use
+    another JSON module, override ``JSONMixin.json_module``. :pr:`1766`
 -   Add a ``url_scheme`` argument to :meth:`~routing.MapAdapter.build`
     to override the bound scheme. :pr:`1721`
 -   When passing a ``Headers`` object to a test client method or

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,15 +21,11 @@ Optional dependencies
 These distributions will not be installed automatically. Werkzeug will
 detect and use them if you install them.
 
-* `SimpleJSON`_ is a fast JSON implementation that is compatible with
-  Python's ``json`` module. It is preferred for JSON operations if it is
-  installed.
 * `Click`_ provides request log highlighting when using the
   development server. On Windows, you should also install `colorama`_.
 * `Watchdog`_ provides a faster, more efficient reloader for the
   development server.
 
-.. _SimpleJSON: https://simplejson.readthedocs.io/en/latest/
 .. _Click: https://pypi.org/project/click/
 .. _Watchdog: https://pypi.org/project/watchdog/
 .. _colorama: https://pypi.org/project/colorama/

--- a/docs/request_data.rst
+++ b/docs/request_data.rst
@@ -109,9 +109,9 @@ There is already a mixin that provides JSON parsing::
 
 The basic implementation of that looks like::
 
+    import json
     from werkzeug.utils import cached_property
     from werkzeug.wrappers import Request
-    import simplejson as json
 
     class JSONRequest(Request):
         @cached_property

--- a/src/werkzeug/wrappers/json.py
+++ b/src/werkzeug/wrappers/json.py
@@ -1,12 +1,8 @@
 import datetime
+import json
 import uuid
 
 from ..exceptions import BadRequest
-
-try:
-    import simplejson as _json
-except ImportError:
-    import json as _json
 
 
 class _JSONModule:
@@ -28,22 +24,17 @@ class _JSONModule:
         kw.setdefault("separators", (",", ":"))
         kw.setdefault("default", cls._default)
         kw.setdefault("sort_keys", True)
-        return _json.dumps(obj, **kw)
+        return json.dumps(obj, **kw)
 
     @staticmethod
     def loads(s, **kw):
-        return _json.loads(s, **kw)
+        return json.loads(s, **kw)
 
 
 class JSONMixin:
     """Mixin to parse :attr:`data` as JSON. Can be mixed in for both
     :class:`~werkzeug.wrappers.Request` and
     :class:`~werkzeug.wrappers.Response` classes.
-
-    If `simplejson`_ is installed it is preferred over Python's built-in
-    :mod:`json` module.
-
-    .. _simplejson: https://simplejson.readthedocs.io/en/latest/
     """
 
     #: A module or other object that has ``dumps`` and ``loads``


### PR DESCRIPTION
In modern Python it's unlikely to be significantly better than the built-in `json`. The module used by `JSONMixin` is overridable, so users can plug it in again if they want.

See https://github.com/pallets/itsdangerous/issues/146