### PR TITLE
Fix parametrizing in send_from_directory tests

### DIFF
--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -159,7 +159,7 @@ def test_from_directory(directory, path):
     rv.close()
 
 
-@pytest.mark.parametrize("path", ["../unsafe.txt", "nothing.txt", "null\x00.txt"])
+@pytest.mark.parametrize("path", ["../res/test.txt", "nothing.txt", "null\x00.txt"])
 def test_from_directory_not_found(path):
     with pytest.raises(NotFound):
-        send_from_directory(res_path, "../bad.txt", environ)
+        send_from_directory(res_path, path, environ)


### PR DESCRIPTION
This PR fix test introduced in #1888:

* test use parametrized value,
* unsafe path point to existing file, so naive joining will fail test.

- fixes #1903 

Checklist:

- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
