### PR TITLE
add helpers for Flask's send_file wrapper

### DIFF
--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -163,3 +163,25 @@ def test_from_directory(directory, path):
 def test_from_directory_not_found(path):
     with pytest.raises(NotFound):
         send_from_directory(res_path, path, environ)
+
+
+def test_root_path(tmp_path):
+    # This is a private API, it should only be used by Flask.
+    d = tmp_path / "d"
+    d.mkdir()
+    (d / "test.txt").write_bytes(b"test")
+    rv = send_file("d/test.txt", environ, _root_path=tmp_path)
+    rv.direct_passthrough = False
+    assert rv.data == b"test"
+    rv.close()
+    rv = send_from_directory("d", "test.txt", environ, _root_path=tmp_path)
+    rv.direct_passthrough = False
+    assert rv.data == b"test"
+    rv.close()
+
+
+def test_max_age_callable():
+    # This is a private API, it should only be used by Flask.
+    rv = send_file(txt_path, environ, max_age=lambda p: 10)
+    rv.close()
+    assert rv.cache_control.max_age == 10


### PR DESCRIPTION
Without these changes, Flask's wrappers would need to duplicate the path processing code. These changes are for internal use only.

* `_root_path` private parameter allows paths to be relative to `app.root_path` instead of cwd.
* `max_age` can be a callable that takes an optional path, allows calling `app.get_send_file_max_age`.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
