### PR TITLE
open form data temp file as 'rb+'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ Unreleased
 -   Fix some word matches for user agent platform when the word can be a
     substring. :issue:`1923`
 -   The development server logs ignored SSL errors. :pr:`1967`
+-   Temporary files for form data are opened in ``rb+`` instead of
+    ``wb+`` mode for better compatibility with some libraries.
+    :issue:`1961`
 
 
 Version 1.0.2

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -51,9 +51,9 @@ def default_stream_factory(
     max_size = 1024 * 500
 
     if SpooledTemporaryFile is not None:
-        return t.cast(t.BinaryIO, SpooledTemporaryFile(max_size=max_size, mode="wb+"))
+        return t.cast(t.BinaryIO, SpooledTemporaryFile(max_size=max_size, mode="rb+"))
     elif total_content_length is None or total_content_length > max_size:
-        return t.cast(t.BinaryIO, TemporaryFile("wb+"))
+        return t.cast(t.BinaryIO, TemporaryFile("rb+"))
 
     return BytesIO()
 


### PR DESCRIPTION
'wb+' should be fine also, but it was causing a too-strict check in Pandas to fail when reading uploaded files.

closes #1961 