### PR TITLE
Adds hooks required for a custom `MultiPartParser` implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,10 @@ Unreleased
     add an ``Authorization`` header. It can be an ``Authorization``
     object or a ``(username, password)`` tuple for ``Basic`` auth.
     :pr:`1809`
+-   ``FormDataParser`` can use a different parser for multipart data by
+    overriding ``mutipart_parser_class``. ``MultiPartParser`` can change
+    how field values and headers are stored by overriding
+    ``build_field_storage``. :issue:`1848`
 
 
 Version 1.0.2

--- a/src/werkzeug/wrappers/base_request.py
+++ b/src/werkzeug/wrappers/base_request.py
@@ -337,7 +337,7 @@ class BaseRequest:
             )
         else:
             data = (
-                self.stream,  # type: ignore
+                self.stream,
                 self.parameter_storage_class(),
                 self.parameter_storage_class(),
             )


### PR DESCRIPTION
Addresses #1848.

(Unfortunately I had to move `FormDataParser` below `MultiPartParser` in order to statically reference it, which makes this PR look more drastic than it is... The changes of interest are in https://github.com/pallets/werkzeug/pull/1849/commits/c218c0d59cd9f3ca667f162b9c92483f0d53c532).

This PR allows developers to define a custom multi-part parser class (with the same interface as a `MultiPartParser`) on `FormDataParser`(https://github.com/pallets/werkzeug/compare/master...colin-nolan:feature/multipartparser-hooks?expand=1#diff-8dc0761bccaf8a1e0c3b6e4c728d5827R215-R216). This pattern is seen elsewhere in the codebase, e.g.: https://github.com/pallets/werkzeug/blob/fc999a6262c847ad185ea3ffe0cc6f2e915a867a/src/werkzeug/wrappers/base_request.py#L127-L129

A hook has then been added to allow a developer to either store details about form parts (including their headers) out-of-band or through the use of a custom representation: https://github.com/pallets/werkzeug/compare/master...colin-nolan:feature/multipartparser-hooks?expand=1#diff-8dc0761bccaf8a1e0c3b6e4c728d5827R215-R216.

From Flask, usage could look something like:
```python
class MyMultiPartParser(MultiPartParser):
    def form_storage_builder(self, name, container, part_charset, headers):
        # We now have access to multipart part headers and have the ability to store 
        # out of band or to embed in a different representation
        return super().form_storage_builder(name, container, part_charset, headers)


class MyFormDataParser(FormDataParser):
    multi_part_parser_class = MyMultiPartParser


class MyRequest(Request):
    form_data_parser_class = MyFormDataParser


app.request_class = MyRequest
```


