### PR TITLE
Fix docs for werkzeug.formparser.parse_form_data

### DIFF
--- a/docs/http.rst
+++ b/docs/http.rst
@@ -130,17 +130,23 @@ by any of the modern web browsers.
 
 Usage example:
 
->>> from cStringIO import StringIO
->>> data = '--foo\r\nContent-Disposition: form-data; name="test"\r\n' \
-... '\r\nHello World!\r\n--foo--'
->>> environ = {'wsgi.input': StringIO(data), 'CONTENT_LENGTH': str(len(data)),
-...            'CONTENT_TYPE': 'multipart/form-data; boundary=foo',
-...            'REQUEST_METHOD': 'POST'}
+>>> from io import BytesIO
+>>> from werkzeug.formparser import parse_form_data
+>>> data = (
+...     b'--foo\r\nContent-Disposition: form-data; name="test"\r\n'
+...     b"\r\nHello World!\r\n--foo--"
+... )
+>>> environ = {
+...     "wsgi.input": BytesIO(data),
+...     "CONTENT_LENGTH": str(len(data)),
+...     "CONTENT_TYPE": "multipart/form-data; boundary=foo",
+...     "REQUEST_METHOD": "POST",
+... }
 >>> stream, form, files = parse_form_data(environ)
 >>> stream.read()
-''
+b''
 >>> form['test']
-u'Hello World!'
+'Hello World!'
 >>> not files
 True
 


### PR DESCRIPTION
* Make input and output bytes.
* black format.
* Correct import statements.

<!--
Before opening a PR, open a ticket describing the issue or feature the PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1926

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
