### PR TITLE
Mark `abort` as having type `NoReturn`

### DIFF
--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -830,7 +830,7 @@ class Aborter:
         if extra is not None:
             self.mapping.update(extra)
 
-    def __call__(self, code: t.Union[int, "Response"], *args, **kwargs) -> None:
+    def __call__(self, code: t.Union[int, "Response"], *args, **kwargs) -> t.NoReturn:
         from .wrappers.response import Response
 
         if isinstance(code, Response):
@@ -842,7 +842,7 @@ class Aborter:
         raise self.mapping[code](*args, **kwargs)
 
 
-def abort(status: t.Union[int, "Response"], *args, **kwargs) -> None:
+def abort(status: t.Union[int, "Response"], *args, **kwargs) -> t.NoReturn:
     """Raises an :py:exc:`HTTPException` for the given status code or WSGI
     application.
 
@@ -857,7 +857,7 @@ def abort(status: t.Union[int, "Response"], *args, **kwargs) -> None:
     _aborter(status, *args, **kwargs)
 
 
-_aborter = Aborter()
+_aborter: Aborter = Aborter()
 
 #: An exception that is used to signal both a :exc:`KeyError` and a
 #: :exc:`BadRequest`. Used by many of the datastructures.


### PR DESCRIPTION
In https://github.com/pallets/werkzeug/pull/1995, typing was added to large parts of this project. This will be really useful to me.

One of the problems I have with the latest release is `abort`. PyCharm doesn't know that `abort` aborts. So it will complain about possibly uninitialised variables if I write code like this:

```
if foo:
    bar = 1
else:
    abort(404)

print(bar)
```
This is because `abort` is declared to return type `None`: `def abort(status: t.Union[int, "Response"], *args, **kwargs) -> None:`.  This is not the case - I think `abort` always raises an exception.

Instead, what we want to do is change the return type to [`t.NoReturn`](https://www.python.org/dev/peps/pep-0484/#the-noreturn-type). This expresses the correct meaning, which is that the `abort` function never returns. In turn, this will help PyCharm and other analysers understand code that uses `abort` better.


Checklist:

(a docs change, so I've skipped some steps)

~- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~
- [x] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue. - this PR builds on https://github.com/pallets/werkzeug/pull/1995, which doesn't have an entry. Should I add an entry to cover both, or leave it alone?
~- [ ] Add `.. versionchanged::` entries in any relevant code docs.~
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
