### PR TITLE
enable conditional and disable max_age by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,12 @@ Unreleased
     ``as_attachment=False`` by using ``Content-Disposition: inline``.
     ``download_name`` replaces Flask's ``attachment_filename``.
     :issue:`1869`
+-   ``send_file`` sets ``conditional=True`` and ``max_age=None`` by
+    default. ``Cache-Control`` is set to ``no-cache`` if ``max_age`` is
+    not set, otherwise ``public``. This tells browsers to validate
+    conditional requests instead of using a timed cache.
+    ``max_age=None`` replaces Flask's ``cache_timeout=43200``.
+    :issue:`1882`
 
 
 Version 1.0.2

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -1,10 +1,10 @@
 import datetime
 import io
-import os
 import pathlib
 
 import pytest
 
+from werkzeug.http import http_date
 from werkzeug.test import EnvironBuilder
 from werkzeug.utils import send_file
 
@@ -12,10 +12,12 @@ res_path = pathlib.Path(__file__).parent / "res"
 html_path = res_path / "index.html"
 txt_path = res_path / "test.txt"
 
+environ = EnvironBuilder().get_environ()
+
 
 @pytest.mark.parametrize("path", [html_path, str(html_path)])
 def test_path(path):
-    rv = send_file(path)
+    rv = send_file(path, environ)
     assert rv.mimetype == "text/html"
     assert rv.direct_passthrough
     rv.direct_passthrough = False
@@ -24,16 +26,15 @@ def test_path(path):
 
 
 def test_x_sendfile():
-    rv = send_file(html_path, use_x_sendfile=True)
+    rv = send_file(html_path, environ, use_x_sendfile=True)
     assert rv.headers["x-sendfile"] == str(html_path)
     assert rv.data == b""
     rv.close()
 
 
 def test_last_modified():
-    environ = EnvironBuilder().get_environ()
     last_modified = datetime.datetime(1999, 1, 1)
-    rv = send_file(txt_path, environ=environ, last_modified=last_modified)
+    rv = send_file(txt_path, environ, last_modified=last_modified)
     assert rv.last_modified == last_modified
     rv.close()
 
@@ -42,7 +43,7 @@ def test_last_modified():
     "file_factory", [lambda: txt_path.open("rb"), lambda: io.BytesIO(b"test")],
 )
 def test_object(file_factory):
-    rv = send_file(file_factory(), mimetype="text/plain", use_x_sendfile=True)
+    rv = send_file(file_factory(), environ, mimetype="text/plain", use_x_sendfile=True)
     rv.direct_passthrough = False
     assert rv.data
     assert rv.mimetype == "text/plain"
@@ -52,11 +53,11 @@ def test_object(file_factory):
 
 def test_object_without_mimetype():
     with pytest.raises(ValueError, match="detect the MIME type"):
-        send_file(io.BytesIO(b"test"))
+        send_file(io.BytesIO(b"test"), environ)
 
 
 def test_object_mimetype_from_name():
-    rv = send_file(io.BytesIO(b"test"), download_name="test.txt")
+    rv = send_file(io.BytesIO(b"test"), environ, download_name="test.txt")
     assert rv.mimetype == "text/plain"
     rv.close()
 
@@ -66,23 +67,27 @@ def test_object_mimetype_from_name():
 )
 def test_text_mode_fails(file_factory):
     with file_factory() as f, pytest.raises(ValueError, match="binary mode"):
-        send_file(f, os.path.realpath(__file__), mimetype="text/plain")
+        send_file(f, environ, mimetype="text/plain")
 
 
 @pytest.mark.parametrize(
     ("as_attachment", "value"), [(False, "inline"), (True, "attachment")]
 )
 def test_disposition_name(as_attachment, value):
-    rv = send_file(txt_path, as_attachment=as_attachment)
+    rv = send_file(txt_path, environ, as_attachment=as_attachment)
     assert rv.headers["Content-Disposition"] == f"{value}; filename=test.txt"
     rv.close()
 
 
 def test_object_attachment_requires_name():
     with pytest.raises(TypeError, match="attachment"):
-        send_file(io.BytesIO(b"test"), mimetype="text/plain", as_attachment=True)
+        send_file(
+            io.BytesIO(b"test"), environ, mimetype="text/plain", as_attachment=True,
+        )
 
-    rv = send_file(io.BytesIO(b"test"), as_attachment=True, download_name="test.txt")
+    rv = send_file(
+        io.BytesIO(b"test"), environ, as_attachment=True, download_name="test.txt",
+    )
     assert rv.headers["Content-Disposition"] == f"attachment; filename=test.txt"
     rv.close()
 
@@ -103,7 +108,7 @@ def test_object_attachment_requires_name():
     ),
 )
 def test_non_ascii_name(name, ascii, utf8):
-    rv = send_file(html_path, as_attachment=True, download_name=name)
+    rv = send_file(html_path, environ, as_attachment=True, download_name=name)
     rv.close()
     content_disposition = rv.headers["Content-Disposition"]
     assert f"filename={ascii}" in content_disposition
@@ -112,3 +117,30 @@ def test_non_ascii_name(name, ascii, utf8):
         assert f"filename*=UTF-8''{utf8}" in content_disposition
     else:
         assert "filename*=UTF-8''" not in content_disposition
+
+
+def test_no_cache_conditional_default():
+    rv = send_file(
+        txt_path,
+        EnvironBuilder(
+            headers={"If-Modified-Since": http_date(datetime.datetime(2020, 7, 12))}
+        ).get_environ(),
+        last_modified=datetime.datetime(2020, 7, 11),
+    )
+    rv.close()
+    assert "no-cache" in rv.headers["Cache-Control"]
+    assert not rv.cache_control.public
+    assert not rv.cache_control.max_age
+    assert not rv.expires
+    assert rv.status_code == 304
+
+
+@pytest.mark.parametrize(("value", "public"), [(0, False), (60, True)])
+def test_max_age(value, public):
+    rv = send_file(txt_path, environ, max_age=value)
+    rv.close()
+    assert ("no-cache" in rv.headers["Cache-Control"]) != public
+    assert rv.cache_control.public == public
+    assert rv.cache_control.max_age == value
+    assert rv.expires
+    assert rv.status_code == 200


### PR DESCRIPTION
Tells browsers to validate cache conditions (etag, last modified, range) rather than using a 12 hour timed cache by default. This fixes the issue where developers who are actively editing or deploying new versions of static files from don't see changes.

* Send `Cache-Control: no-cache` by default, or `public` if `max_age > 0`. `no-cache` doesn't actually mean "don't cache" (that would be `no-store`).
* Rename `cache_timeout` to `max_age`. I think this makes it clearer that the parameter directly affects the `Cache-Control: max-age` value.
* Reorder the cache-related parameters into an order that made a bit more sense to me.
* Make the `environ` parameter required. It got added as optional when copying from Flask, but Flask's version would never be callable without an active `request`. With `conditional=True` it's required by default anyway.

fixes #1882 

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
