### PR TITLE
Explicitily specify that "Response.add_etag" adds etag based on the "Response.get_data"

### DIFF
--- a/src/werkzeug/wrappers/etag.py
+++ b/src/werkzeug/wrappers/etag.py
@@ -258,7 +258,7 @@ class ETagResponseMixin:
         return self  # type: ignore
 
     def add_etag(self, overwrite: bool = False, weak: bool = False) -> None:
-        """Add an etag for the current response if there is none yet."""
+        """Add an etag based on the current response data to current response, if there is none yet."""
         if overwrite or "etag" not in self.headers:
             self.set_etag(generate_etag(self.get_data()), weak)  # type: ignore
 

--- a/src/werkzeug/wrappers/etag.py
+++ b/src/werkzeug/wrappers/etag.py
@@ -258,7 +258,8 @@ class ETagResponseMixin:
         return self  # type: ignore
 
     def add_etag(self, overwrite: bool = False, weak: bool = False) -> None:
-        """Add an etag based on the current response data to current response, if there is none yet."""
+        """Add an etag based on the current response data
+        to current response headers, if there is none yet."""
         if overwrite or "etag" not in self.headers:
             self.set_etag(generate_etag(self.get_data()), weak)  # type: ignore
 


### PR DESCRIPTION
Nothing much, Just clarified `werkzeug.Response.add_etag` uses `werkzeug.Response.get_data` on it's docstring to make it less confusing with `werkzeug.Response.set_etag`, It's not much, But it is honest work :D 

- fixes #1948

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
