### PR TITLE
send_file sets content-encoding from detected mimetype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,9 @@ Unreleased
 -   ``send_file`` can be called with ``etag="string"`` to set a custom
     ETag instead of generating one. ``etag`` replaces Flask's
     ``add_etags``. :issue:`1868`
+-   ``send_file`` sets the ``Content-Encoding`` header if an encoding is
+    returned when guessing ``mimetype`` from ``download_name``.
+    :pr:`3896`
 -   Update the defaults used by ``generate_password_hash``. Increase
     PBKDF2 iterations to 260000 from 150000. Increase salt length to 16
     from 8. Use ``secrets`` module to generate salt. :pr:`1935`

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -160,6 +160,13 @@ def test_etag():
     assert rv.headers["ETag"] == '"unique"'
 
 
+def test_content_encoding():
+    rv = send_file(txt_path, environ, download_name="logo.svgz")
+    rv.close()
+    assert rv.mimetype == "image/svg+xml"
+    assert rv.content_encoding == "gzip"
+
+
 @pytest.mark.parametrize(
     ("directory", "path"),
     [(str(res_path), "test.txt"), (res_path, pathlib.Path("test.txt"))],


### PR DESCRIPTION
`mimetypes.guess_mimetype()` returns `(mimetype, encoding)`. If `encoding` is not none, set the `Content-Encoding` header of the response.

Based on pallets/flask#3755.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
