### PR TITLE
avoid double encoding in EnvironBuilder.from_environ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Unreleased
     add an ``Authorization`` header. It can be an ``Authorization``
     object or a ``(username, password)`` tuple for ``Basic`` auth.
     :pr:`1809`
+-   ``EnvironBuilder.from_environ`` decodes values encoded for WSGI, to
+    avoid double encoding the new values. :pr:`1959`
 -   The default stat reloader will watch Python files under
     non-system/virtualenv ``sys.path`` entries, which should contain
     most user code. It will also watch all Python files under

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -367,17 +367,19 @@ def test_create_environ_query_string_error():
 
 def test_builder_from_environ():
     environ = create_environ(
-        "/foo",
+        "/ㄱ",
         base_url="https://example.com/base",
         query_string={"name": "Werkzeug"},
-        data={"foo": "bar"},
-        headers={"X-Foo": "bar"},
+        data={"foo": "ㄴ"},
+        headers={"X-Foo": "ㄷ"},
     )
     builder = EnvironBuilder.from_environ(environ)
+
     try:
         new_environ = builder.get_environ()
     finally:
         builder.close()
+
     assert new_environ == environ
 
 


### PR DESCRIPTION
Avoid double encoding WSGI path and query values when copying environ with builder. This was causing some Flask tests to fail.