### PR TITLE
Change "request" to "response" in BaseResponse.get_data docstring

### DIFF
--- a/src/werkzeug/wrappers/base_response.py
+++ b/src/werkzeug/wrappers/base_response.py
@@ -320,8 +320,8 @@ class BaseResponse(object):
             raise ValueError("Empty status argument")
 
     def get_data(self, as_text=False):
-        """The string representation of the request body.  Whenever you call
-        this property the request iterable is encoded and flattened.  This
+        """The string representation of the response body.  Whenever you call
+        this property the response iterable is encoded and flattened.  This
         can lead to unwanted behavior if you stream big data.
 
         This behavior can be disabled by setting


### PR DESCRIPTION
This is a very minor documentation update. I noticed that the `BaseResponse.get_data` docstring accidentally mentions "request" a few times instead of "response".

I assumed opening an issue wouldn't be necessary, but let me know if you'd like me to do so.