### PR TITLE
Log SSL errors before discarding them

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,7 @@ Unreleased
     :pr:`1965`
 -   Fix some word matches for user agent platform when the word can be a
     substring. :issue:`1923`
+-   The development server logs ignored SSL errors. :pr:`1967`
 
 
 Version 1.0.2

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -329,7 +329,9 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
         except (ConnectionError, socket.timeout) as e:
             self.connection_dropped(e)
         except Exception as e:
-            if self.server.ssl_context is None or not is_ssl_error(e):
+            if self.server.ssl_context is not None and is_ssl_error(e):
+                self.log_error("SSL error occurred: %s", e)
+            else:
                 raise
         if self.server.shutdown_signal:
             self.initiate_shutdown()


### PR DESCRIPTION
Instead of simply discarding SSL errors, log them before.
Based on https://github.com/pallets/werkzeug/pull/694 by @jdreed

Fixes #625

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.

I could not add a test because I keep running into this problem when following the instructions given in CONTRIBUTING.rst:
```
➜  werkzeug git:(log-ssl-errors) ✗ python3 -m venv env                   
➜  werkzeug git:(log-ssl-errors) ✗ . env/bin/activate                    
(env) ➜  werkzeug git:(log-ssl-errors) ✗ pip install -e . -r requirements/dev.txt
Obtaining file:///home/user/projects/werkzeug
    ERROR: Command errored out with exit status 1:
     command: /home/user/projects/werkzeug/env/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/user/projects/werkzeug/setup.py'"'"'; __file__='"'"'/home/user/projects/werkzeug/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /home/user/tmp/pip-pip-egg-info-cy1ugs3a
         cwd: /home/user/projects/werkzeug/
    Complete output (28 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/user/projects/werkzeug/setup.py", line 4, in <module>
        setup(name="Werkzeug", extras_require={"watchdog": ["watchdog"]})
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.6/distutils/core.py", line 121, in setup
        dist.parse_config_files()
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/dist.py", line 494, in parse_config_files
        ignore_option_errors=ignore_option_errors)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 106, in parse_configuration
        meta.parse()
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 382, in parse
        section_parser_method(section_options)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 355, in parse_section
        self[name] = value
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 173, in __setitem__
        value = parser(value)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 430, in _parse_version
        version = self._parse_attr(value)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 305, in _parse_attr
        module = import_module(module_name)
      File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 994, in _gcd_import
      File "<frozen importlib._bootstrap>", line 971, in _find_and_load
      File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
    ModuleNotFoundError: No module named 'werkzeug'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

If I install werkzeug manually, I get another error:
```
(env) ➜  werkzeug git:(log-ssl-errors) ✗ pip3 install werkzeug
Collecting werkzeug
  Using cached Werkzeug-1.0.1-py2.py3-none-any.whl (298 kB)
