### PR TITLE
Drop unreachable code in `safe_str_cmp`

### DIFF
--- a/src/werkzeug/security.py
+++ b/src/werkzeug/security.py
@@ -18,7 +18,6 @@ SALT_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 DEFAULT_PBKDF2_ITERATIONS = 260000
 
 _pack_int = Struct(">I").pack
-_builtin_safe_str_cmp = getattr(hmac, "compare_digest", None)
 _os_alt_seps = list(
     sep for sep in [os.path.sep, os.path.altsep] if sep not in (None, "/")
 )
@@ -98,17 +97,7 @@ def safe_str_cmp(a: str, b: str) -> bool:
     if isinstance(b, str):
         b = b.encode("utf-8")  # type: ignore
 
-    if _builtin_safe_str_cmp is not None:
-        return _builtin_safe_str_cmp(a, b)
-
-    if len(a) != len(b):
-        return False
-
-    rv = 0
-    for x, y in zip(a, b):
-        rv |= x ^ y  # type: ignore
-
-    return rv == 0
+    return hmac.compare_digest(a, b)
 
 
 def gen_salt(length: int) -> str:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -20,18 +20,6 @@ def test_safe_str_cmp():
     assert safe_str_cmp("aaa", "aaa") is True
 
 
-def test_safe_str_cmp_no_builtin():
-    import werkzeug.security as sec
-
-    prev_value = sec._builtin_safe_str_cmp
-    sec._builtin_safe_str_cmp = None
-    assert safe_str_cmp("a", "ab") is False
-
-    assert safe_str_cmp("str", "str") is True
-    assert safe_str_cmp("str1", "str2") is False
-    sec._builtin_safe_str_cmp = prev_value
-
-
 def test_password_hashing():
     hash0 = generate_password_hash("default")
     assert check_password_hash(hash0, "default")


### PR DESCRIPTION
`hmac.compare_digest` was added in Python 3.3.