### PR TITLE
Correct minor security issue for cookie prefixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,9 @@ Unreleased
 -   The reloader ignores ``__pycache__`` directories again. :pr:`1945`
 -   ``run_simple`` takes ``exclude_patterns`` a list of ``fnmatch``
     patterns that will not be scanned by the reloader. :issue:`1333`
+-   Cookie names are no longer unquoted. This was against :rfc:`6265`
+    and potentially allowed setting ``__Secure`` prefixed cookies.
+    :pr:`1965`
 
 
 Version 1.0.2

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -441,7 +441,7 @@ def _cookie_parse_impl(b: bytes) -> t.Iterator[t.Tuple[bytes, bytes]]:
         value = match.group("val") or b""
         i = match.end(0)
 
-        yield _cookie_unquote(key), _cookie_unquote(value)
+        yield key, _cookie_unquote(value)
 
 
 def _encode_idna(domain: str) -> bytes:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -439,7 +439,7 @@ class TestHTTPUtility:
     def test_parse_cookie(self):
         cookies = http.parse_cookie(
             "dismiss-top=6; CP=null*; PHPSESSID=0a539d42abc001cdc762809248d4beed;"
-            ' a=42; b="\\";"; ; fo234{=bar;blub=Blah;'
+            'a=42; b="\\";"; ; fo234{=bar;blub=Blah; "__Secure-c"=d'
         )
         assert cookies.to_dict() == {
             "CP": "null*",
@@ -449,6 +449,7 @@ class TestHTTPUtility:
             "b": '";',
             "fo234{": "bar",
             "blub": "Blah",
+            '"__Secure-c"': "d",
         }
 
     def test_dump_cookie(self):


### PR DESCRIPTION
**NOTE: I did not see any special contact address for security issues. Seeing as this is a quite low severity issue I am just opening a public ticket. Feel free to delete if this is not the right thing to do.**

Browsers assign special meaning to cookies prefixed with either `__Secure-` or `__Host-`. Due to the unquoting of cookie keys done by Werkzeurg this protection can be bypassed by creating a cookie with these prefixes inside quotes. The browses will not enforce the requirements needed by those prefixes while the server will not be able to differentiate between the unsecure quoted cookie and the more secure unquoted cookie.

While the cookie [spec](https://tools.ietf.org/html/rfc6265#section-4.1.1) encourages encoding the cookie value it does not specify anything with regard to cookie name and the character set for the cookie name is more restricted.

This issue was brought up for the Rails platform recently which is what prompted me to see what other platforms have the same or similar issues. See that investigation for more information:

https://hackerone.com/reports/895727

I have created what I hope to be a POC of this issue at:

https://github.com/eric1234/werkzeug-cookie-prefix-poc

This commit changes the code so that only the value is unquoted and the key is not. If someone provides a quoted key then the
quote will become part of the cookie name.

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
