### PR TITLE
Switch locals to be based on ContextVars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -145,6 +145,8 @@ Unreleased
     is proxied, so the proxy will look like the object in more cases,
     including ``isinstance``. Use ``issubclass(type(obj), LocalProxy)``
     to check if an object is actually a proxy. :issue:`1754`
+-   ``Local`` uses ``ContextVar`` on Python 3.7+ instead of
+    ``threading.local``. :pr:`1778`
 
 
 Version 1.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,12 @@ ignore_missing_imports = True
 [mypy-cryptography.*]
 ignore_missing_imports = True
 
+[mypy-eventlet.*]
+ignore_missing_imports = True
+
+[mypy-gevent.*]
+ignore_missing_imports = True
+
 [mypy-greenlet.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
`ContextVar` was introduced in Python 3.7 and is effectively the same as `Local` in Werkzeug (although a different API). They should work in Greenlet and threading contexts as before but also now in asyncio or other async/await contexts.

The `__storage__` attribute has been kept for backwards compatibility (even though it is a dunder it seems it is used, e.g. in tests).

The `ident_func` though must be deprecated as this is now handled by the `ContextVar`. This may cause some backwards incompatibility.