### PR TITLE
Add option to exclude paths from reloader.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,8 @@ Unreleased
     most user code. It will also watch all Python files under
     directories given in ``extra_files``. :pr:`1945`
 -   The reloader ignores ``__pycache__`` directories again. :pr:`1945`
+-   ``run_simple`` takes ``exclude_patterns`` a list of ``fnmatch``
+    patterns that will not be scanned by the reloader. :issue:`1333`
 
 
 Version 1.0.2

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -6,6 +6,7 @@ import threading
 import time
 import typing as t
 from itertools import chain
+from pathlib import PurePath
 
 from ._internal import _log
 
@@ -112,7 +113,7 @@ def _find_watchdog_paths(extra_files, exclude_patterns):
 def _find_common_roots(paths):
     root = {}
 
-    for chunks in sorted((x.split(os.path.sep) for x in paths), key=len, reverse=True):
+    for chunks in sorted((PurePath(x).parts for x in paths), key=len, reverse=True):
         node = root
 
         for chunk in chunks:
@@ -127,7 +128,7 @@ def _find_common_roots(paths):
             _walk(child, path + (prefix,))
 
         if not node:
-            rv.add("/".join(path))
+            rv.add(os.path.join(*path))
 
     _walk(root, ())
     return rv

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -763,6 +763,7 @@ def run_simple(
     use_debugger=False,
     use_evalex=True,
     extra_files=None,
+    exclude_patterns=None,
     reloader_interval=1,
     reloader_type="auto",
     threaded=False,
@@ -778,6 +779,9 @@ def run_simple(
     This function has a command-line interface too::
 
         python -m werkzeug.serving --help
+
+    .. versionchanged:: 2.0
+        Added ``exclude_patterns`` parameter.
 
     .. versionadded:: 0.5
        `static_files` was added to simplify serving of static files as well
@@ -814,6 +818,9 @@ def run_simple(
     :param extra_files: a list of files the reloader should watch
                         additionally to the modules.  For example configuration
                         files.
+    :param exclude_patterns: List of :mod:`fnmatch` patterns to ignore
+        when running the reloader. For example, ignore cache files that
+        shouldn't reload when updated.
     :param reloader_interval: the interval for the reloader in seconds.
     :param reloader_type: the type of reloader to use.  The default is
                           auto detection.  Valid values are ``'stat'`` and
@@ -926,7 +933,13 @@ def run_simple(
 
         from ._reloader import run_with_reloader
 
-        run_with_reloader(inner, extra_files, reloader_interval, reloader_type)
+        run_with_reloader(
+            inner,
+            extra_files=extra_files,
+            exclude_patterns=exclude_patterns,
+            interval=reloader_interval,
+            reloader_type=reloader_type,
+        )
     else:
         inner()
 

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -113,7 +113,7 @@ def test_exclude_patterns(find):
     paths = find(set(), set())
     assert any(p.startswith(sys.prefix) for p in paths)
     # Those paths should be excluded due to the pattern.
-    paths = find(set(), {f"{sys.prefix}/*"})
+    paths = find(set(), {f"{sys.prefix}*"})
     assert not any(p.startswith(sys.prefix) for p in paths)
 
 

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 
 from werkzeug import run_simple
+from werkzeug._reloader import _find_stat_paths
+from werkzeug._reloader import _find_watchdog_paths
 from werkzeug._reloader import _get_args_for_reloading
 from werkzeug.datastructures import FileStorage
 from werkzeug.serving import make_ssl_devcert
@@ -103,6 +105,16 @@ def test_windows_get_args_for_reloading(monkeypatch, tmp_path):
     monkeypatch.setattr("os.name", "nt")
     rv = _get_args_for_reloading()
     assert rv == argv
+
+
+@pytest.mark.parametrize("find", [_find_stat_paths, _find_watchdog_paths])
+def test_exclude_patterns(find):
+    # Imported paths under sys.prefix will be included by default.
+    paths = find(set(), set())
+    assert any(p.startswith(sys.prefix) for p in paths)
+    # Those paths should be excluded due to the pattern.
+    paths = find(set(), {f"{sys.prefix}/*"})
+    assert not any(p.startswith(sys.prefix) for p in paths)
 
 
 def test_wrong_protocol(standard_app):


### PR DESCRIPTION
Add a `exclude_patterns` parameter to `run_simple`. This is a list of `fnmatch` patterns that are removed from the list of files to watch.

- fixes #1333

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
