### PR TITLE
ignore empty list and None when building url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ Unreleased
     anyway) is no longer used. :issue:`1963`
 -   Add a ``url_scheme`` argument to :meth:`~routing.MapAdapter.build`
     to override the bound scheme. :pr:`1721`
+-   Passing an empty list as a query string parameter to ``build()``
+    won't append an unnecessary ``?``. Also drop any number of ``None``
+    items in a list. :issue:`1992`
 -   When passing a ``Headers`` object to a test client method or
     ``EnvironBuilder``, multiple values for a key are joined into one
     comma separated value. This matches the HTTP spec on multi-value

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -711,16 +711,30 @@ def test_anyconverter():
     assert a.match("/a.2") == ("yes_dot", {"a": "a.2"})
 
 
-def test_build_append_unknown():
-    map = r.Map([r.Rule("/bar/<float:bazf>", endpoint="barf")])
-    adapter = map.bind("example.org", "/", subdomain="blah")
+@pytest.mark.parametrize(
+    ("value", "expect"),
+    [
+        (None, ""),
+        ([None], ""),
+        ([None, None], ""),
+        ("", "?extra="),
+        ([""], "?extra="),
+        (1.0, "?extra=1.0"),
+        ([1, 2], "?extra=1&extra=2"),
+        ([1, None, 2], "?extra=1&extra=2"),
+        ([1, "", 2], "?extra=1&extra=&extra=2"),
+    ],
+)
+def test_build_append_unknown(value, expect):
+    map = r.Map([r.Rule("/foo/<name>", endpoint="foo")])
+    adapter = map.bind("example.org", "/", subdomain="test")
     assert (
-        adapter.build("barf", {"bazf": 0.815, "bif": 1.0})
-        == "http://example.org/bar/0.815?bif=1.0"
+        adapter.build("foo", {"name": "bar", "extra": value})
+        == f"http://example.org/foo/bar{expect}"
     )
     assert (
-        adapter.build("barf", {"bazf": 0.815, "bif": 1.0}, append_unknown=False)
-        == "http://example.org/bar/0.815"
+        adapter.build("foo", {"name": "bar", "extra": value}, append_unknown=False)
+        == "http://example.org/foo/bar"
     )
 
 


### PR DESCRIPTION
Bug introduced in #1281. Passing an empty list as a query parameter to build should not cause a '?' to be appended to the URL since the query string is empty. Also discard any number of `None` values in the list.

- fixes #1992 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
