### PR TITLE
add FormFieldStorage and request.form_headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,10 @@ Unreleased
     add an ``Authorization`` header. It can be an ``Authorization``
     object or a ``(username, password)`` tuple for ``Basic`` auth.
     :pr:`1809`
+-   ``MultipartParser`` now returns ``FormFieldStorage`` objects for
+    values, similar to ``FileStorage`` for files. This captures the
+    ``headers`` associated with each part. This information is available
+    through ``request.form_headers``. :issue:`1848`
 
 
 Version 1.0.2

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -8,6 +8,7 @@ from io import FileIO
 from itertools import chain
 from typing import Any
 from typing import AnyStr
+from typing import BinaryIO
 from typing import Callable
 from typing import Dict
 from typing import IO
@@ -204,7 +205,7 @@ def get_content_length(environ: WSGIEnvironment) -> Optional[int]:
 
 def get_input_stream(
     environ: WSGIEnvironment, safe_fallback: bool = True
-) -> Union[BytesIO, "LimitedStream"]:
+) -> Union[BinaryIO, "LimitedStream"]:
     """Returns the input stream from the WSGI environment and wraps it
     in the most sensible way possible. The stream returned is not the
     raw WSGI stream in most cases but one that is safe to read from

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -132,7 +132,7 @@ def test_retry_after_mixin(cls, value, expect):
     "cls",
     sorted(
         (e for e in HTTPException.__subclasses__() if e.code and e.code >= 400),
-        key=lambda e: e.code,
+        key=lambda e: e.code,  # type: ignore
     ),
 )
 def test_passing_response(cls):


### PR DESCRIPTION
Add a `FormFieldStorage` class, and make it the base class of `FileStorage`. `MultipartParser.parse_parts()` now returns instances of this instead of only the text value. `BaseRequest.form_headers` exposes this information, and `form` still exposes only the text value. This adds a bit (unmeasured) of overhead since `form` has to be populated using another comprehension after building `form_headers`. Like files, the field storage can be used with the test client.

I'm making this PR as a proof of concept, since I went through the trouble of implementing it. However, after more consideration, discussed in #1848, I've concluded that extra headers are against the HTTP `multipart/form-data` spec. If the content type is needed for more than the `charset` option the part should be given a `filename` to be treated as a file, which is the current behavior.

- fixes #1848 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
