### PR TITLE
Allow BaseRequest subclasses to override empty value handling

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -794,13 +794,11 @@ def url_decode(
         separator = separator.decode(charset or "ascii")
     elif isinstance(s, bytes) and not isinstance(separator, bytes):
         separator = separator.encode(charset or "ascii")
-    return cls(_url_decode_impl(
-        s.split(separator),
-        charset,
-        include_empty,
-        errors,
-        empty_value,
-    ))
+    return cls(
+        _url_decode_impl(
+            s.split(separator), charset, include_empty, errors, empty_value,
+        )
+    )
 
 
 def url_decode_stream(
@@ -866,13 +864,7 @@ def url_decode_stream(
     return cls(decoder)
 
 
-def _url_decode_impl(
-    pair_iter,
-    charset,
-    include_empty,
-    errors,
-    empty_value=""
-):
+def _url_decode_impl(pair_iter, charset, include_empty, errors, empty_value=""):
     for pair in pair_iter:
         if not pair:
             continue

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -888,8 +888,7 @@ def _url_decode_impl(
             if value is not None:
                 value = s(value)
         key = url_unquote_plus(key, charset, errors)
-        value = url_unquote_plus(value, charset, errors)
-        yield key, value
+        yield key, url_unquote_plus(value, charset, errors)
 
 
 def url_encode(

--- a/src/werkzeug/wrappers/base_request.py
+++ b/src/werkzeug/wrappers/base_request.py
@@ -74,6 +74,9 @@ class BaseRequest:
     #: the error handling procedure for errors, defaults to 'replace'
     encoding_errors = "replace"
 
+    #: the value to assign to url parameters with empty values, defaults to ""
+    empty_value = ""
+
     #: the maximum content length.  This is forwarded to the form data
     #: parsing function (:func:`parse_form_data`).  When set and the
     #: :attr:`form` or :attr:`files` attribute is accessed and the
@@ -403,6 +406,7 @@ class BaseRequest:
             self.url_charset,
             errors=self.encoding_errors,
             cls=self.parameter_storage_class,
+            empty_value=self.empty_value,
         )
 
     @cached_property

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -99,13 +99,13 @@ def test_url_decoding():
 
 def test_url_empty_value_decoding():
     x = urls.url_decode("a=1&b=&c&d")
-    assert x["c"] == ""
+    assert x == OrderedMultiDict({"a": "1", "b": "", "c": "", "d": ""})
 
     x = urls.url_decode("a=1&b=&c&d", empty_value=None)
-    assert x["c"] is None
+    assert x == OrderedMultiDict({"a": "1", "b": "", "c": None, "d": None})
 
     x = urls.url_decode("a=1&b=&c=&d", empty_value=None)
-    assert x["c"] == ""
+    assert x == OrderedMultiDict({"a": "1", "b": "", "c": "", "d": None})
 
 
 def test_url_bytes_decoding():

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -104,6 +104,9 @@ def test_url_empty_value_decoding():
     x = urls.url_decode("a=1&b=&c&d", empty_value=None)
     assert x["c"] is None
 
+    x = urls.url_decode("a=1&b=&c=&d", empty_value=None)
+    assert x["c"] == ""
+
 
 def test_url_bytes_decoding():
     x = urls.url_decode(b"foo=42&bar=23&uni=H%C3%A4nsel", charset=None)

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -97,6 +97,14 @@ def test_url_decoding():
     assert x["Üh"] == "Hänsel"
 
 
+def test_url_empty_value_decoding():
+    x = urls.url_decode("a=1&b=&c&d")
+    assert x["c"] == ""
+
+    x = urls.url_decode("a=1&b=&c&d", empty_value=None)
+    assert x["c"] is None
+
+
 def test_url_bytes_decoding():
     x = urls.url_decode(b"foo=42&bar=23&uni=H%C3%A4nsel", charset=None)
     assert x[b"foo"] == b"42"

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -68,6 +68,7 @@ def request_empty_value_app(environ, start_response):
         @property
         def empty_value(self):
             return None
+
     request = EmptyValueRequest(environ)
     start_response("200 OK", [("Content-Type", "text/plain")])
     return [pickle.dumps({"args": request.args})]

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -87,9 +87,9 @@ def test_base_request():
     client = Client(request_demo_app, RequestTestResponse)
 
     # get requests
-    response = client.get("/?foo=bar&foo=hehe")
-    assert response["args"] == MultiDict([("foo", "bar"), ("foo", "hehe")])
-    assert response["args_as_list"] == [("foo", ["bar", "hehe"])]
+    response = client.get("/?foo=bar&foo=hehe&baz")
+    assert response["args"] == MultiDict([("foo", "bar"), ("foo", "hehe"), ("baz", "")])
+    assert response["args_as_list"] == [("foo", ["bar", "hehe"]), ("baz", [""])]
     assert response["form"] == MultiDict()
     assert response["form_as_list"] == []
     assert response["data"] == b""

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -63,6 +63,16 @@ def request_demo_app(environ, start_response):
     ]
 
 
+def request_empty_value_app(environ, start_response):
+    class EmptyValueRequest(wrappers.BaseRequest):
+        @property
+        def empty_value(self):
+            return None
+    request = EmptyValueRequest(environ)
+    start_response("200 OK", [("Content-Type", "text/plain")])
+    return [pickle.dumps({"args": request.args})]
+
+
 def prepare_environ_pickle(environ):
     result = {}
     for key, value in iter(environ.items()):
@@ -128,6 +138,13 @@ def test_base_request():
     assert response["data"] == json
     assert response["args"] == MultiDict([("a", "b")])
     assert response["form"] == MultiDict()
+
+
+def test_base_request_empty_value():
+    client = Client(request_empty_value_app, RequestTestResponse)
+
+    response = client.post("/?foo=1&bar=&baz")
+    assert response["args"] == MultiDict([("foo", "1"), ("bar", ""), ("baz", None)])
 
 
 def test_query_string_is_bytes():


### PR DESCRIPTION
This change introduces an `empty_value` property on the `BaseRequest` class, enabling subclasses to override the default value assigned to arguments when an empty value is encountered.

For backwards-compatibility, the existing empty string value remains the default, and an implementor would have to specifically override this in order to see a change in behaviour.

Resolves #1799 