### PR TITLE
deprecation warnings for local ident func

### DIFF
--- a/examples/plnt/database.py
+++ b/examples/plnt/database.py
@@ -11,7 +11,11 @@ from sqlalchemy.orm import mapper
 from sqlalchemy.orm import scoped_session
 
 from .utils import application
-from .utils import local_manager
+
+try:
+    from greenlet import getcurrent as get_ident
+except ImportError:
+    from threading import get_ident
 
 
 def new_db_session():
@@ -19,7 +23,7 @@ def new_db_session():
 
 
 metadata = MetaData()
-session = scoped_session(new_db_session, local_manager.get_ident)
+session = scoped_session(new_db_session, get_ident)
 
 
 blog_table = Table(

--- a/examples/simplewiki/database.py
+++ b/examples/simplewiki/database.py
@@ -14,9 +14,12 @@ from sqlalchemy.orm import relation
 from sqlalchemy.orm import scoped_session
 
 from .utils import application
-from .utils import local_manager
 from .utils import parse_creole
 
+try:
+    from greenlet import getcurrent as get_ident
+except ImportError:
+    from threading import get_ident
 
 # create a global metadata
 metadata = MetaData()
@@ -35,7 +38,7 @@ def new_db_session():
 
 # and create a new global session factory.  Calling this object gives
 # you the current active session
-session = scoped_session(new_db_session, local_manager.get_ident)
+session = scoped_session(new_db_session, get_ident)
 
 
 # our database tables.


### PR DESCRIPTION
* Updated deprecation warnings so they're consistently worded. Don't raise `RuntimeError`.
* Removed the ability to change `ident_func`, it always returns `get_ident` and setting does nothing.
* Add deprecation warning for `get_ident`, even though it's not a public API and shouldn't have been imported by anything.
* Deprecated `ident_func` in `LocalManager` as well.
* Removed `ident_func` attribute from fake ContextVar implementation.

- fixes #2034

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- ~Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.~
- ~Add or update relevant docs, in the docs folder and in code.~
- ~Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.~
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
