### PR TITLE
debugger icons license/attribution

### DIFF
--- a/src/werkzeug/debug/shared/ICON_LICENSE.md
+++ b/src/werkzeug/debug/shared/ICON_LICENSE.md
@@ -1,0 +1,5 @@
+Silk icon set 1.3 by Mark James (mjames@gmail.com)
+
+http://www.famfamfam.com/lab/icons/silk/
+
+License: [Creative Commons Attribution 2.5](https://creativecommons.org/licenses/by/2.5/) or [Creative Commons Attribution 3.0](https://creativecommons.org/licenses/by/3.0/).


### PR DESCRIPTION
Fixes #1813.

It might also be a good idea to add a notice to the top-level `LICENSE.rst` and/or `README.rst` that these icons (and the ubuntu font) are covered under a different license.