### PR TITLE
use SHA-1 instead of MD5 for etag and debugger pin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,10 @@ Unreleased
 -   Temporary files for form data are opened in ``rb+`` instead of
     ``wb+`` mode for better compatibility with some libraries.
     :issue:`1961`
+-   Use SHA-1 instead of MD5 for generating ETags and the debugger pin,
+    and in some tests. MD5 is not available in some environments, such
+    as FIPS 140. This may invalidate some caches since the ETag will be
+    different. :issue:`1897`
 
 
 Version 1.0.2

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -32,7 +32,7 @@ PIN_TIME = 60 * 60 * 24 * 7
 
 
 def hash_pin(pin: str) -> str:
-    return hashlib.md5(f"{pin} added salt".encode("utf-8", "replace")).hexdigest()[:12]
+    return hashlib.sha1(f"{pin} added salt".encode("utf-8", "replace")).hexdigest()[:12]
 
 
 _machine_id: t.Optional[str] = None
@@ -176,7 +176,7 @@ def get_pin_and_cookie_name(
     # within the unauthenticated debug page.
     private_bits = [str(uuid.getnode()), get_machine_id()]
 
-    h = hashlib.md5()
+    h = hashlib.sha1()
     for bit in chain(probably_public_bits, private_bits):
         if not bit:
             continue

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -6,7 +6,7 @@ import warnings
 from datetime import datetime
 from datetime import timedelta
 from email.utils import parsedate_tz
-from hashlib import md5
+from hashlib import sha1
 from time import gmtime
 from time import struct_time
 from time import time
@@ -867,8 +867,12 @@ def parse_etags(value: t.Optional[str]) -> "ds.ETags":
 
 
 def generate_etag(data: bytes) -> str:
-    """Generate an etag for some data."""
-    return md5(data).hexdigest()
+    """Generate an etag for some data.
+
+    .. versionchanged:: 2.0
+        Use SHA-1. MD5 may not be available in some environments.
+    """
+    return sha1(data).hexdigest()
 
 
 def parse_date(value: t.Optional[str]) -> t.Optional[datetime]:
@@ -1024,6 +1028,10 @@ def is_resource_modified(
     :param ignore_if_range: If `False`, `If-Range` header will be taken into
                             account.
     :return: `True` if the resource was modified, otherwise `False`.
+
+    .. versionchanged:: 2.0
+        SHA-1 is used to generate an etag value for the data. MD5 may
+        not be available in some environments.
 
     .. versionchanged:: 1.0.0
         The check is run for methods other than ``GET`` and ``HEAD``.

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -1229,7 +1229,12 @@ class Response:
         return self
 
     def add_etag(self, overwrite: bool = False, weak: bool = False) -> None:
-        """Add an etag for the current response if there is none yet."""
+        """Add an etag for the current response if there is none yet.
+
+        .. versionchanged:: 2.0
+            SHA-1 is used to generate the value. MD5 may not be
+            available in some environments.
+        """
         if overwrite or "etag" not in self.headers:
             self.set_etag(generate_etag(self.get_data()), weak)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -43,16 +43,6 @@ def test_password_hashing():
     assert fakehash == "plain$$default"
     assert check_password_hash(fakehash, "default")
 
-    mhash = generate_password_hash("default", method="md5")
-    assert mhash.startswith("md5$")
-    assert check_password_hash(mhash, "default")
-
-    legacy = "md5$$c21f969b5f03d33d43e04f8f136e7682"
-    assert check_password_hash(legacy, "default")
-
-    legacy = "md5$$c21f969b5f03d33d43e04f8f136e7682"
-    assert check_password_hash(legacy, "default")
-
 
 def test_safe_join():
     assert safe_join("foo", "bar/baz") == posixpath.join("foo", "bar/baz")

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -700,7 +700,7 @@ def test_etag_response():
     response = wrappers.Response("Hello World")
     assert response.get_etag() == (None, None)
     response.add_etag()
-    assert response.get_etag() == ("b10a8db164e0754105b7a99be72e3fe5", False)
+    assert response.get_etag() == ("0a4d55a8d778e5022fab701977c5d840bbc486d0", False)
     assert not response.cache_control
     response.cache_control.must_revalidate = True
     response.cache_control.max_age = 60
@@ -741,7 +741,7 @@ def test_etag_response_412():
     response = wrappers.Response("Hello World")
     assert response.get_etag() == (None, None)
     response.add_etag()
-    assert response.get_etag() == ("b10a8db164e0754105b7a99be72e3fe5", False)
+    assert response.get_etag() == ("0a4d55a8d778e5022fab701977c5d840bbc486d0", False)
     assert not response.cache_control
     response.cache_control.must_revalidate = True
     response.cache_control.max_age = 60


### PR DESCRIPTION
MD5 is not available in some environments such as FIPS 140. Neither of the uses in Werkzeug require a strong hash, so I'm just updating to SHA-1 at this time. Affects etags generated from bytes data with `werkzeug.http.generate_etag`. This could invalidate caches, but shouldn't cause errors. Also invalidates existing debugger pin cookies (which are session scoped anyway), but the user will just get prompted for an new pin.

The tests that used MD5 seemed redundant at this point, so I just removed them.

I don't actually have a FIPS 140 system, so I can't test if I got everything. If something else comes up please submit a new issue.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1897

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
