### PR TITLE
Add samesite='None' to debugger cookie

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -438,6 +438,7 @@ class DebuggedApplication:
                 self.pin_cookie_name,
                 f"{int(time.time())}|{hash_pin(self.pin)}",
                 httponly=True,
+                samesite='None',
             )
         elif bad_cookie:
             rv.delete_cookie(self.pin_cookie_name)

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -438,7 +438,7 @@ class DebuggedApplication:
                 self.pin_cookie_name,
                 f"{int(time.time())}|{hash_pin(self.pin)}",
                 httponly=True,
-                samesite='None',
+                samesite="None",
             )
         elif bad_cookie:
             rv.delete_cookie(self.pin_cookie_name)


### PR DESCRIPTION
This adds samesite='None' to debugger cookie so the debugger can be accessed in an iframe

When entering the debugger pin into the debugger when running in an iframe, Chrome states that "Because a cookie's SameSite attribute was not set or is invalid, it defaults to SameSite=Lax, which prevents the cookie from being set in a cross-site context."

- fixes #1912