### PR TITLE
use pathlib internally in send_file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,8 +41,8 @@ Unreleased
     ``RAW_URI``. :issue:`1781`
 -   Switch the parameter order of ``default_stream_factory`` to match
     the order used when calling it. :pr:`1085`
--   Add ``send_file`` to generate a response that serves a file, based
-    on Flask's implementation. :issue:`265`, :pr:`1850`
+-   Add ``send_file()`` function to generate a response that serves a
+    file, adapted from Flask's implementation. :issue:`265`, :pr:`1850`
 
 
 Version 1.0.2

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -5,54 +5,41 @@ import pathlib
 
 import pytest
 
-from werkzeug.test import Client
+from werkzeug.test import EnvironBuilder
 from werkzeug.utils import send_file
-from werkzeug.wrappers.response import Response
-from werkzeug.wsgi import responder
 
-res_path = os.path.join(os.path.dirname(__file__), "res")
-html_path = os.path.join(res_path, "index.html")
-txt_path = os.path.join(res_path, "test.txt")
+res_path = pathlib.Path(__file__).parent / "res"
+html_path = res_path / "index.html"
+txt_path = res_path / "test.txt"
 
 
-@pytest.mark.parametrize("path", [html_path, pathlib.Path(html_path)])
+@pytest.mark.parametrize("path", [html_path, str(html_path)])
 def test_path(path):
     rv = send_file(path)
     assert rv.mimetype == "text/html"
     assert rv.direct_passthrough
     rv.direct_passthrough = False
-
-    with open(html_path, "rb") as f:
-        assert rv.data == f.read()
-
+    assert rv.data == html_path.read_bytes()
     rv.close()
 
 
 def test_x_sendfile():
     rv = send_file(html_path, use_x_sendfile=True)
-    assert rv.headers["x-sendfile"] == html_path
+    assert rv.headers["x-sendfile"] == str(html_path)
     assert rv.data == b""
     rv.close()
 
 
 def test_last_modified():
+    environ = EnvironBuilder().get_environ()
     last_modified = datetime.datetime(1999, 1, 1)
-
-    def foo(environ, start_response):
-        return send_file(
-            io.BytesIO(b"party like it's"),
-            environ=environ,
-            last_modified=last_modified,
-            mimetype="text/plain",
-        )
-
-    client = Client(responder(foo), Response)
-    rv = client.get("/")
+    rv = send_file(txt_path, environ=environ, last_modified=last_modified)
     assert rv.last_modified == last_modified
+    rv.close()
 
 
 @pytest.mark.parametrize(
-    "file_factory", [lambda: open(txt_path, "rb"), lambda: io.BytesIO(b"test")],
+    "file_factory", [lambda: txt_path.open("rb"), lambda: io.BytesIO(b"test")],
 )
 def test_object(file_factory):
     rv = send_file(file_factory(), mimetype="text/plain", use_x_sendfile=True)
@@ -75,7 +62,7 @@ def test_object_mimetype_from_attachment():
 
 
 @pytest.mark.parametrize(
-    "file_factory", [lambda: open(txt_path), lambda: io.StringIO("test")],
+    "file_factory", [lambda: txt_path.open(), lambda: io.StringIO("test")],
 )
 def test_text_mode_fails(file_factory):
     with file_factory() as f, pytest.raises(ValueError, match="binary mode"):
@@ -83,7 +70,7 @@ def test_text_mode_fails(file_factory):
 
 
 @pytest.mark.parametrize(
-    ("filename", "ascii", "utf8"),
+    ("name", "ascii", "utf8"),
     (
         ("index.html", "index.html", None),
         (
@@ -97,8 +84,8 @@ def test_text_mode_fails(file_factory):
         ("те:/ст", '":/"', "%D1%82%D0%B5%3A%2F%D1%81%D1%82"),
     ),
 )
-def test_non_ascii_filename(filename, ascii, utf8):
-    rv = send_file(html_path, as_attachment=True, attachment_filename=filename)
+def test_non_ascii_filename(name, ascii, utf8):
+    rv = send_file(html_path, as_attachment=True, attachment_filename=name)
     rv.close()
     content_disposition = rv.headers["Content-Disposition"]
     assert f"filename={ascii}" in content_disposition


### PR DESCRIPTION
* rename first arg to `path_or_file`
* check for `os.PathLike` before `__fspath__`
* reduce number of calls to `stat()`
* file name from path is always str
* remove old code that assumed path might come from file object

fixes #1881 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
