### PR TITLE
show inherited docs in wrappers

### DIFF
--- a/docs/wrappers.rst
+++ b/docs/wrappers.rst
@@ -78,14 +78,14 @@ Wrapper Classes
 
 .. autoclass:: Request
     :members:
-    :member-order: bysource
+    :inherited-members:
 
     .. automethod:: _get_file_stream
 
 
 .. autoclass:: Response
     :members:
-    :member-order: bysource
+    :inherited-members:
 
     .. automethod:: __call__
 


### PR DESCRIPTION
Continues #2005, needed to include `:inherited-members:` in docs so wrappers would get the docs from the sansio classes.