### PR TITLE
Fix dict-like mention on Headers datastructure

### DIFF
--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -908,8 +908,9 @@ def _unicodify_header_value(value: UnicodeEncodable) -> str:
 
 
 class Headers:
-    """An object that stores some headers.  It has a dict-like interface
-    but is ordered and can store the same keys multiple times.
+    """An object that stores some headers. It has a dict-like interface,
+    but is ordered, can store the same key multiple times, and iterating
+    yields ``(key, value)`` pairs instead of only keys.
 
     This data structure is useful if you want a nicer way to handle WSGI
     headers which are stored as tuples in a list.


### PR DESCRIPTION
Update `datastructure.Headers` dict-like mention to reflect `__iter__` difference.

- fixes #1946