### PR TITLE
Add the sunset header to the response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,7 @@ Unreleased
     extracted to contain all the behavior that is not WSGI or IO
     dependent. These are not a public API, they are part of an ongoing
     refactor to let ASGI frameworks use Werkzeug. :pr:`2005`
+-   Add the sunset header to the ``Response`` class. :pr:`2019`.
 
 
 Version 1.0.2

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -629,3 +629,11 @@ class Response:
         explicitly grant the document permission. Values must be a member of the
         :class:`werkzeug.http.COEP` enum.""",
     )
+
+    sunset = header_property[datetime](
+        "Sunset",
+        load_func=parse_date,  # type: ignore
+        dump_func=http_date,
+        doc="""Header to indicate to the client that this resource will be
+        sunsetted (unavailable) at a certain date.""",
+    )

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1591,3 +1591,9 @@ def test_response_coep():
     assert response.cross_origin_embedder_policy is COEP.UNSAFE_NONE
     response.cross_origin_embedder_policy = COEP.REQUIRE_CORP
     assert response.headers["Cross-Origin-Embedder-Policy"] == "require-corp"
+
+
+def test_response_sunset():
+    response = wrappers.Response("Hello World")
+    response.sunset = datetime(2021, 1, 25)
+    assert response.headers["Sunset"] == "Mon, 25 Jan 2021 00:00:00 GMT"


### PR DESCRIPTION
This makes it easier for users of Werkzeug to know how to make use of
this header (and that it exists), as it is named and typed.

See also RFC-8594 for the RFC on this header and its usage.

I understand there may be a reluctance to add all these headers, however I think it is incredibly helpful to have the IDE know these headers exist and how they should be used. I find it much easier to discover useful headers this way, than via searching.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
