### PR TITLE
 Live server test refactor

### DIFF
--- a/tests/middleware/test_http_proxy.py
+++ b/tests/middleware/test_http_proxy.py
@@ -5,17 +5,7 @@ from werkzeug.wrappers import BaseResponse
 
 
 def test_http_proxy(dev_server):
-    server = dev_server(
-        """
-        from werkzeug.wrappers import Request, Response
-
-        @Request.application
-        def app(request):
-            special = request.headers.get("X-Special")
-            host = request.environ["HTTP_HOST"]
-            return Response(f"{special}|{host}|{request.full_path}")
-        """
-    )
+    server = dev_server("proxy_app")
 
     app = ProxyMiddleware(
         BaseResponse("ROOT"),

--- a/tests/run_dev_server.py
+++ b/tests/run_dev_server.py
@@ -1,0 +1,56 @@
+import json
+import logging
+import os
+import sys
+import time
+
+from werkzeug import serving
+from werkzeug._internal import _to_bytes
+
+
+def _patch_reloader_loop():
+    def f(x):
+        print("reloader loop finished")
+        # Need to flush for some reason even though xprocess opens the
+        # subprocess' stdout in unbuffered mode.
+        # flush=True makes the test fail on py2, so flush manually
+        sys.stdout.flush()
+        return time.sleep(x)
+
+    import werkzeug._reloader
+
+    werkzeug._reloader.ReloaderLoop._sleep = staticmethod(f)
+
+
+pid_logger = logging.getLogger("get_pid_middleware")
+pid_logger.setLevel(logging.INFO)
+pid_handler = logging.StreamHandler(sys.stdout)
+pid_logger.addHandler(pid_handler)
+
+
+def _get_pid_middleware(f):
+    def inner(environ, start_response):
+        if environ["PATH_INFO"] == "/_getpid":
+            start_response("200 OK", [("Content-Type", "text/plain")])
+            pid_logger.info("pid=%s", os.getpid())
+            return [_to_bytes(str(os.getpid()))]
+        return f(environ, start_response)
+
+    return inner
+
+
+def _dev_server():
+    _patch_reloader_loop()
+    sys.path.insert(0, sys.argv[1])
+    sys.path.insert(0, sys.argv[2])
+    import test_apps
+
+    app = _get_pid_middleware(getattr(test_apps, sys.argv[3], None))
+    kwargs = json.loads(sys.argv[4])
+    if sys.argv[3] == "stdlib_ssl_app":
+        kwargs.update(test_apps.ssl_kwargs)
+    serving.run_simple(application=app, **kwargs)
+
+
+if __name__ == "__main__":
+    _dev_server()

--- a/tests/test_apps/__init__.py
+++ b/tests/test_apps/__init__.py
@@ -1,0 +1,8 @@
+from .chunked_encoding_app import app as chunked_app
+from .debug_app import app as debug_app
+from .proxy_app import app as proxy_app
+from .reloader_app import app as reloader_app
+from .standard_app import app as standard_app
+from .stdlib_ssl_app import ssl_kwargs
+from .stdlib_ssl_app import stdlib_ssl_app
+from werkzeug.testapp import test_app

--- a/tests/test_apps/chunked_encoding_app.py
+++ b/tests/test_apps/chunked_encoding_app.py
@@ -1,0 +1,12 @@
+from werkzeug.wrappers import Request
+
+
+def app(environ, start_response):
+    assert environ["HTTP_TRANSFER_ENCODING"] == "chunked"
+    assert environ.get("wsgi.input_terminated", False)
+    request = Request(environ)
+    assert request.mimetype == "multipart/form-data"
+    assert request.files["file"].read() == b"This is a test\n"
+    assert request.form["type"] == "text/plain"
+    start_response("200 OK", [("Content-Type", "text/plain")])
+    return [b"YES"]

--- a/tests/test_apps/debug_app.py
+++ b/tests/test_apps/debug_app.py
@@ -1,0 +1,9 @@
+from werkzeug.debug import DebuggedApplication
+
+
+@DebuggedApplication
+def app(environ, start_response):
+    if environ["PATH_INFO"] == "/crash=True":
+        1 / 0
+    start_response("200 OK", [("Content-Type", "text/html")])
+    return [b"hello"]

--- a/tests/test_apps/proxy_app.py
+++ b/tests/test_apps/proxy_app.py
@@ -1,0 +1,9 @@
+from werkzeug.wrappers import Request
+from werkzeug.wrappers import Response
+
+
+@Request.application
+def app(request):
+    special = request.headers.get("X-Special")
+    host = request.environ["HTTP_HOST"]
+    return Response(f"{special}|{host}|{request.full_path}")

--- a/tests/test_apps/reloader_app.py
+++ b/tests/test_apps/reloader_app.py
@@ -1,0 +1,11 @@
+from typing import List
+
+trials: List[int] = []
+
+
+def app(environ, start_response):
+    assert not trials, "should have reloaded"
+    trials.append(1)
+    import real_app  # type: ignore
+
+    return real_app.real_app(environ, start_response)

--- a/tests/test_apps/reloader_real_app.py
+++ b/tests/test_apps/reloader_real_app.py
@@ -1,0 +1,3 @@
+def real_app(environ, start_response):
+    start_response("200 OK", [("Content-Type", "text/html")])
+    return [b"hello"]

--- a/tests/test_apps/standard_app.py
+++ b/tests/test_apps/standard_app.py
@@ -1,0 +1,11 @@
+import json
+
+from werkzeug.wrappers import BaseResponse as Response
+
+
+def app(environ, start_response):
+    if environ["PATH_INFO"] == "/crash=True":
+        1 / 0
+    response_body = {key: str(value) for (key, value) in environ.items()}
+    response = Response(json.dumps(response_body), mimetype="text/plain")
+    return response(environ, start_response)

--- a/tests/test_apps/stdlib_ssl_app.py
+++ b/tests/test_apps/stdlib_ssl_app.py
@@ -1,0 +1,18 @@
+import ssl
+import tempfile
+
+from werkzeug import serving
+
+
+def stdlib_ssl_app(environ, start_response):
+    start_response("200 OK", [("Content-Type", "text/html")])
+    return [b"hello"]
+
+
+certificate, private_key = serving.make_ssl_devcert(
+    str(tempfile.mkdtemp(suffix="certs"))
+)
+ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+ctx.load_cert_chain(certificate, private_key)
+ssl_kwargs = {}
+ssl_kwargs["ssl_context"] = ctx


### PR DESCRIPTION
Fixes #1762, except for simplifying the reloader tests. 

Changes made: 

1. **Consolidation of server applications:**
- The strings of code that were used to run the server applications were moved into code and consolidated within their own `test_apps` folder. The majority of assertions within the applications were moved into the tests.
- The resulting set of applications consist of:

| App | Description |
| ----------- | ----------- |
| standard_app | The most commonly used testing app. It returns the environment variables within the server to assert on. |
| chunked_encoded_app | The app to be used when `Transfer_encoding` is chunked |
| debug_app | An app with the `@DebuggedApplication` decorator. Used by `test_debug.test_basic`. |
| proxy_app | An app with the `@Request.application decorator`. Used by `test_http_proxy` |
| reloader_app | The app used for reloader tests. |
| reloader_real_app | The contents of this application are written into the real_app files during the reloader tests |
| stdlib_ssl_app | An app that creates ssl credentials on the process it is run on |

- Module-level fixtures were created for the standard_app and the chunked_app. To enable this, the dev_server fixture was elevated to a module level pytest fixture, and a module-level monkeypatch fixture was created
- The `_ServerInfo` class was extended to include an HTTPConnection and a get method that could be shared across the tests

2. **Change in how of `xprocess` is run**
- A new file called `run_dev_server.py` was created as an entry point for xprocess instead of using `conftest.py`
- The `test_apps` folder was made into a module that could be imported in the new process
- The kwargs and the name of the app were also passed as args to the new process

3. **Removal of `requests` related libraries**
- Get requests with the requests library were removed, and the `get` method on the returned `_ServerInfo` item was called instead
- To handle the case where there was ssl verification but verification needed to be disabled, `ssl._create_default_https_context` was monkeypatched with `ssl._create_unverified_context`
- The call to `/_get_pid` using the `requests_unixsocket` library was replaced by sending an http request to the server at socket level. To fully replace the library for `get` methods with headers seems to be a more complicated challenge that would involve sending multiple requests and adding logic to figure out the length of the response.

How it works after the changes:
1. The dev_server fixture produces a function that takes the name of the application to be run (from the above table), and a list of kwargs. It returns a `_ServerInfo` object that can be used to send get requests to the server or get information like the logfile or pid of the server process. The tests either call the fixture directly, or they call the `standard_app` or `chunked_app` fixtures that use the `dev_server` fixture to create servers reused for all tests in the module.
2. dev_server uses xprocess to run the `run_dev_server.py` entrypoint as a python module. The arguments on the command line are 1) the `test_apps` module to add to the sys path, 2) the tmpdir_factory base directory to add to the sys path, 3) the name of the application to run, and 4) the list of kwargs to run the application with. It patches the reloader to log loops, adds a middleware to get the inner pid when the reloader is active, then calls `run_simple` with the named application and kwargs as arguments.
3. Some tests make a request and examine the response. Others read the log file from xprocess. Reloader tests wait for either the reloader loop or the inner pid to change, or both. This is exposed through the `_ServerInfo` object the dev_server function returns to the test.
5. Finally, special care has to be taken to kill the process group (and it's different on Windows, of course), since xprocess doesn't kill the reloader correctly on its own.
