### PR TITLE
Update documentation of SharedDataMiddleware

### DIFF
--- a/src/werkzeug/middleware/shared_data.py
+++ b/src/werkzeug/middleware/shared_data.py
@@ -36,7 +36,7 @@ class SharedDataMiddleware:
         from werkzeug.middleware.shared_data import SharedDataMiddleware
 
         app = SharedDataMiddleware(app, {
-            '/static': os.path.join(os.path.dirname(__file__), 'static')
+            '/shared': os.path.join(os.path.dirname(__file__), 'shared')
         })
 
     The contents of the folder ``./shared`` will now be available on


### PR DESCRIPTION
I was reading the documentation of the `middleware.SharedDataMiddleware` class and I noticed that the example code snippet is not reflecting the explanation.