### PR TITLE
Expect REQUEST_URI to preserve the query string

### DIFF
--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -817,3 +817,9 @@ def test_raw_request_uri():
     response = client.get("/hello%2fworld")
     data = response.get_data(as_text=True)
     assert data == "/hello/world\n/hello%2fworld"
+
+    response = client.get("/?a=b")
+    assert response.get_data(as_text=True) == "/\n/?a=b"
+
+    response = client.get("/%3f?")  # escaped ? in path, and empty query string
+    assert response.get_data(as_text=True) == "/?\n/%3f?"


### PR DESCRIPTION
Following #1781, for which I forgot to include the reproduction steps. Sorry about that.

The tests should be working assuming the query string was preserved in REQUEST_URI, but they don’t. Here’s what I get instead:

```
        response = client.get("/?a=b")
>       assert response.get_data(as_text=True) == "/\n/?a=b"
E       AssertionError: assert '/\n/' == '/\n/?a=b'
E           /
E         - /?a=b
E         + /
```

I’m making this pull request a draft as you probably don’t want to merge it until the tests pass.