### PR TITLE
fix order of parameters for default_stream_factory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Unreleased
 -   The debugger no longer uses jQuery. :issue:`1807`
 -   The test client includes the query string in ``REQUEST_URI`` and
     ``RAW_URI``. :issue:`1781`
+-   Switch the parameter order of ``default_stream_factory`` to match
+    the order used when calling it. :pr:`1085`
 
 
 Version 1.0.2

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -39,7 +39,7 @@ _supported_multipart_encodings = frozenset(["base64", "quoted-printable"])
 
 
 def default_stream_factory(
-    total_content_length, filename, content_type, content_length=None
+    total_content_length, content_type, filename, content_length=None
 ):
     """The stream factory that is used per default."""
     max_size = 1024 * 500


### PR DESCRIPTION
I found if I set `stream_factory` to a function defined as `def custom_stream_factory(total_content_length, filename, content_type, content_length=None)` and ran debug, the argument `filename` is `content_type`. I think this is due to the inconsistent order of arguments for function `def _get_file_stream(total_content_length, content_type, filename=None, content_length=None)` defined in `wrappers/base_request.py` and this one.