### PR TITLE
Fix checks without assert statements

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -455,7 +455,7 @@ class TestOrderedMultiDict(_MutableMultiDictTests):
         assert d.poplist("bar") == [42]
         assert not d
 
-        d.get("missingkey") is None
+        assert d.get("missingkey") is None
 
         d.add("foo", 42)
         d.add("foo", 23)
@@ -913,7 +913,7 @@ class TestCallbackDict:
             dct["a"]
             dct.get("a")
             pytest.raises(KeyError, lambda: dct["x"])
-            "a" in dct
+            assert "a" in dct
             list(iter(dct))
             dct.copy()
         with assert_calls(0, "callback triggered without modification"):


### PR DESCRIPTION
Make flake bugbear happy which found these missing assert statements.
They triggered warning with code B015 for pre-commit (see dependabot PRs).

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
