### PR TITLE
Switch environ usage to headers in request mixins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ Unreleased
     :pr:`1915`
 -   Add arguments to ``delete_cookie`` to match ``set_cookie`` and the
     attributes modern browsers expect. :pr:`1889`
+-   Use ``request.headers`` instead of ``request.environ`` to look up
+    header attributes. :pr:`1808`
 
 
 Version 1.0.2

--- a/src/werkzeug/wrappers/accept.py
+++ b/src/werkzeug/wrappers/accept.py
@@ -17,16 +17,14 @@ class AcceptMixin:
         """List of mimetypes this client supports as
         :class:`~werkzeug.datastructures.MIMEAccept` object.
         """
-        return parse_accept_header(self.environ.get("HTTP_ACCEPT"), MIMEAccept)
+        return parse_accept_header(self.headers.get("Accept"), MIMEAccept)
 
     @cached_property
     def accept_charsets(self):
         """List of charsets this client supports as
         :class:`~werkzeug.datastructures.CharsetAccept` object.
         """
-        return parse_accept_header(
-            self.environ.get("HTTP_ACCEPT_CHARSET"), CharsetAccept
-        )
+        return parse_accept_header(self.headers.get("Accept-Charset"), CharsetAccept)
 
     @cached_property
     def accept_encodings(self):
@@ -34,7 +32,7 @@ class AcceptMixin:
         are compression encodings such as gzip.  For charsets have a look at
         :attr:`accept_charset`.
         """
-        return parse_accept_header(self.environ.get("HTTP_ACCEPT_ENCODING"))
+        return parse_accept_header(self.headers.get("Accept-Encoding"))
 
     @cached_property
     def accept_languages(self):
@@ -45,6 +43,4 @@ class AcceptMixin:
            In previous versions this was a regular
            :class:`~werkzeug.datastructures.Accept` object.
         """
-        return parse_accept_header(
-            self.environ.get("HTTP_ACCEPT_LANGUAGE"), LanguageAccept
-        )
+        return parse_accept_header(self.headers.get("Accept-Language"), LanguageAccept)

--- a/src/werkzeug/wrappers/auth.py
+++ b/src/werkzeug/wrappers/auth.py
@@ -20,7 +20,7 @@ class AuthorizationMixin:
     @cached_property
     def authorization(self) -> "Authorization":
         """The `Authorization` object in parsed form."""
-        header = self.environ.get("HTTP_AUTHORIZATION")
+        header = self.headers.get("Authorization")  # type: ignore
         return parse_authorization_header(header)
 
 

--- a/src/werkzeug/wrappers/common_descriptors.py
+++ b/src/werkzeug/wrappers/common_descriptors.py
@@ -15,7 +15,6 @@ from ..http import parse_date
 from ..http import parse_options_header
 from ..http import parse_set_header
 from ..utils import cached_property
-from ..utils import environ_property
 from ..utils import get_content_type
 from ..utils import header_property
 from ..wsgi import get_content_length
@@ -32,12 +31,13 @@ class CommonRequestDescriptorsMixin:
 
     environ: WSGIEnvironment
 
-    content_type = environ_property(
-        "CONTENT_TYPE",
+    content_type = header_property(
+        "Content-Type",
         doc="""The Content-Type entity-header field indicates the media
         type of the entity-body sent to the recipient or, in the case of
         the HEAD method, the media type that would have been sent had
         the request been a GET.""",
+        read_only=True,
     )
 
     @cached_property
@@ -47,10 +47,10 @@ class CommonRequestDescriptorsMixin:
         the entity-body that would have been sent had the request been a
         GET.
         """
-        return get_content_length(self.environ)
+        return get_content_length(self.headers)
 
-    content_encoding = environ_property(
-        "HTTP_CONTENT_ENCODING",
+    content_encoding = header_property(
+        "Content-Encoding",
         doc="""The Content-Encoding entity-header field is used as a
         modifier to the media-type. When present, its value indicates
         what additional content codings have been applied to the
@@ -59,9 +59,10 @@ class CommonRequestDescriptorsMixin:
         header field.
 
         .. versionadded:: 0.9""",
+        read_only=True,
     )
-    content_md5 = environ_property(
-        "HTTP_CONTENT_MD5",
+    content_md5 = header_property(
+        "Content-MD5",
         doc="""The Content-MD5 entity-header field, as defined in
         RFC 1864, is an MD5 digest of the entity-body for the purpose of
         providing an end-to-end message integrity check (MIC) of the
@@ -70,36 +71,40 @@ class CommonRequestDescriptorsMixin:
         against malicious attacks.)
 
         .. versionadded:: 0.9""",
+        read_only=True,
     )
-    referrer = environ_property(
-        "HTTP_REFERER",
+    referrer = header_property(
+        "Referer",
         doc="""The Referer[sic] request-header field allows the client
         to specify, for the server's benefit, the address (URI) of the
         resource from which the Request-URI was obtained (the
         "referrer", although the header field is misspelled).""",
+        read_only=True,
     )
-    date = environ_property(
-        "HTTP_DATE",
+    date = header_property(
+        "Date",
         None,
         parse_date,
         doc="""The Date general-header field represents the date and
         time at which the message was originated, having the same
         semantics as orig-date in RFC 822.""",
+        read_only=True,
     )
-    max_forwards = environ_property(
-        "HTTP_MAX_FORWARDS",
+    max_forwards = header_property(
+        "Max-Forwards",
         None,
         int,
         doc="""The Max-Forwards request-header field provides a
         mechanism with the TRACE and OPTIONS methods to limit the number
         of proxies or gateways that can forward the request to the next
         inbound server.""",
+        read_only=True,
     )
 
     def _parse_content_type(self) -> None:
         if not hasattr(self, "_parsed_content_type"):
             self._parsed_content_type = parse_options_header(
-                self.environ.get("CONTENT_TYPE", "")
+                self.headers.get("Content-Type", "")  # type: ignore
             )
 
     @property
@@ -129,7 +134,7 @@ class CommonRequestDescriptorsMixin:
         optional behavior from the viewpoint of the protocol; however, some
         systems MAY require that behavior be consistent with the directives.
         """
