### PR TITLE
Deprecate utils.escape/unescape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
     :func:`utils.validate_arguments`, use :meth:`Signature.bind` and
     :func:`inspect.signature` instead. :issue:`1757`
 -   Deprecate :class:`utils.HTMLBuilder`. :issue:`1761`
+-   Deprecate :func:`utils.escape` and :func:`utils.unescape`, use
+    MarkupSafe instead. :issue:`1758`
 -   ``JSONMixin`` no longer uses simplejson if it's installed. To use
     another JSON module, override ``JSONMixin.json_module``. :pr:`1766`
 -   Add a ``url_scheme`` argument to :meth:`~routing.MapAdapter.build`

--- a/docs/levels.rst
+++ b/docs/levels.rst
@@ -19,7 +19,7 @@ user with the name entered.
 
 .. code-block:: python
 
-    from werkzeug.utils import escape
+    from html import escape
     from werkzeug.wrappers import Request, Response
 
     @Request.application
@@ -38,8 +38,8 @@ user with the name entered.
 Alternatively the same application could be used without request and response
 objects but by taking advantage of the parsing functions werkzeug provides::
 
+    from html import escape
     from werkzeug.formparser import parse_form_data
-    from werkzeug.utils import escape
 
     def hello_world(environ, start_response):
         result = ['<title>Greeter</title>']

--- a/examples/plnt/sync.py
+++ b/examples/plnt/sync.py
@@ -1,8 +1,8 @@
 """Does the synchronization. Called by "manage-plnt.py sync"."""
 from datetime import datetime
+from html import escape
 
 import feedparser
-from werkzeug.utils import escape
 
 from .database import Blog
 from .database import Entry

--- a/src/werkzeug/debug/console.py
+++ b/src/werkzeug/debug/console.py
@@ -1,9 +1,9 @@
 import code
 import sys
+from html import escape
 from types import CodeType
 
 from ..local import Local
-from ..utils import escape
 from .repr import debug_repr
 from .repr import dump
 from .repr import helper

--- a/src/werkzeug/debug/repr.py
+++ b/src/werkzeug/debug/repr.py
@@ -8,9 +8,8 @@ import codecs
 import re
 import sys
 from collections import deque
+from html import escape
 from traceback import format_exception_only
-
-from ..utils import escape
 
 
 missing = object()

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -6,14 +6,13 @@ import re
 import sys
 import sysconfig
 import traceback
+from html import escape
 from tokenize import TokenError
 
 from .._internal import _to_str
 from ..filesystem import get_filesystem_encoding
 from ..utils import cached_property
-from ..utils import escape
 from .console import Console
