### PR TITLE
send_file accepts etag string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,9 @@ Unreleased
     conditional requests instead of using a timed cache.
     ``max_age=None`` replaces Flask's ``cache_timeout=43200``.
     :issue:`1882`
+-   ``send_file`` can be called with ``etag="string"`` to set a custom
+    ETag instead of generating one. ``etag`` replaces Flask's
+    ``add_etags``. :issue:`1868`
 -   Update the defaults used by ``generate_password_hash``. Increase
     PBKDF2 iterations to 260000 from 150000. Increase salt length to 16
     from 8. Use ``secrets`` module to generate salt. :pr:`1935`

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -148,6 +148,18 @@ def test_max_age(value, public):
     assert rv.status_code == 200
 
 
+def test_etag():
+    rv = send_file(txt_path, environ)
+    rv.close()
+    assert rv.headers["ETag"].count("-") == 2
+    rv = send_file(txt_path, environ, etag=False)
+    rv.close()
+    assert "ETag" not in rv.headers
+    rv = send_file(txt_path, environ, etag="unique")
+    rv.close()
+    assert rv.headers["ETag"] == '"unique"'
+
+
 @pytest.mark.parametrize(
     ("directory", "path"),
     [(str(res_path), "test.txt"), (res_path, pathlib.Path("test.txt"))],


### PR DESCRIPTION
`send_file` accepts a string to use for the etag, in case you already generated one through some other process. Renamed the `add_etags` parameter to `etag`.

- fixes #1868

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.