### PR TITLE
fix: default secure to True if samesite is not set

### DIFF
--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -1171,6 +1171,9 @@ def dump_cookie(
         if samesite not in {"Strict", "Lax", "None"}:
             raise ValueError("SameSite must be 'Strict', 'Lax', or 'None'.")
 
+    if not samesite or samesite == "None":
+        secure = True
+
     buf = [key + b"=" + _cookie_quote(value)]
 
     # XXX: In theory all of these parameters that are not marked with `None`

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -314,7 +314,7 @@ def test_base_response():
         ("Content-Type", "text/plain; charset=utf-8"),
         (
             "Set-Cookie",
-            "foo=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/",
+            "foo=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Secure; Path=/",
         ),
     ]
 
@@ -1486,7 +1486,7 @@ class TestSetCookie:
                 "Set-Cookie",
                 "foo=bar; Domain=example.org;"
                 " Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=60;"
-                " HttpOnly; Path=/blub",
+                " Secure; HttpOnly; Path=/blub",
             ),
         ]
 


### PR DESCRIPTION
Browsers will soon start to discard cookies that do not have "Secure" if SameSite is not set/set to None

This pull request sets Secure by default whenever SameSite isn't passed as a param to `dump_cookie()`. Also updated are all the tests to reflect changes made to the code.