### PR TITLE
skip live reloader test on Windows during CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,6 @@ jobs:
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
-          - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
           - {name: Docs, python: '3.8', os: ubuntu-latest, tox: docs}
           - {name: Typing, python: '3.8', os: ubuntu-latest, tox: typing}
           - {name: Windows, python: '3.8', os: windows-latest, tox: py38}

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -1,5 +1,6 @@
 import http.client
 import json
+import os
 import shutil
 import socket
 import ssl
@@ -80,6 +81,9 @@ def test_ssl_object(dev_server):
 
 
 @pytest.mark.parametrize("reloader_type", ["stat", "watchdog"])
+@pytest.mark.skipif(
+    os.name == "nt" and "CI" in os.environ, reason="unreliable on Windows during CI",
+)
 def test_reloader_sys_path(tmp_path, dev_server, reloader_type):
     """This tests the general behavior of the reloader. It also tests
     that fixing an import error triggers a reload, not just Python

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ skip_missing_interpreters = true
 
 [testenv]
 deps = -r requirements/tests.txt
-commands = pytest --tb=short --basetemp={envtmpdir} {posargs}
+passenv = CI
+commands = pytest -v --tb=short --basetemp={envtmpdir} {posargs}
 
 [testenv:style]
 deps = pre-commit


### PR DESCRIPTION
Despite the refactor in #1945, the Windows env on CI still causes the live reloader test to hang about 50% of the time for some reason. I'm no longer interested in fixing it, so it's skipped on Windows during CI. The test still passes quickly when running locally on Windows.

Tox now passes pytest the `-v` flag to print every test on its own line, which should be more responsive for the live CI logs.

Also has a commit to remove the "Style" (pre-commit) CI env, since we're now using pre-commit.ci.