### PR TITLE
Bugfix accept additional attributes to the delete cookie

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Unreleased
     from 8. Use ``secrets`` module to generate salt. :pr:`1935`
 -   The reloader doesn't crash if ``sys.stdin`` is somehow ``None``.
     :pr:`1915`
+-   Add arguments to ``delete_cookie`` to match ``set_cookie`` and the
+    attributes modern browsers expect. :pr:`1889`
 
 
 Version 1.0.2

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -853,13 +853,13 @@ class Client:
         server_name: str,
         key: str,
         value: str = "",
-        max_age: None = None,
-        expires: None = None,
+        max_age: Optional[int] = None,
+        expires: Optional[int] = None,
         path: str = "/",
-        domain: None = None,
-        secure: None = None,
+        domain: Optional[str] = None,
+        secure: bool = False,
         httponly: bool = False,
-        samesite: None = None,
+        samesite: Optional[str] = None,
         charset: str = "utf-8",
     ) -> None:
         """Sets a cookie in the client's cookie jar.  The server name
@@ -883,10 +883,27 @@ class Client:
         headers = [("Set-Cookie", header)]
         self.cookie_jar.extract_wsgi(environ, headers)
 
-    def delete_cookie(self, server_name, key, path="/", domain=None):
+    def delete_cookie(
+        self,
+        server_name: str,
+        key: str,
+        path: str = "/",
+        domain: Optional[str] = None,
+        secure: bool = False,
+        httponly: bool = False,
+        samesite: Optional[str] = None,
+    ) -> None:
         """Deletes a cookie in the test client."""
         self.set_cookie(
-            server_name, key, expires=0, max_age=0, path=path, domain=domain
+            server_name,
+            key,
+            expires=0,
+            max_age=0,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
         )
 
     def run_wsgi_app(

--- a/src/werkzeug/wrappers/base_response.py
+++ b/src/werkzeug/wrappers/base_response.py
@@ -496,13 +496,11 @@ class BaseResponse:
                        readable by the domain ``www.example.com``,
                        ``foo.example.com`` etc.  Otherwise, a cookie will only
                        be readable by the domain that set it.
-        :param secure: If `True`, the cookie will only be available via HTTPS
-        :param httponly: disallow JavaScript to access the cookie.  This is an
-                         extension to the cookie standard and probably not
-                         supported by all browsers.
-        :param samesite: Limits the scope of the cookie such that it will only
-                         be attached to requests if those requests are
-                         "same-site".
+        :param secure: If ``True``, the cookie will only be available
+            via HTTPS.
+        :param httponly: Disallow JavaScript access to the cookie.
+        :param samesite: Limit the scope of the cookie to only be
+            attached to requests that are "same-site".
         """
         self.headers.add(
             "Set-Cookie",
@@ -521,7 +519,15 @@ class BaseResponse:
             ),
         )
 
-    def delete_cookie(self, key: str, path: str = "/", domain: None = None) -> None:
+    def delete_cookie(
+        self,
+        key: str,
+        path: str = "/",
+        domain: Optional[str] = None,
+        secure: bool = False,
+        httponly: bool = False,
+        samesite: Optional[str] = None,
+    ) -> None:
         """Delete a cookie.  Fails silently if key doesn't exist.
 
         :param key: the key (name) of the cookie to be deleted.
@@ -529,8 +535,22 @@ class BaseResponse:
                      path, the path has to be defined here.
         :param domain: if the cookie that should be deleted was limited to a
                        domain, that domain has to be defined here.
+        :param secure: If ``True``, the cookie will only be available
+            via HTTPS.
+        :param httponly: Disallow JavaScript access to the cookie.
+        :param samesite: Limit the scope of the cookie to only be
+            attached to requests that are "same-site".
         """
-        self.set_cookie(key, expires=0, max_age=0, path=path, domain=domain)
+        self.set_cookie(
+            key,
+            expires=0,
+            max_age=0,
+            path=path,
+            domain=domain,
+            secure=secure,
+            httponly=httponly,
+            samesite=samesite,
+        )
 
     @property
     def is_streamed(self) -> bool:


### PR DESCRIPTION
Recent browser changes mean that cookies will not be set if they have
the wrong combination of attributes e.g. SameSite none and not
secure. This also affects deletion which itself is a set cookie
command.

Only the SameSite and secure attributes are required, however it seems
more useful to accept all the possibilities for other edge cases.

See also https://chromestatus.com/feature/5633521622188032

See also https://www.thinktecture.com/en/identity/samesite/how-to-delete-samesite-cookies/
