### PR TITLE
send_file sends download_name for inline and attachment disposition

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,8 +41,12 @@ Unreleased
     ``RAW_URI``. :issue:`1781`
 -   Switch the parameter order of ``default_stream_factory`` to match
     the order used when calling it. :pr:`1085`
--   Add ``send_file()`` function to generate a response that serves a
+-   Add ``send_file`` function to generate a response that serves a
     file, adapted from Flask's implementation. :issue:`265`, :pr:`1850`
+-   ``send_file`` takes ``download_name``, which is passed even if
+    ``as_attachment=False`` by using ``Content-Disposition: inline``.
+    ``download_name`` replaces Flask's ``attachment_filename``.
+    :issue:`1869`
 
 
 Version 1.0.2


### PR DESCRIPTION
Replace `attachment_filename` with `download_name`. Always send `download_name`, using `Content-Disposition: inline` if `as_attachment=False`.

fixes #1869 

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

Technically, `Content-Disposition: attachment` can be sent without the `filename` directive. I've kept the existing behavior of raising an error if `as_attachment=True` and no name is given, I think it promotes better design.