### PR TITLE
fix mistyped path in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -64,7 +64,7 @@ First time setup
 
 - Create a virtualenv::
 
-        python3 -m venv env
+        python3 -m venv venv
         . venv/bin/activate
         # or "venv\Scripts\activate" on Windows
 


### PR DESCRIPTION
Hi.
The path for using virtualenv in CONTRIBUTING.rst is wrong.
I found this mistype when I tried to contribute other problem.
I didn't create a Issue because it was a minor fix.
