### PR TITLE
prevent crash if stdin is None.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,8 @@ Unreleased
 -   Update the defaults used by ``generat_password_hash``. Increase
     PBKDF2 iterations to 260000 from 150000. Increase salt length to 16
     from 8. Use ``secrets`` module to generate salt. :pr:`1935`
+-   The reloader doesn't crash if ``sys.stdin`` is somehow ``None``.
+    :pr:`1915`
 
 
 Version 1.0.2

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -306,13 +306,16 @@ def ensure_echo_on():
     """Ensure that echo mode is enabled. Some tools such as PDB disable
     it which causes usability issues after a reload."""
     # tcgetattr will fail if stdin isn't a tty
-    if not sys.stdin.isatty():
+    if sys.stdin is None or not sys.stdin.isatty():
         return
+
     try:
         import termios
     except ImportError:
         return
+
     attributes = termios.tcgetattr(sys.stdin)
+
     if not attributes[3] & termios.ECHO:
         attributes[3] |= termios.ECHO
         termios.tcsetattr(sys.stdin, termios.TCSANOW, attributes)


### PR DESCRIPTION
This can happen if you use external tools like `entr` to reload the server, then `sys.stdin` can be `None`, and one uses `run(debug=True)`.