### PR TITLE
fix colors in log on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,9 @@ Unreleased
     addresses, instead of ``0.0.0.0`` or ``::``. It also warns about not
     running the development server in production in this case.
     :issue:`1964`
+-   Colors in the development server log are displayed if Colorama is
+    installed on Windows. For all platforms, style support no longer
+    requires Click. :issue:`1832`
 
 
 Version 1.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,9 @@ warn_redundant_casts = True
 warn_unused_configs = True
 warn_unused_ignores = True
 
+[mypy-colorama.*]
+ignore_missing_imports = True
+
 [mypy-cryptography.*]
 ignore_missing_imports = True
 

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -183,6 +183,20 @@ def _has_level_handler(logger: logging.Logger) -> bool:
     return False
 
 
+class _ColorStreamHandler(logging.StreamHandler):
+    """On Windows, wrap stream with Colorama for ANSI style support."""
+
+    def __init__(self):
+        try:
+            import colorama
+        except ImportError:
+            stream = None
+        else:
+            stream = colorama.AnsiToWin32(sys.stderr)
+
+        super().__init__(stream)
+
+
 def _log(type: str, message: str, *args, **kwargs) -> None:
     """Log a message to the 'werkzeug' logger.
 
@@ -200,7 +214,7 @@ def _log(type: str, message: str, *args, **kwargs) -> None:
             _logger.setLevel(logging.INFO)
 
         if not _has_level_handler(_logger):
-            _logger.addHandler(logging.StreamHandler())
+            _logger.addHandler(_ColorStreamHandler())
 
     getattr(_logger, type)(message.rstrip(), *args, **kwargs)
 


### PR DESCRIPTION
No longer requires Click, as `click.style` wasn't doing what I expected and other utilities weren't much use. Replaced with a simple wrapper with just the styles used. On Windows, style information is only added if Colorama is installed. The handler added to the "werkzeug" logger wraps the stream with `colorama.AnsiToWin32` to output the styles correctly.

This means that if the user overrides the logging configuration, they'll get ANSI codes in the output again. However, that was already the case, even before the switch from termcolor to Click. If they're overriding logging, they can also make the decision to call `colorama.init()` before that to ensure `sys.stderr` is wrapped globally, but I didn't want Werkzeug to force that on import.

Also considered just removing styles. Until the recent switch to Click very few people ever saw them because termcolor wouldn't have been installed. For now I'll leave them in.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1832 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
