### PR TITLE
server shows valid address instead of 0.0.0.0 or ::

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,11 @@ Unreleased
 -   Add ``Cross-Origin-Opener-Policy`` and
     ``Cross-Origin-Embedder-Policy`` response header properties.
     :pr:`2008`
+-   ``run_simple`` tries to show a valid IP address when binding to all
+    addresses, instead of ``0.0.0.0`` or ``::``. It also warns about not
+    running the development server in production in this case.
+    :issue:`1964`
+
 
 Version 1.0.2
 -------------


### PR DESCRIPTION
`0.0.0.0` (IPv4) and `::` (IPv6) can be used to bind to all addresses, but they are not valid addresses. Firefox understands them but Chrome does not. By trying to connect to an arbitrary private address, we can get the address the socket used, which should be (one of) the valid external address. If it fails it falls back to `127.0.0.1` or `::1`, which should also still work.

Shows a new message about binding to all addresses, and warns not to use the development server in production in this case. It's the same warning the Flask shows when `FLASK_ENV=development` is not set, so Flask users will see the warning twice. Starting to think it might be better for Werkzeug to show that warning no matter what, and take out the conditional messages.

```
 * Running on all addresses.
   WARNING: This is a development server. Do not use it in a production deployment.
 * Running on http://192.168.1.241:5000/ (Press CTRL+C to quit)
```

```
 * Running on all addresses.
   WARNING: This is a development server. Do not use it in a production deployment.
 * Running on http://[2603:8000:e603:cbd3::09a1]:5000/ (Press CTRL+C to quit)
```

I generated random private IP addresses to try connecting to. They don't actually have to be accessible, and hopefully the randomness means nothing is running on them in practice either, although that shouldn't matter. ``10.0.0.0/8`` is private in IPv4, and `fd00::/8` is the ULA private space in IPv6.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1964

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
