### PR TITLE
Make sure we encode keys with empty lists in test environment

### DIFF
--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -196,8 +196,11 @@ def _iter_data(data):
     else:
         for key, values in data.items():
             if isinstance(values, list):
-                for value in values:
-                    yield key, value
+                if values:
+                    for value in values:
+                        yield key, value
+                else:
+                    yield key, b""
             else:
                 yield key, values
 

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -153,6 +153,9 @@ def test_environ_builder_data():
     b = EnvironBuilder(data={"foo": ["bar1", "bar2"]})
     assert b.form.getlist("foo") == ["bar1", "bar2"]
 
+    b = EnvironBuilder(data={"foo": []})
+    assert b.form["foo"] == b""
+
     def check_list_content(b, length):
         foo = b.files.getlist("foo")
         assert len(foo) == length


### PR DESCRIPTION
The test environment builder swallows keys from `data` dictionary if
the corresponding values are empty lists.  E.g., `data={'key': []}`
is treated as equivalent to `data={}`.

This patch makes it so that it's empty value is returned instead.