### PR TITLE
Remove remaining vestiges of Python 2 support

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -180,7 +180,7 @@ for ``"maybe"``. ::
         regex = r"(?:yes|no|maybe)"
 
         def __init__(self, url_map, maybe=False):
-            super(BooleanConverter, self).__init__(url_map)
+            super().__init__(url_map)
             self.maybe = maybe
 
         def to_python(self, value):

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -111,7 +111,7 @@ class ImmutableDictMixin:
 
     @classmethod
     def fromkeys(cls, keys, value=None):
-        instance = super(cls, cls).__new__(cls)
+        instance = super().__new__(cls)
         instance.__init__(zip(keys, repeat(value)))
         return instance
 
@@ -191,7 +191,7 @@ class UpdateDictMixin:
 
     def calls_update(name):  # noqa: B902
         def oncall(self, *args, **kw):
-            rv = getattr(super(UpdateDictMixin, self), name)(*args, **kw)
+            rv = getattr(super(), name)(*args, **kw)
             if self.on_update is not None:
                 self.on_update(self)
             return rv
@@ -689,9 +689,6 @@ class OrderedMultiDict(MultiDict):
 
     __hash__ = None
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __reduce_ex__(self, protocol):
         return type(self), (list(self.items(multi=True)),)
 
@@ -897,9 +894,6 @@ class Headers:
         ) == set(map(lowered, self._list))
 
     __hash__ = None
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def get(self, key, default=None, type=None, as_bytes=False):
         """Return the default value if the requested data doesn't exist.

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -91,7 +91,7 @@ class HTTPException(Exception):
             show_exception = False
 
             def __init__(self, arg=None, *args, **kwargs):
-                super(cls, self).__init__(*args, **kwargs)
+                super().__init__(*args, **kwargs)
 
                 if arg is None:
                     exception.__init__(self)

--- a/src/werkzeug/local.py
+++ b/src/werkzeug/local.py
@@ -339,7 +339,6 @@ class LocalProxy:
     __ne__ = lambda x, o: x._get_current_object() != o
     __gt__ = lambda x, o: x._get_current_object() > o
     __ge__ = lambda x, o: x._get_current_object() >= o
-    __cmp__ = lambda x, o: cmp(x._get_current_object(), o)  # noqa
     __hash__ = lambda x: hash(x._get_current_object())
     __call__ = lambda x, *a, **kw: x._get_current_object()(*a, **kw)
     __len__ = lambda x: len(x._get_current_object())

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1113,9 +1113,6 @@ class Rule(RuleFactory):
 
     __hash__ = None
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __str__(self):
         return self.rule
 

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -22,7 +22,8 @@ def test_basic_local():
     threads = [Thread(target=value_setter, args=(x,)) for x in [1, 2, 3]]
     for thread in threads:
         thread.start()
-    time.sleep(0.2)
+    for thread in threads:
+        thread.join()
     assert sorted(values) == [1, 2, 3]
 
     def delfoo():
@@ -63,6 +64,8 @@ def test_local_proxy():
 def test_local_proxy_operations_math():
     foo = 2
     ls = local.LocalProxy(lambda: foo)
+    assert ls == 2
+    assert ls != 3
     assert ls + 1 == 3
     assert 1 + ls == 3
     assert ls - 1 == 1


### PR DESCRIPTION
Python 2 support was dropped in #1693.

* Remove superfluous __ne__ and __cmp__ implementations.
* Use no-arg super() rather than 2-arg super(...).

Also improve associated tests.