### PR TITLE
debugger.js: Show console only when EVALEX enabled

### DIFF
--- a/src/werkzeug/debug/shared/debugger.js
+++ b/src/werkzeug/debug/shared/debugger.js
@@ -6,14 +6,28 @@ docReady(() => {
   if (CONSOLE_MODE && EVALEX) {
     createInteractiveConsole();
   }
+
+  const frames = document.querySelectorAll("div.traceback div.frame");
+  if (EVALEX) {
+    addConsoleIconToFrames(frames);
+  }
   addEventListenersToElements(document.querySelectorAll("div.detail"), "click", () =>
     document.querySelector("div.traceback").scrollIntoView(false)
   );
-  addConsoleIconToFrames(document.querySelectorAll("div.traceback div.frame"));
+  addToggleFrameTraceback(frames);
   addToggleTraceTypesOnClick(document.querySelectorAll("h2.traceback"));
   addInfoPrompt(document.querySelectorAll("span.nojavascript"));
   wrapPlainTraceback();
 });
+
+function addToggleFrameTraceback(frames) {
+  frames.forEach((frame, i) => {
+    frame.addEventListener("click", () => {
+      frame.getElementsByTagName("pre")[i].parentElement.classList.toggle("expanded");
+    });
+  })
+}
+
 
 function wrapPlainTraceback() {
   const plainTraceback = document.querySelector("div.plain textarea");
@@ -160,9 +174,6 @@ function addConsoleIconToFrames(frames) {
     let consoleNode = null;
     const target = frames[i];
     const frameID = frames[i].id.substring(6);
-    target.addEventListener("click", () => {
-      target.getElementsByTagName("pre")[i].parentElement.classList.toggle("expanded");
-    });
 
     for (let j = 0; j < target.getElementsByTagName("pre").length; j++) {
       const img = createIconForConsole();


### PR DESCRIPTION
Allow user to open interactive console only when
interactive debugging is enabled.

Fixes https://github.com/pallets/werkzeug/issues/1875

<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->


<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
