### PR TITLE
range request on empty file returns 200

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,9 @@ Unreleased
 -   Colors in the development server log are displayed if Colorama is
     installed on Windows. For all platforms, style support no longer
     requires Click. :issue:`1832`
+-   A range request for an empty file (or other data with length 0) will
+    return a 200 response with the empty file instead of a 416 error.
+    :issue:`1937`
 -   New sans-IO base classes for ``Request`` and ``Response`` have been
     extracted to contain all the behavior that is not WSGI or IO
     dependent. These are not a public API, they are part of an ongoing

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -710,12 +710,16 @@ class Response(_SansIOResponse):
 
         :raises: :class:`~werkzeug.exceptions.RequestedRangeNotSatisfiable`
                  if `Range` header could not be parsed or satisfied.
+
+        .. versionchanged:: 2.0
+            Returns ``False`` if the length is 0.
         """
         from ..exceptions import RequestedRangeNotSatisfiable
 
         if (
             accept_ranges is None
             or complete_length is None
+            or complete_length == 0
             or not self._is_range_request_processable(environ)
         ):
             return False
@@ -780,6 +784,10 @@ class Response(_SansIOResponse):
                                 Range Requests completion.
         :raises: :class:`~werkzeug.exceptions.RequestedRangeNotSatisfiable`
                  if `Range` header could not be parsed or satisfied.
+
+        .. versionchanged:: 2.0
+            Range processing is skipped if length is 0 instead of
+            raising a 416 Range Not Satisfiable error.
         """
         environ = _get_environ(request_or_environ)
         if environ["REQUEST_METHOD"] in ("GET", "HEAD"):

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -843,11 +843,11 @@ def test_range_request_with_complete_file():
         assert response.data == fcontent
 
 
-def test_range_request_without_complete_length():
-    env = create_environ()
+@pytest.mark.parametrize("value", [None, 0])
+def test_range_request_without_complete_length(value):
+    env = create_environ(headers={"Range": "bytes=0-10"})
     response = wrappers.Response("Hello World")
-    env["HTTP_RANGE"] = "bytes=-"
-    response.make_conditional(env, accept_ranges=True, complete_length=None)
+    response.make_conditional(env, accept_ranges=True, complete_length=value)
     assert response.status_code == 200
     assert response.data == b"Hello World"
 


### PR DESCRIPTION
Don't attempt to apply a range request if the response body is empty (usually an empty file). This is a weird corner case that isn't sufficiently addressed in the spec, but it's acceptable to return a 200 response and ignore the range request.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to automatically close an issue.
-->

- fixes #1937 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