-        return parse_set_header(self.environ.get("HTTP_PRAGMA", ""))
+        return parse_set_header(self.headers.get("Pragma", ""))
 
 
 class CommonResponseDescriptorsMixin:

--- a/src/werkzeug/wrappers/cors.py
+++ b/src/werkzeug/wrappers/cors.py
@@ -1,6 +1,5 @@
 from ..http import dump_header
 from ..http import parse_set_header
-from ..utils import environ_property
 from ..utils import header_property
 
 
@@ -12,17 +11,18 @@ class CORSRequestMixin:
     .. versionadded:: 1.0
     """
 
-    origin = environ_property(
-        "HTTP_ORIGIN",
+    origin = header_property(
+        "Origin",
         doc=(
             "The host that the request originated from. Set"
             " :attr:`~CORSResponseMixin.access_control_allow_origin` on"
             " the response to indicate which origins are allowed."
         ),
+        read_only=True,
     )
 
-    access_control_request_headers = environ_property(
-        "HTTP_ACCESS_CONTROL_REQUEST_HEADERS",
+    access_control_request_headers = header_property(
+        "Access-Control-Request-Headers",
         load_func=parse_set_header,
         doc=(
             "Sent with a preflight request to indicate which headers"
@@ -30,16 +30,18 @@ class CORSRequestMixin:
             " :attr:`~CORSResponseMixin.access_control_allow_headers`"
             " on the response to indicate which headers are allowed."
         ),
+        read_only=True,
     )
 
-    access_control_request_method = environ_property(
-        "HTTP_ACCESS_CONTROL_REQUEST_METHOD",
+    access_control_request_method = header_property(
+        "Access-Control-Request-Method",
         doc=(
             "Sent with a preflight request to indicate which method"
             " will be used for the cross origin request. Set"
             " :attr:`~CORSResponseMixin.access_control_allow_methods`"
             " on the response to indicate which methods are allowed."
         ),
+        read_only=True,
     )
 
 

--- a/src/werkzeug/wrappers/etag.py
+++ b/src/werkzeug/wrappers/etag.py
@@ -40,7 +40,7 @@ class ETagRequestMixin:
         """A :class:`~werkzeug.datastructures.RequestCacheControl` object
         for the incoming cache control headers.
         """
-        cache_control = self.environ.get("HTTP_CACHE_CONTROL")
+        cache_control = self.headers.get("Cache-Control")
         return parse_cache_control_header(cache_control, None, RequestCacheControl)
 
     @cached_property
@@ -49,7 +49,7 @@ class ETagRequestMixin:
 
         :rtype: :class:`~werkzeug.datastructures.ETags`
         """
-        return parse_etags(self.environ.get("HTTP_IF_MATCH"))
+        return parse_etags(self.headers.get("If-Match"))
 
     @cached_property
     def if_none_match(self):
@@ -57,17 +57,17 @@ class ETagRequestMixin:
 
         :rtype: :class:`~werkzeug.datastructures.ETags`
         """
-        return parse_etags(self.environ.get("HTTP_IF_NONE_MATCH"))
+        return parse_etags(self.headers.get("If-None-Match"))
 
     @cached_property
     def if_modified_since(self):
         """The parsed `If-Modified-Since` header as datetime object."""
-        return parse_date(self.environ.get("HTTP_IF_MODIFIED_SINCE"))
+        return parse_date(self.headers.get("If-Modified-Since"))
 
     @cached_property
     def if_unmodified_since(self):
         """The parsed `If-Unmodified-Since` header as datetime object."""
-        return parse_date(self.environ.get("HTTP_IF_UNMODIFIED_SINCE"))
+        return parse_date(self.headers.get("If-Unmodified-Since"))
 
     @cached_property
     def if_range(self):
@@ -77,7 +77,7 @@ class ETagRequestMixin:
 
         :rtype: :class:`~werkzeug.datastructures.IfRange`
         """
-        return parse_if_range_header(self.environ.get("HTTP_IF_RANGE"))
+        return parse_if_range_header(self.headers.get("If-Range"))
 
     @cached_property
     def range(self):
@@ -87,7 +87,7 @@ class ETagRequestMixin:
 
         :rtype: :class:`~werkzeug.datastructures.Range`
         """
-        return parse_range_header(self.environ.get("HTTP_RANGE"))
+        return parse_range_header(self.headers.get("Range"))
 
 
 class ETagResponseMixin:

--- a/src/werkzeug/wrappers/user_agent.py
+++ b/src/werkzeug/wrappers/user_agent.py
@@ -11,4 +11,4 @@ class UserAgentMixin:
     @cached_property
     def user_agent(self):
         """The current user agent."""
-        return UserAgent(self.environ)
+        return UserAgent(self.headers.get("User-Agent", ""))


### PR DESCRIPTION
This allows these mixins to be used in ASGI frameworks that have no
concept of environs but do have headers.

The downside is the extra indirection, although the headers are a cached property and the environ/headers are immutable.