### PR TITLE
Make the MultiPart Form parser Sans-IO

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,7 @@ Unreleased
 -   Add new "edg" identifier for Edge in UserAgentPreparser.
     :issue:`1797`
 -   Upgrade the debugger to jQuery 3.5.1. :issue:`1802`
+-   Make MultiPart Form parser Sans-IO. :issue:`1788`
 
 
 Version 1.0.1

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -494,13 +494,12 @@ class MultiPartParser:
         def feed(self, input_buffer):
             if not input_buffer:
                 yield self._leftover_buffer
-            else:
-                input_buffer = self._leftover_buffer + input_buffer
 
-                for line in self._split_lines(input_buffer):  # noqa: B007
-                    if line:
-                        yield line
-                        input_buffer = input_buffer[len(line) :]
+            input_buffer = self._leftover_buffer + input_buffer
+
+            for line in self._split_lines(input_buffer):
+                if line:
+                    yield line
 
     class LineParser:
         """Parses lines as form data, generating the same output as
@@ -595,8 +594,6 @@ class MultiPartParser:
                 parts = line.split(":", 1)
                 if len(parts) == 2:
                     self._headers.append((parts[0].strip(), parts[1].strip()))
-
-                return None
 
         def _state_output(self, line):
             if not line:
@@ -718,7 +715,7 @@ class MultiPartParser:
                         transfer_encoding = "base64_codec"
                     try:
                         line = codecs.decode(line, transfer_encoding)  # type: ignore
-                    except Exception:
+                    except ValueError:
                         self.fail("could not decode transfer encoded chunk")
 
                 # we have something in the buffer from the last iteration.

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -469,6 +469,9 @@ class MultiPartParser:
             self.fail("Boundary longer than buffer size")
 
     class LineSplitter:
+        """Generate lines over an input buffer with the same output as
+        ``make_line_iter`` but as a state machine."""
+
         def __init__(self, cap=None):
             self.cap = cap
             self._leftover_buffer = b""  # Holds lines to be used by next chunk of data
@@ -757,6 +760,9 @@ class MultiPartParser:
     ) -> Iterator[Union[Tuple[str, Tuple[str, Union[str, FileStorage]]]]]:
         """Generate ``('file', (name, val))`` and
         ``('form', (name, val))`` parts.
+
+        .. versionchanged:: 1.0.1
+            Make parser Sans-IO
         """
         in_memory = 0
 

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -763,23 +763,23 @@ class MultiPartParser:
             for line in line_splitter.feed(buffer):
                 for ellt, ell in line_parser.feed(line):
                     if ellt == _begin_file:
-                        headers, name, filename = ell  # type: ignore
+                        headers, name, filename = ell
                         is_file = True
                         guard_memory = False
                         filename, container = self.start_file_streaming(
-                            filename, headers, content_length  # type: ignore
+                            filename, headers, content_length
                         )
                         _write = container.write
 
                     elif ellt == _begin_form:
-                        headers, name = ell  # type: ignore
+                        headers, name = ell
                         is_file = False
                         container = []  # type: ignore
                         _write = container.append  # type: ignore
                         guard_memory = self.max_form_memory_size is not None
 
                     elif ellt == _cont:
-                        _write(ell)  # type: ignore
+                        _write(ell)
                         # if we write into memory and there is a memory size limit we
                         # count the number of bytes in memory and raise an exception if
                         # there is too much data in memory.
@@ -791,23 +791,18 @@ class MultiPartParser:
                     elif ellt == _end:
                         if is_file:
                             container.seek(0)
-                            yield (  # type: ignore
+                            yield (
                                 "file",
                                 (
                                     name,
                                     FileStorage(
-                                        container,
-                                        filename,
-                                        name,  # type: ignore
-                                        headers=headers,  # type: ignore
+                                        container, filename, name, headers=headers,
                                     ),
                                 ),
                             )
                         else:
-                            part_charset = self.get_part_charset(
-                                headers
-                            )  # type: ignore
-                            yield (  # type: ignore
+                            part_charset = self.get_part_charset(headers)
+                            yield (
                                 "form",
                                 (
                                     name,


### PR DESCRIPTION
This PR addresses #1788 and lays groundwork to make form parser Sans-IO in order to support ASGI.

Relevant PR and issues:

- PR: #1330 

- fixes #1788 


Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