Installing collected packages: werkzeug
Successfully installed werkzeug-1.0.1
(env) ➜  werkzeug git:(log-ssl-errors) ✗ pip install -e . -r requirements/dev.txt
Obtaining file:///home/user/projects/werkzeug
Requirement already satisfied: alabaster==0.7.12 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 7)) (0.7.12)
Requirement already satisfied: appdirs==1.4.4 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 8)) (1.4.4)
Requirement already satisfied: attrs==19.3.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 9)) (19.3.0)
Requirement already satisfied: babel==2.8.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 10)) (2.8.0)
Requirement already satisfied: certifi==2020.4.5.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 11)) (2020.4.5.1)
Requirement already satisfied: cffi==1.14.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 12)) (1.14.0)
Requirement already satisfied: cfgv==3.1.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 13)) (3.1.0)
Requirement already satisfied: chardet==3.0.4 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 14)) (3.0.4)
Requirement already satisfied: click==7.1.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 15)) (7.1.2)
Requirement already satisfied: cryptography==3.2.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 16)) (3.2.1)
Requirement already satisfied: distlib==0.3.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 17)) (0.3.0)
Requirement already satisfied: docutils==0.16 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 18)) (0.16)
Requirement already satisfied: filelock==3.0.12 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 19)) (3.0.12)
Requirement already satisfied: greenlet==0.4.17 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 20)) (0.4.17)
Requirement already satisfied: identify==1.4.15 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 21)) (1.4.15)
Requirement already satisfied: idna==2.9 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 22)) (2.9)
Requirement already satisfied: imagesize==1.2.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 23)) (1.2.0)
Requirement already satisfied: iniconfig==1.0.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 24)) (1.0.0)
Requirement already satisfied: jinja2==2.11.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 25)) (2.11.2)
Requirement already satisfied: markupsafe==1.1.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 26)) (1.1.1)
Requirement already satisfied: mypy-extensions==0.4.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 27)) (0.4.3)
Requirement already satisfied: mypy==0.782 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 28)) (0.782)
Requirement already satisfied: nodeenv==1.3.5 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 29)) (1.3.5)
Requirement already satisfied: packaging==20.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 30)) (20.3)
Requirement already satisfied: pallets-sphinx-themes==1.2.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 31)) (1.2.3)
Requirement already satisfied: pathtools==0.1.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 32)) (0.1.2)
Requirement already satisfied: pip-tools==5.3.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 33)) (5.3.1)
Requirement already satisfied: pluggy==0.13.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 34)) (0.13.1)
Requirement already satisfied: pre-commit==2.8.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 35)) (2.8.2)
Requirement already satisfied: psutil==5.7.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 36)) (5.7.0)
Requirement already satisfied: py==1.9.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 37)) (1.9.0)
Requirement already satisfied: pycparser==2.20 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 38)) (2.20)
Requirement already satisfied: pygments==2.6.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 39)) (2.6.1)
Requirement already satisfied: pyparsing==2.4.7 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 40)) (2.4.7)
Requirement already satisfied: pytest-timeout==1.4.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 41)) (1.4.2)
Requirement already satisfied: pytest-xprocess==0.16.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 42)) (0.16.0)
Requirement already satisfied: pytest==6.1.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 43)) (6.1.2)
Requirement already satisfied: pytz==2020.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 44)) (2020.1)
Requirement already satisfied: pyyaml==5.3.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 45)) (5.3.1)
Requirement already satisfied: requests==2.24.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 46)) (2.24.0)
Requirement already satisfied: six==1.14.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 47)) (1.14.0)
Requirement already satisfied: snowballstemmer==2.0.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 48)) (2.0.0)
Requirement already satisfied: sphinx-issues==1.2.0 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 49)) (1.2.0)
Requirement already satisfied: sphinx==3.2.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 50)) (3.2.1)
Requirement already satisfied: sphinxcontrib-applehelp==1.0.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 51)) (1.0.2)
Requirement already satisfied: sphinxcontrib-devhelp==1.0.2 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 52)) (1.0.2)
Requirement already satisfied: sphinxcontrib-htmlhelp==1.0.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 53)) (1.0.3)
Requirement already satisfied: sphinxcontrib-jsmath==1.0.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 54)) (1.0.1)
Requirement already satisfied: sphinxcontrib-log-cabinet==1.0.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 55)) (1.0.1)
Requirement already satisfied: sphinxcontrib-qthelp==1.0.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 56)) (1.0.3)
Requirement already satisfied: sphinxcontrib-serializinghtml==1.1.4 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 57)) (1.1.4)
Requirement already satisfied: toml==0.10.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 58)) (0.10.1)
Requirement already satisfied: tox==3.20.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 59)) (3.20.1)
Requirement already satisfied: typed-ast==1.4.1 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 60)) (1.4.1)
Requirement already satisfied: typing-extensions==3.7.4.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 61)) (3.7.4.3)
Requirement already satisfied: urllib3==1.25.9 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 62)) (1.25.9)
Requirement already satisfied: virtualenv==20.0.20 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 63)) (20.0.20)
Requirement already satisfied: watchdog==0.10.3 in ./env/lib/python3.6/site-packages (from -r requirements/dev.txt (line 64)) (0.10.3)
Requirement already satisfied: importlib-metadata; python_version < "3.8" in ./env/lib/python3.6/site-packages (from pallets-sphinx-themes==1.2.3->-r requirements/dev.txt (line 31)) (2.0.0)
Requirement already satisfied: pip>=20.0 in ./env/lib/python3.6/site-packages (from pip-tools==5.3.1->-r requirements/dev.txt (line 33)) (20.2.4)
Requirement already satisfied: importlib-resources; python_version < "3.7" in ./env/lib/python3.6/site-packages (from pre-commit==2.8.2->-r requirements/dev.txt (line 35)) (3.3.0)
Requirement already satisfied: setuptools in ./env/lib/python3.6/site-packages (from sphinx==3.2.1->-r requirements/dev.txt (line 50)) (39.0.1)
Requirement already satisfied: zipp>=0.5 in ./env/lib/python3.6/site-packages (from importlib-metadata; python_version < "3.8"->pallets-sphinx-themes==1.2.3->-r requirements/dev.txt (line 31)) (3.4.0)
Installing collected packages: Werkzeug
  Attempting uninstall: Werkzeug
    Found existing installation: Werkzeug 1.0.1
    Uninstalling Werkzeug-1.0.1:
      Successfully uninstalled Werkzeug-1.0.1
  Running setup.py develop for Werkzeug
    ERROR: Command errored out with exit status 1:
     command: /home/user/projects/werkzeug/env/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/user/projects/werkzeug/setup.py'"'"'; __file__='"'"'/home/user/projects/werkzeug/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps
         cwd: /home/user/projects/werkzeug/
    Complete output (28 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/user/projects/werkzeug/setup.py", line 4, in <module>
        setup(name="Werkzeug", extras_require={"watchdog": ["watchdog"]})
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/__init__.py", line 129, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib/python3.6/distutils/core.py", line 121, in setup
        dist.parse_config_files()
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/dist.py", line 494, in parse_config_files
        ignore_option_errors=ignore_option_errors)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 106, in parse_configuration
        meta.parse()
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 382, in parse
        section_parser_method(section_options)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 355, in parse_section
        self[name] = value
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 173, in __setitem__
        value = parser(value)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 430, in _parse_version
        version = self._parse_attr(value)
      File "/home/user/projects/werkzeug/env/lib/python3.6/site-packages/setuptools/config.py", line 305, in _parse_attr
        module = import_module(module_name)
      File "/usr/lib/python3.6/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 994, in _gcd_import
      File "<frozen importlib._bootstrap>", line 971, in _find_and_load
      File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
    ModuleNotFoundError: No module named 'werkzeug'
    ----------------------------------------
  Rolling back uninstall of Werkzeug
  Moving to /home/user/projects/werkzeug/env/lib/python3.6/site-packages/Werkzeug-1.0.1.dist-info/
   from /home/user/projects/werkzeug/env/lib/python3.6/site-packages/~erkzeug-1.0.1.dist-info
  Moving to /home/user/projects/werkzeug/env/lib/python3.6/site-packages/werkzeug/
   from /home/user/projects/werkzeug/env/lib/python3.6/site-packages/~erkzeug
ERROR: Command errored out with exit status 1: /home/user/projects/werkzeug/env/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/user/projects/werkzeug/setup.py'"'"'; __file__='"'"'/home/user/projects/werkzeug/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps Check the logs for full command output.
```

Environment:

- Python version: 3.6.9
- Werkzeug version: git master