### PR TITLE
Add redirect chain to test response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,8 +65,12 @@ Unreleased
     attributes modern browsers expect. :pr:`1889`
 -   Use ``request.headers`` instead of ``request.environ`` to look up
     header attributes. :pr:`1808`
--   Responses from the test client have a ``redirect_chain`` attribute
-    to track intermediate redirect responses. :issue:`763`
+-   The test ``Client`` request methods (``client.get``, etc.) always
+    return an instance of ``TestResponse``. In addition to the normal
+    behavior of ``Resposne``, this class provides ``request`` with the
+    request that produced the response, and ``history`` to track
+    intermediate responses when ``follow_redirects`` is used.
+    :issue:`763, 1894`
 
 
 Version 1.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@ Unreleased
     attributes modern browsers expect. :pr:`1889`
 -   Use ``request.headers`` instead of ``request.environ`` to look up
     header attributes. :pr:`1808`
+-   Responses from the test client have a ``redirect_chain`` attribute
+    to track intermediate redirect responses. :issue:`763`
 
 
 Version 1.0.2

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -1,166 +1,111 @@
-==============
-Test Utilities
-==============
-
 .. module:: werkzeug.test
 
-Quite often you want to unittest your application or just check the output
-from an interactive python session.  In theory that is pretty simple because
-you can fake a WSGI environment and call the application with a dummy
-`start_response` and iterate over the application iterator but there are
-argumentably better ways to interact with an application.
+Testing WSGI Applications
+=========================
 
 
-Diving In
-=========
+Test Client
+-----------
 
-Werkzeug provides a `Client` object which you can pass a WSGI application (and
-optionally a response wrapper) which you can use to send virtual requests to
-the application.
-
-A response wrapper is a callable that takes three arguments: the application
-iterator, the status and finally a list of headers.  The default response
-wrapper returns a tuple.  Because response objects have the same signature,
-you can use them as response wrapper, ideally by subclassing them and hooking
-in test functionality.
+Werkzeug provides a :class:`Client` to simulate requests to a WSGI
+application without starting a server. The client has methods for making
+different types of requests, as well as managing cookies across
+requests.
 
 >>> from werkzeug.test import Client
 >>> from werkzeug.testapp import test_app
->>> from werkzeug.wrappers import BaseResponse
->>> c = Client(test_app, BaseResponse)
->>> resp = c.get('/')
->>> resp.status_code
+>>> c = Client(test_app)
+>>> response = c.get("/")
+>>> response.status_code
 200
 >>> resp.headers
 Headers([('Content-Type', 'text/html; charset=utf-8'), ('Content-Length', '6658')])
->>> resp.data.splitlines()[0]
-b'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"'
+>>> response.get_data(as_text=True)
+'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"...'
 
-Or without a wrapper defined:
-
->>> c = Client(test_app)
->>> app_iter, status, headers = c.get('/')
->>> status
-'200 OK'
->>> headers
-Headers([('Content-Type', 'text/html; charset=utf-8'), ('Content-Length', '6658')])
->>> b''.join(app_iter).splitlines()[0]
-b'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"'
+The client's request methods return instances of :class:`TestResponse`.
+This provides extra attributes and methods on top of
+:class:`~werkzeug.wrappers.Response` that are useful for testing.
 
 
-Environment Building
-====================
+Request Body
+------------
 
-.. versionadded:: 0.5
+By passing a dict to ``data``, the client will construct a request body
+with file and form data. It will set the content type to
+``application/x-www-form-urlencoded`` if there are no files, or
+``multipart/form-data`` there are.
 
-The easiest way to interactively test applications is using the
-:class:`EnvironBuilder`.  It can create both standard WSGI environments
-and request objects.
+.. code-block:: python
 
-The following example creates a WSGI environment with one uploaded file
-and a form field:
+    import io
 
->>> from werkzeug.test import EnvironBuilder
->>> from io import BytesIO
->>> builder = EnvironBuilder(method='POST', data={'foo': 'this is some text',
-...      'file': (BytesIO('my file contents'.encode("utf8")), 'test.txt')})
->>> env = builder.get_environ()
+    response = client.post(data={
+        "name": "test",
+        "file": (BytesIO("file contents".encode("utf8")), "test.txt")
+    })
 
-The resulting environment is a regular WSGI environment that can be used for
-further processing:
+Pass a string, bytes, or file-like object to ``data`` to use that as the
+raw request body. In that case, you should set the content type
+appropriately. For example, to post YAML:
 
