### PR TITLE
Allow an auth parameter when EnvironBuilder building

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,10 +69,14 @@ Unreleased
     header attributes. :pr:`1808`
 -   The test ``Client`` request methods (``client.get``, etc.) always
     return an instance of ``TestResponse``. In addition to the normal
-    behavior of ``Resposne``, this class provides ``request`` with the
+    behavior of ``Response``, this class provides ``request`` with the
     request that produced the response, and ``history`` to track
     intermediate responses when ``follow_redirects`` is used.
     :issue:`763, 1894`
+-   The test ``Client`` request methods takes an ``auth`` parameter to
+    add an ``Authorization`` header. It can be an ``Authorization``
+    object or a ``(username, password)`` tuple for ``Basic`` auth.
+    :pr:`1809`
 
 
 Version 1.0.2

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -28,8 +28,8 @@ from ._internal import _cookie_quote
 from ._internal import _make_cookie_domain
 from ._internal import _to_bytes
 from ._internal import _to_str
-from werkzeug.types import T
-from werkzeug.types import WSGIEnvironment
+from .types import T
+from .types import WSGIEnvironment
 
 if TYPE_CHECKING:
     from .datastructures import (  # noqa: F401

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -682,3 +682,17 @@ class TestRegression:
             datastructures.MIMEAccept,
         ).best_match(["foo/bar"])
         assert rv == "foo/bar"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Basic V2Vya3pldWc6V2VrcnpldWc=",
+        'Digest username=Mufasa, realm="testrealm@host.invalid",'
+        ' nonce=dcd98b7102dd2f0e8b11d0f600bfb0c093, uri="/dir/index.html", qop=auth,'
+        " nc=00000001, cnonce=0a4f113b, response=6629fae49393a05397450978507c4ef1,"
+        " opaque=5ccc069c403ebaf9f0171e9517f40e41",
+    ],
+)
+def test_authorization_to_header(value: str) -> None:
+    assert http.parse_authorization_header(value).to_header() == value


### PR DESCRIPTION
This allows a shorthand for testing basic auth in Werkzeug (and
Flask). Specifically it allows

    test_client.get("/", auth=(username, password))

as a shorthand for

    credentials = b64encode(b":".join((username.encode(), password.encode())))
    headers = {"Authorization": "Basic {}".format(credentials.decode())}
    test_client.get("/", headers=headers)

I'm not sure if the auth param should also allow the `Authenticate` datastructures (alongside the tuple in this PR). This would allow more than just basic auth, but would require the ability to write these headers via the datastructure. @jab do you have a view?