### PR TITLE
request.values ignores form data for GET

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,9 @@ Unreleased
     to check if an object is actually a proxy. :issue:`1754`
 -   ``Local`` uses ``ContextVar`` on Python 3.7+ instead of
     ``threading.local``. :pr:`1778`
+-   ``request.values`` does not include ``form`` for GET requests (even
+    though GET bodies are undefined). This prevents bad caching proxies
+    from caching form data instead of query strings. :pr:`2037`
 
 
 Version 1.0.2

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1203,6 +1203,21 @@ def test_form_data_ordering():
     assert req.values.getlist("foo") == ["1", "3"]
 
 
+def test_values():
+    r = wrappers.Request.from_values(
+        method="POST", query_string={"a": "1"}, data={"a": "2", "b": "2"}
+    )
+    assert r.values["a"] == "1"
+    assert r.values["b"] == "2"
+
+    # form should not be combined for GET method
+    r = wrappers.Request.from_values(
+        method="GET", query_string={"a": "1"}, data={"a": "2", "b": "2"}
+    )
+    assert r.values["a"] == "1"
+    assert "b" not in r.values
+
+
 def test_storage_classes():
     class MyRequest(wrappers.Request):
         dict_storage_class = dict


### PR DESCRIPTION
`request.values` combines `request.args` and `request.form`. GET requests can have form bodies (although it's undefined / ambiguous in specs). Poorly implemented caching proxies may not understand that GET requests can have form data, which would allow form data to invisibly affect a public cached URL.

Now `request.values` won't use `request.form` if `request.method == "GET"`.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