->>> from werkzeug.wrappers import Request
->>> req = Request(env)
->>> req.form['foo']
-'this is some text'
->>> req.files['file']
-<FileStorage: 'test.txt' ('text/plain')>
->>> req.files['file'].read()
-b'my file contents'
+.. code-block:: python
 
-The :class:`EnvironBuilder` figures out the content type automatically if you
-pass a dict to the constructor as `data`.  If you provide a string or an
-input stream you have to do that yourself.
+    response = client.post(
+        data="a: value\nb: 1\n", content_type="application/yaml"
+    )
 
-By default it will try to use ``application/x-www-form-urlencoded`` and only
-use ``multipart/form-data`` if files are uploaded:
+A shortcut when testing JSON APIs is to pass a dict to ``json`` instead
+of using ``data``. This will automatically call ``json.dumps()`` and
+set the content type to ``application/json``. Additionally, if the
+app returns JSON, ``response.json`` will automatically call
+``json.loads()``.
 
->>> builder = EnvironBuilder(method='POST', data={'foo': 'bar'})
->>> builder.content_type
-'application/x-www-form-urlencoded'
->>> builder.files['foo'] = BytesIO('contents'.encode("utf8"))
->>> builder.content_type
-'multipart/form-data'
+.. code-block:: python
 
-If a string is provided as data (or an input stream) you have to specify
-the content type yourself:
-
->>> builder = EnvironBuilder(method='POST', data='{"json": "this is"}')
->>> builder.content_type
->>> builder.content_type = 'application/json'
+    response = client.post("/api", json={"a": "value", "b": 1})
+    obj = response.json()
 
 
-Testing API
-===========
+Environment Builder
+-------------------
 
-.. autoclass:: EnvironBuilder
-   :members:
+:class:`EnvironBuilder` is used to construct a WSGI environ dict. The
+test client uses this internally to prepare its requests. The arguments
+passed to the client request methods are the same as the builder.
 
-   .. attribute:: path
+Sometimes, it can be useful to construct a WSGI environment manually.
+An environ builder or dict can be passed to the test client request
+methods in place of other arguments to use a custom environ.
 
-      The path of the application.  (aka `PATH_INFO`)
+.. code-block:: Python
 
-   .. attribute:: charset
+    from werkzeug.test import EnvironBuilder
+    builder = EnvironBuilder(...)
+    # build an environ dict
+    environ = builder.get_environ()
+    # build an environ dict wrapped in a request
+    request = builder.get_request()
 
-      The charset used to encode to bytes.
+The test client responses make this available through
+:attr:`TestResponse.request` and ``response.request.environ``.
 
-   .. attribute:: headers
 
-      A :class:`Headers` object with the request headers.
-
-   .. attribute:: errors_stream
-
-      The error stream used for the `wsgi.errors` stream.
-
-   .. attribute:: multithread
-
-      The value of `wsgi.multithread`
-
-   .. attribute:: multiprocess
-
-      The value of `wsgi.multiprocess`
-
-   .. attribute:: environ_base
-
-      The dict used as base for the newly create environ.
-
-   .. attribute:: environ_overrides
-
-      A dict with values that are used to override the generated environ.
+API
+---
 
 .. autoclass:: Client
+    :members:
+    :member-order: bysource
 
-   .. automethod:: open
+.. autoclass:: TestResponse
+    :members:
+    :member-order: bysource
 
-   Shortcut methods are available for many HTTP methods:
+.. autoclass:: EnvironBuilder
+    :members:
+    :member-order: bysource
 
-   .. automethod:: get
-
-   .. automethod:: patch
-
-   .. automethod:: post
-
-   .. automethod:: head
-
-   .. automethod:: put
-
-   .. automethod:: delete
-
-   .. automethod:: options
-
-   .. automethod:: trace
-
-
-.. autofunction:: create_environ([options])
+.. autofunction:: create_environ
 
 .. autofunction:: run_wsgi_app

--- a/tests/middleware/test_http_proxy.py
+++ b/tests/middleware/test_http_proxy.py
@@ -35,7 +35,7 @@ def test_http_proxy(dev_server):
         },
     )
 
-    client = Client(app, response_wrapper=BaseResponse)
+    client = Client(app)
 
     rv = client.get("/")
     assert rv.data == b"ROOT"

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -16,7 +16,6 @@ from werkzeug.debug.repr import helper
 from werkzeug.debug.tbtools import Traceback
 from werkzeug.test import Client
 from werkzeug.wrappers import Request
