### PR TITLE
Fixes request log output for light terminal themes

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -389,7 +389,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
             if code[0] == "1":  # 1xx - Informational
                 msg = color(msg, bold=True)
             elif code[0] == "2":  # 2xx - Success
-                msg = color(msg, fg="white")
+                msg = color(msg)
             elif code == "304":  # 304 - Resource Not Modified
                 msg = color(msg, fg="cyan")
             elif code[0] == "3":  # 3xx - Redirection


### PR DESCRIPTION
E.g., when using Solarized Light in Konsole on Linux:

![image](https://user-images.githubusercontent.com/2628379/95610231-fbd86100-0a2d-11eb-8752-3f4ce86ab99b.png)

>Describe how to replicate the bug.

1) Use a terminal with a light theme

2) Run "A Simple Example" from README and make a request that results in 200 response

>Describe the expected behavior that should have happened but didn't.

Log should use default foreground color. click fg kwarg should just be blank instead of `"white"`.

Environment:

- Python version: 3.8.6
- Werkzeug version: 1.0.1