-
 
 _coding_re = re.compile(br"coding[:=]\s*([-\w.]+)")
 _line_re = re.compile(br"^(.*?)$", re.MULTILINE)

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -47,9 +47,9 @@ code, you can add a second except for a specific subclass of an error:
 """
 import sys
 from datetime import datetime
+from html import escape
 
 from ._internal import _get_environ
-from .utils import escape
 
 
 class HTTPException(Exception):

--- a/src/werkzeug/testapp.py
+++ b/src/werkzeug/testapp.py
@@ -4,10 +4,10 @@ it for WSGI compliance.
 import base64
 import os
 import sys
+from html import escape
 from textwrap import wrap
 
 from . import __version__ as _werkzeug_version
-from .utils import escape
 from .wrappers import BaseRequest as Request
 from .wrappers import BaseResponse as Response
 

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -430,16 +430,20 @@ def secure_filename(filename):
 
 
 def escape(s):
-    """Replace special characters "&", "<", ">" and (") to HTML-safe sequences.
+    """Replace ``&``, ``<``, ``>``, and ``"`` with HTML-safe sequences.
 
-    There is a special handling for `None` which escapes to an empty string.
+    ``None`` is escaped to an empty string.
 
-    .. versionchanged:: 0.9
-       `quote` is now implicitly on.
-
-    :param s: the string to escape.
-    :param quote: ignored.
+    .. deprecated:: 2.0
+        Will be removed in 2.1. Use MarkupSafe instead.
     """
+    warnings.warn(
+        "'utils.escape' is deprecated and will be removed in 2.1. Use"
+        " MarkupSafe instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if s is None:
         return ""
     elif hasattr(s, "__html__"):
@@ -457,11 +461,18 @@ def escape(s):
 
 
 def unescape(s):
-    """The reverse function of `escape`.  This unescapes all the HTML
-    entities, not only the XML entities inserted by `escape`.
+    """The reverse of :func:`escape`. This unescapes all the HTML
+    entities, not only those inserted by ``escape``.
 
-    :param s: the string to unescape.
+    .. deprecated:: 2.0
+        Will be removed in 2.1. Use MarkupSafe instead.
     """
+    warnings.warn(
+        "'utils.unescape' is deprecated and will be removed in 2.1. Use"
+        " MarkupSafe instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     def handle_match(m):
         name = m.group(1)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -22,26 +22,25 @@ from werkzeug.wrappers import Response
 class TestDebugRepr:
     def test_basic_repr(self):
         assert debug_repr([]) == "[]"
-        assert (
-            debug_repr([1, 2])
-            == '[<span class="number">1</span>, <span class="number">2</span>]'
+        assert debug_repr([1, 2]) == (
+            '[<span class="number">1</span>, <span class="number">2</span>]'
         )
-        assert (
-            debug_repr([1, "test"])
-            == '[<span class="number">1</span>, <span class="string">\'test\'</span>]'
+        assert debug_repr([1, "test"]) == (
+            '[<span class="number">1</span>,'
+            ' <span class="string">&#x27;test&#x27;</span>]'
         )
         assert debug_repr([None]) == '[<span class="object">None</span>]'
 
     def test_string_repr(self):
-        assert debug_repr("") == "<span class=\"string\">''</span>"
-        assert debug_repr("foo") == "<span class=\"string\">'foo'</span>"
+        assert debug_repr("") == '<span class="string">&#x27;&#x27;</span>'
+        assert debug_repr("foo") == '<span class="string">&#x27;foo&#x27;</span>'
         assert debug_repr("s" * 80) == (
-            f'<span class="string">\'{"s" * 69}'
-            f'<span class="extended">{"s" * 11}\'</span></span>'
+            f'<span class="string">&#x27;{"s" * 69}'
+            f'<span class="extended">{"s" * 11}&#x27;</span></span>'
         )
         assert debug_repr("<" * 80) == (
-            f'<span class="string">\'{"&lt;" * 69}'
-            f'<span class="extended">{"&lt;" * 11}\'</span></span>'
+            f'<span class="string">&#x27;{"&lt;" * 69}'
+            f'<span class="extended">{"&lt;" * 11}&#x27;</span></span>'
         )
 
     def test_string_subclass_repr(self):
@@ -50,7 +49,7 @@ class TestDebugRepr:
 
         assert debug_repr(Test("foo")) == (
             '<span class="module">test_debug.</span>'
-            "Test(<span class=\"string\">'foo'</span>)"
+            'Test(<span class="string">&#x27;foo&#x27;</span>)'
         )
 
     def test_sequence_repr(self):
@@ -71,7 +70,7 @@ class TestDebugRepr:
     def test_mapping_repr(self):
         assert debug_repr({}) == "{}"
         assert debug_repr({"foo": 42}) == (
-            '{<span class="pair"><span class="key"><span class="string">\'foo\''
+            '{<span class="pair"><span class="key"><span class="string">&#x27;foo&#x27;'
             '</span></span>: <span class="value"><span class="number">42'
             "</span></span></span>}"
         )
@@ -109,8 +108,8 @@ class TestDebugRepr:
             "</span></span></span></span>}"
         )
         assert debug_repr((1, "zwei", "drei")) == (
-            '(<span class="number">1</span>, <span class="string">\''
-            "zwei'</span>, <span class=\"string\">'drei'</span>)"
+            '(<span class="number">1</span>, <span class="string">&#x27;'
+            'zwei&#x27;</span>, <span class="string">&#x27;drei&#x27;</span>)'
         )
 
     def test_custom_repr(self):
@@ -143,9 +142,11 @@ class TestDebugRepr:
     def test_set_repr(self):
         assert (
             debug_repr(frozenset("x"))
-            == "frozenset([<span class=\"string\">'x'</span>])"
+            == 'frozenset([<span class="string">&#x27;x&#x27;</span>])'
         )
-        assert debug_repr(set("x")) == "set([<span class=\"string\">'x'</span>])"
+        assert debug_repr(set("x")) == (
+            'set([<span class="string">&#x27;x&#x27;</span>])'
+        )
 
     def test_recursive_repr(self):
         a = [1]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -172,22 +172,6 @@ def test_environ_property():
     assert a.environ["date"] == "Tue, 22 Jan 2008 10:00:00 GMT"
 
 
-def test_escape():
-    class Foo(str):
-        def __html__(self):
-            return str(self)
-
-    assert utils.escape(None) == ""
-    assert utils.escape(42) == "42"
-    assert utils.escape("<>") == "&lt;&gt;"
-    assert utils.escape('"foo"') == "&quot;foo&quot;"
-    assert utils.escape(Foo("<foo>")) == "<foo>"
-
-
-def test_unescape():
-    assert utils.unescape("&lt;&auml;&gt;") == "<ä>"
-
-
 def test_import_string():
     from datetime import date
     from werkzeug.debug import DebuggedApplication


### PR DESCRIPTION
This moves utils.escape and utils.unescape implementations to _internal, renaming them to _escape and _unescape, respectively (escape and unescape are now importing these functions from _internal). Since utils.HTMLBuilder is used by unescape, I opted to move it to _internal along with the other two functions (not sure how to conciliate this with #1772 )

Fixes #1758