-from werkzeug.wrappers import Response
 
 
 class TestDebugRepr:
@@ -235,7 +234,7 @@ class TestDebugHelpers:
                 raise KeyError("outer")
 
         debugged = DebuggedApplication(app)
-        client = Client(debugged, Response)
+        client = Client(debugged)
         response = client.get("/")
         data = response.get_data(as_text=True)
         assert 'raise ValueError("inner")' in data

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -227,7 +227,7 @@ class TestFormParser:
 class TestMultiPart:
     def test_basic(self):
         resources = join(dirname(__file__), "multipart")
-        client = Client(form_data_consumer, Response)
+        client = Client(form_data_consumer)
 
         repository = [
             (
@@ -301,7 +301,7 @@ class TestMultiPart:
             assert response.get_data() == repr(text).encode("utf-8")
 
     def test_ie7_unc_path(self):
-        client = Client(form_data_consumer, Response)
+        client = Client(form_data_consumer)
         data_file = join(dirname(__file__), "multipart", "ie7_full_path_request.http")
         data = get_contents(data_file)
         boundary = "---------------------------7da36d1b4a0164"

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -517,6 +517,12 @@ def test_follow_redirect_exhaust_intermediate():
     assert not app.active
 
 
+def test_redirects_are_tracked():
+    c = Client(redirect_with_get_app, response_wrapper=BaseResponse)
+    resp = c.get("/first/request", follow_redirects=True)
+    assert resp.redirect_chain == [("http://localhost/some/redirect/", 302)]
+
+
 def test_cookie_across_redirect():
     @Request.application
     def app(request):

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -76,47 +76,47 @@ def multi_value_post_app(environ, start_response):
 def test_cookie_forging():
     c = Client(cookie_app)
     c.set_cookie("localhost", "foo", "bar")
-    appiter, code, headers = c.open()
-    assert list(appiter) == [b"foo=bar"]
+    response = c.open()
+    assert response.data == b"foo=bar"
 
 
 def test_set_cookie_app():
     c = Client(cookie_app)
-    appiter, code, headers = c.open()
-    assert "Set-Cookie" in dict(headers)
+    response = c.open()
+    assert "Set-Cookie" in response.headers
 
 
 def test_cookiejar_stores_cookie():
     c = Client(cookie_app)
-    appiter, code, headers = c.open()
+    c.open()
     assert "test" in c.cookie_jar._cookies["localhost.local"]["/"]
 
 
 def test_no_initial_cookie():
     c = Client(cookie_app)
-    appiter, code, headers = c.open()
-    assert b"".join(appiter) == b"No Cookie"
+    response = c.open()
+    assert response.data == b"No Cookie"
 
 
 def test_resent_cookie():
     c = Client(cookie_app)
     c.open()
-    appiter, code, headers = c.open()
-    assert b"".join(appiter) == b"test=test"
+    response = c.open()
+    assert response.data == b"test=test"
 
 
 def test_disable_cookies():
     c = Client(cookie_app, use_cookies=False)
     c.open()
-    appiter, code, headers = c.open()
-    assert b"".join(appiter) == b"No Cookie"
+    response = c.open()
+    assert response.data == b"No Cookie"
 
 
 def test_cookie_for_different_path():
     c = Client(cookie_app)
     c.open("/path1")
-    appiter, code, headers = c.open("/path2")
-    assert b"".join(appiter) == b"test=test"
+    response = c.open("/path2")
+    assert response.data == b"test=test"
 
 
 def test_environ_builder_basics():
@@ -176,7 +176,7 @@ def test_environ_builder_json():
         assert request.content_type == "application/json"
         return Response(json.loads(request.get_data(as_text=True))["foo"])
 
-    c = Client(app, Response)
+    c = Client(app)
     response = c.post("/", json={"foo": "bar"})
     assert response.data == b"bar"
 
@@ -384,18 +384,18 @@ def test_file_closing():
 def test_follow_redirect():
     env = create_environ("/", base_url="http://localhost")
     c = Client(redirect_with_get_app)
-    appiter, code, headers = c.open(environ_overrides=env, follow_redirects=True)
-    assert code == "200 OK"
-    assert b"".join(appiter) == b"current url: http://localhost/some/redirect/"
+    response = c.open(environ_overrides=env, follow_redirects=True)
+    assert response.status == "200 OK"
+    assert response.data == b"current url: http://localhost/some/redirect/"
 
     # Test that the :cls:`Client` is aware of user defined response wrappers
-    c = Client(redirect_with_get_app, response_wrapper=BaseResponse)
+    c = Client(redirect_with_get_app)
     resp = c.get("/", follow_redirects=True)
     assert resp.status_code == 200
     assert resp.data == b"current url: http://localhost/some/redirect/"
 
     # test with URL other than '/' to make sure redirected URL's are correct
-    c = Client(redirect_with_get_app, response_wrapper=BaseResponse)
+    c = Client(redirect_with_get_app)
     resp = c.get("/first/request", follow_redirects=True)
     assert resp.status_code == 200
     assert resp.data == b"current url: http://localhost/some/redirect/"
@@ -413,7 +413,7 @@ def test_follow_local_redirect():
             response = Response(f"current path: {req.path}")
         return response(environ, start_response)
 
-    c = Client(local_redirect_app, response_wrapper=BaseResponse)
+    c = Client(local_redirect_app)
     resp = c.get("/from/location", follow_redirects=True)
     assert resp.status_code == 200
     assert resp.data == b"current path: /to/location"
@@ -438,7 +438,7 @@ def test_follow_redirect_body(code, keep):
 
         return redirect("http://localhost/some/redirect/", code=code)
 
-    c = Client(app, response_wrapper=BaseResponse)
+    c = Client(app)
     response = c.post(
         "/", follow_redirects=True, data={"foo": "bar"}, headers={"X-Foo": "bar"}
     )
@@ -473,7 +473,7 @@ def test_follow_external_redirect_on_same_subdomain():
 
 
 def test_follow_redirect_loop():
-    c = Client(redirect_loop_app, response_wrapper=BaseResponse)
+    c = Client(redirect_loop_app)
     with pytest.raises(ClientRedirectError):
         c.get("/", follow_redirects=True)
 
@@ -486,7 +486,7 @@ def test_follow_redirect_non_root_base_url():
 
         return Response(request.path)
 
-    c = Client(app, response_wrapper=Response)
+    c = Client(app)
     response = c.get(
         "/redirect", base_url="http://localhost/other", follow_redirects=True
     )
@@ -511,16 +511,38 @@ def test_follow_redirect_exhaust_intermediate():
                 self.active -= 1
 
     app = Middleware(redirect_with_get_app)
-    client = Client(Middleware(redirect_with_get_app), Response)
+    client = Client(Middleware(redirect_with_get_app))
     response = client.get("/", follow_redirects=True, buffered=False)
     assert response.data == b"current url: http://localhost/some/redirect/"
     assert not app.active
 
 
 def test_redirects_are_tracked():
-    c = Client(redirect_with_get_app, response_wrapper=BaseResponse)
-    resp = c.get("/first/request", follow_redirects=True)
-    assert resp.redirect_chain == [("http://localhost/some/redirect/", 302)]
+    @Request.application
+    def app(request):
+        if request.path == "/first":
+            return redirect("/second")
+
+        if request.path == "/second":
+            return redirect("/third")
+
+        return Response("done")
+
+    c = Client(app)
+    response = c.get("/first", follow_redirects=True)
+    assert response.data == b"done"
+    assert len(response.history) == 2
+
+    assert response.history[-1].request.path == "/second"
+    assert response.history[-1].status_code == 302
+    assert response.history[-1].location == "http://localhost/third"
+    assert len(response.history[-1].history) == 1
+    assert response.history[-1].history[-1] is response.history[-2]
+
+    assert response.history[-2].request.path == "/first"
+    assert response.history[-2].status_code == 302
+    assert response.history[-2].location == "http://localhost/second"
+    assert len(response.history[-2].history) == 0
 
 
 def test_cookie_across_redirect():
@@ -539,7 +561,7 @@ def test_cookie_across_redirect():
             rv.delete_cookie("auth")
             return rv
 
-    c = Client(app, Response)
+    c = Client(app)
     assert c.get("/").data == b"out"
     assert c.get("/in", follow_redirects=True).data == b"in"
     assert c.get("/").data == b"in"
@@ -560,7 +582,7 @@ def test_redirect_mutate_environ():
         pop_path_info(environ)
         return app(environ, start_response)
 
-    c = Client(middleware, Response)
+    c = Client(middleware)
     rv = c.get("/prefix/first", follow_redirects=True)
     # if modified environ was used by client, this would be /
     assert rv.data == b"/second"
@@ -571,20 +593,20 @@ def test_path_info_script_name_unquoting():
         start_response("200 OK", [("Content-Type", "text/plain")])
         return [f"{environ['PATH_INFO']}\n{environ['SCRIPT_NAME']}"]
 
-    c = Client(test_app, response_wrapper=BaseResponse)
+    c = Client(test_app)
     resp = c.get("/foo%40bar")
     assert resp.data == b"/foo@bar\n"
-    c = Client(test_app, response_wrapper=BaseResponse)
+    c = Client(test_app)
     resp = c.get("/foo%40bar", "http://localhost/bar%40baz")
     assert resp.data == b"/foo@bar\n/bar@baz"
 
 
 def test_multi_value_submit():
-    c = Client(multi_value_post_app, response_wrapper=BaseResponse)
+    c = Client(multi_value_post_app)
     data = {"field": ["val1", "val2"]}
     resp = c.post("/", data=data)
     assert resp.status_code == 200
-    c = Client(multi_value_post_app, response_wrapper=BaseResponse)
+    c = Client(multi_value_post_app)
     data = MultiDict({"field": ["val1", "val2"]})
     resp = c.post("/", data=data)
     assert resp.status_code == 200
@@ -729,7 +751,7 @@ def test_multiple_cookies():
         response.set_cookie("test2", b"bar")
         return response
 
-    client = Client(test_app, Response)
+    client = Client(test_app)
     resp = client.get("/")
     assert resp.data == b"[]"
     resp = client.get("/")
@@ -769,7 +791,7 @@ def test_full_url_requests_with_args():
     def test_app(request):
         return Response(request.args["x"])
 
-    client = Client(test_app, Response)
+    client = Client(test_app)
     resp = client.get("/?x=42", base)
     assert resp.data == b"42"
     resp = client.get("http://www.example.com/?x=23", base)
@@ -781,13 +803,13 @@ def test_delete_requests_with_form():
     def test_app(request):
         return Response(request.form.get("x", None))
 
-    client = Client(test_app, Response)
+    client = Client(test_app)
     resp = client.delete("/", data={"x": 42})
     assert resp.data == b"42"
 
 
 def test_post_with_file_descriptor(tmpdir):
-    c = Client(Response(), response_wrapper=Response)
+    c = Client(Response())
     f = tmpdir.join("some-file.txt")
     f.write("foo")
     with open(f.strpath, mode="rt") as data:
@@ -803,7 +825,7 @@ def test_content_type():
     def test_app(request):
         return Response(request.content_type)
 
-    client = Client(test_app, Response)
+    client = Client(test_app)
 
     resp = client.get("/", data=b"testing", mimetype="text/css")
     assert resp.data == b"text/css; charset=utf-8"
@@ -819,7 +841,7 @@ def test_raw_request_uri():
         request_uri = request.environ["REQUEST_URI"]
         return Response("\n".join((path_info, request_uri)))
 
-    client = Client(app, Response)
+    client = Client(app)
     response = client.get("/hello%2fworld")
     data = response.get_data(as_text=True)
     assert data == "/hello/world\n/hello%2fworld"
@@ -829,3 +851,15 @@ def test_raw_request_uri():
 
     response = client.get("/%3f?")  # escaped ? in path, and empty query string
     assert response.get_data(as_text=True) == "/?\n/%3f?"
+
+
+def test_deprecated_tuple():
+    app = Request.application(lambda r: Response())
+    client = Client(app)
+    response = client.get()
+
+    with pytest.deprecated_call():
+        assert len(list(response)) == 3
+
+    with pytest.deprecated_call():
+        assert response[1] == "200 OK"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -250,7 +250,7 @@ def test_append_slash_redirect():
     def app(env, sr):
         return utils.append_slash_redirect(env)(env, sr)
 
-    client = Client(app, BaseResponse)
+    client = Client(app)
     response = client.get("foo", base_url="http://example.org/app")
     assert response.status_code == 301
     assert response.headers["Location"] == "http://example.org/app/foo/"

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -75,7 +75,7 @@ def test_responder():
     def foo(environ, start_response):
         return BaseResponse(b"Test")
 
-    client = Client(wsgi.responder(foo), BaseResponse)
+    client = Client(wsgi.responder(foo))
     response = client.get("/")
     assert response.status_code == 200
     assert response.data == b"Test"


### PR DESCRIPTION
This PR adds support for `redirect_chains` property in the responses returned by the test client.

- fixes #1894 
- fixes #763 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
