### PR TITLE
parse_date returns timzeone-aware value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,15 @@ Unreleased
 -   Deprecate the ``environ["werkzeug.server.shutdown"]`` function
     that is available when running the development server. :issue:`1752`
 -   Remove the unused, internal ``posixemulation`` module. :issue:`1759`
+-   All ``datetime`` values are timezone-aware with
+    ``tzinfo=timezone.utc``. This applies to anything using
+    ``http.parse_date``: ``Request.date``, ``.if_modified_since``,
+    ``.if_unmodified_since``; ``Response.date``, ``.expires``,
+    ``.last_modified``, ``.retry_after``; ``parse_if_range_header``, and
+    ``IfRange.date``. When comparing values, the other values must also
+    be aware, or these values must be made naive. When passing
+    parameters or setting attributes, naive values are still assumed to
+    be in UTC. :pr:`2040`
 -   Merge all request and response wrapper mixin code into single
     ``Request`` and ``Response`` classes. Using the mixin classes is no
     longer necessary and will show a deprecation warning. Checking
@@ -86,6 +95,11 @@ Unreleased
     :pr:`1915`
 -   Add arguments to ``delete_cookie`` to match ``set_cookie`` and the
     attributes modern browsers expect. :pr:`1889`
+-   ``utils.cookie_date`` is deprecated, use ``utils.http_date``
+    instead. The value for ``Set-Cookie expires`` is no longer "-"
+    delimited. :pr:`2040`
+-   ``utils.http_date``, and attributes and values that use it, no
+    longer accept ``time.struct_time`` tuples. :pr:`2040`
 -   Use ``request.headers`` instead of ``request.environ`` to look up
     header attributes. :pr:`1808`
 -   The test ``Client`` request methods (``client.get``, etc.) always

--- a/docs/http.rst
+++ b/docs/http.rst
@@ -9,20 +9,31 @@ that are useful when implementing WSGI middlewares or whenever you are
 operating on a lower level layer.  All this functionality is also exposed
 from request and response objects.
 
-Date Functions
-==============
 
-The following functions simplify working with times in an HTTP context.
-Werkzeug uses offset-naive :class:`~datetime.datetime` objects internally
-that store the time in UTC.  If you're working with timezones in your
-application make sure to replace the tzinfo attribute with a UTC timezone
-information before processing the values.
+Datetime Functions
+==================
 
-.. autofunction:: cookie_date
+These functions simplify working with times in an HTTP context. Werkzeug
+produces timezone-aware :class:`~datetime.datetime` objects in UTC. When
+passing datetime objects to Werkzeug, it assumes any naive datetime is
+in UTC.
+
+When comparing datetime values from Werkzeug, your own datetime objects
+must also be timezone-aware, or you must make the values from Werkzeug
+naive.
+
+*   ``dt = datetime.now(timezone.utc)`` gets the current time in UTC.
+*   ``dt = datetime(..., tzinfo=timezone.utc)`` creates a time in UTC.
+*   ``dt = dt.replace(tzinfo=timezone.utc)`` makes a naive object aware
+    by assuming it's in UTC.
+*   ``dt = dt.replace(tzinfo=None)`` makes an aware object naive.
+
+.. autofunction:: parse_date
 
 .. autofunction:: http_date
 
-.. autofunction:: parse_date
+.. autofunction:: cookie_date
+
 
 Header Parsing
 ==============

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -185,7 +185,7 @@ True
 E-tags and other conditional headers are available in parsed form as well:
 
 >>> request.if_modified_since
-datetime.datetime(2009, 2, 20, 10, 10, 25)
+datetime.datetime(2009, 2, 20, 10, 10, 25, tzinfo=datetime.timezone.utc)
 >>> request.if_none_match
 <ETags '"e51c9-1e5d-46356dc86c640"'>
 >>> request.cache_control
@@ -253,8 +253,8 @@ retrieve them:
 
 >>> response.content_length
 12
->>> from datetime import datetime
->>> response.date = datetime(2009, 2, 20, 17, 42, 51)
+>>> from datetime import datetime, timezone
+>>> response.date = datetime(2009, 2, 20, 17, 42, 51, tzinfo=timezone.utc)
 >>> response.headers['Date']
 'Fri, 20 Feb 2009 17:42:51 GMT'
 

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -229,7 +229,11 @@ class Request:
         parse_date,
         doc="""The Date general-header field represents the date and
         time at which the message was originated, having the same
-        semantics as orig-date in RFC 822.""",
+        semantics as orig-date in RFC 822.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
+        """,
         read_only=True,
     )
     max_forwards = header_property(
@@ -341,21 +345,30 @@ class Request:
 
     @cached_property
     def if_modified_since(self) -> t.Optional[datetime]:
-        """The parsed `If-Modified-Since` header as datetime object."""
+        """The parsed `If-Modified-Since` header as a datetime object.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
+        """
         return parse_date(self.headers.get("If-Modified-Since"))
 
     @cached_property
     def if_unmodified_since(self) -> t.Optional[datetime]:
-        """The parsed `If-Unmodified-Since` header as datetime object."""
+        """The parsed `If-Unmodified-Since` header as a datetime object.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
+        """
         return parse_date(self.headers.get("If-Unmodified-Since"))
 
     @cached_property
     def if_range(self) -> IfRange:
-        """The parsed `If-Range` header.
+        """The parsed ``If-Range`` header.
+
+        .. versionchanged:: 2.0.0
+            ``IfRange.date`` is timezone-aware.
 
         .. versionadded:: 0.7
-
-        :rtype: :class:`~werkzeug.datastructures.IfRange`
         """
         return parse_if_range_header(self.headers.get("If-Range"))
 

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -2,6 +2,7 @@ import typing
 import typing as t
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 from .._internal import _to_str
 from ..datastructures import Headers
@@ -382,7 +383,11 @@ class Response:
         http_date,
         doc="""The Date general-header field represents the date and
         time at which the message was originated, having the same
-        semantics as orig-date in RFC 822.""",
+        semantics as orig-date in RFC 822.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
+        """,
     )
     expires = header_property(
         "Expires",
@@ -391,7 +396,11 @@ class Response:
         http_date,
         doc="""The Expires entity-header field gives the date/time after
         which the response is considered stale. A stale cache entry may
-        not normally be returned by a cache.""",
+        not normally be returned by a cache.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
+        """,
     )
     last_modified = header_property(
         "Last-Modified",
@@ -400,7 +409,11 @@ class Response:
         http_date,
         doc="""The Last-Modified entity-header field indicates the date
         and time at which the origin server believes the variant was
-        last modified.""",
+        last modified.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
+        """,
     )
 
     @property
@@ -410,12 +423,15 @@ class Response:
         service is expected to be unavailable to the requesting client.
 
         Time in seconds until expiration or date.
+
+        .. versionchanged:: 2.0.0
+            The datetime object is timezone-aware.
         """
         value = self.headers.get("retry-after")
         if value is None:
             return None
         elif value.isdigit():
-            return datetime.utcnow() + timedelta(seconds=int(value))
+            return datetime.now(timezone.utc) + timedelta(seconds=int(value))
         return parse_date(value)
 
     @retry_after.setter

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -22,6 +22,7 @@ import typing as t
 import warnings
 from datetime import datetime as dt
 from datetime import timedelta
+from datetime import timezone
 from http.server import BaseHTTPRequestHandler
 from http.server import HTTPServer
 
@@ -475,8 +476,8 @@ def generate_adhoc_ssl_pair(
         .issuer_name(subject)
         .public_key(pkey.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(dt.utcnow())
-        .not_valid_after(dt.utcnow() + timedelta(days=365))
+        .not_valid_before(dt.now(timezone.utc))
+        .not_valid_after(dt.now(timezone.utc) + timedelta(days=365))
         .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
         .add_extension(x509.SubjectAlternativeName([x509.DNSName("*")]), critical=False)
         .sign(pkey, hashes.SHA256(), default_backend())

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -11,7 +11,6 @@ import unicodedata
 import warnings
 from datetime import datetime
 from html.entities import name2codepoint
-from time import struct_time
 from time import time
 from zlib import adler32
 
@@ -564,7 +563,7 @@ def send_file(
     download_name: t.Optional[str] = None,
     conditional: bool = True,
     etag: t.Union[bool, str] = True,
-    last_modified: t.Optional[t.Union[datetime, int, float, struct_time]] = None,
+    last_modified: t.Optional[t.Union[datetime, int, float]] = None,
     max_age: t.Optional[
         t.Union[int, t.Callable[[t.Optional[t.Union[os.PathLike, str]]], int]]
     ] = None,

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from warnings import filterwarnings
 from warnings import resetwarnings
 
@@ -8,14 +7,6 @@ from werkzeug import _internal as internal
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
-
-
-def test_date_to_unix():
-    assert internal._date_to_unix(datetime(1970, 1, 1)) == 0
-    assert internal._date_to_unix(datetime(1970, 1, 1, 1, 0, 0)) == 3600
-    assert internal._date_to_unix(datetime(1970, 1, 1, 1, 1, 1)) == 3661
-    x = datetime(2010, 2, 15, 16, 15, 39)
-    assert internal._date_to_unix(x) == 1266250539
 
 
 def test_easteregg():

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -35,7 +35,7 @@ def test_x_sendfile():
 
 
 def test_last_modified():
-    last_modified = datetime.datetime(1999, 1, 1)
+    last_modified = datetime.datetime(1999, 1, 1, tzinfo=datetime.timezone.utc)
     rv = send_file(txt_path, environ, last_modified=last_modified)
     assert rv.last_modified == last_modified
     rv.close()

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -3,6 +3,7 @@ import json
 import os
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from io import BytesIO
 
 import pytest
@@ -258,7 +259,7 @@ def test_base_response():
         (
             "Set-Cookie",
             "foo=bar; Domain=example.org;"
-            " Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=60;"
+            " Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=60;"
             " Path=/blub; SameSite=Strict",
         ),
     ]
@@ -270,7 +271,7 @@ def test_base_response():
         ("Content-Type", "text/plain; charset=utf-8"),
         (
             "Set-Cookie",
-            "foo=; Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=0; Path=/",
+            "foo=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/",
         ),
     ]
 
@@ -434,8 +435,9 @@ def test_etag_request():
         assert etags.contains_weak("foo")
         assert not etags.contains("foo")
 
-    assert request.if_modified_since == datetime(2008, 1, 22, 11, 18, 44)
-    assert request.if_unmodified_since == datetime(2008, 1, 22, 11, 18, 44)
+    dt = datetime(2008, 1, 22, 11, 18, 44, tzinfo=timezone.utc)
+    assert request.if_modified_since == dt
+    assert request.if_unmodified_since == dt
 
 
 def test_user_agent():
@@ -910,7 +912,7 @@ def test_common_response_descriptors():
     del response.mimetype_params["charset"]
     assert response.content_type == "text/html; x-foo=yep"
 
-    now = datetime.utcnow().replace(microsecond=0)
+    now = datetime.now(timezone.utc).replace(microsecond=0)
 
     assert response.content_length is None
     response.content_length = "42"
@@ -967,7 +969,7 @@ def test_common_request_descriptors():
     assert request.mimetype_params == {"charset": "utf-8"}
     assert request.content_length == 23
     assert request.referrer == "http://www.example.com/"
-    assert request.date == datetime(2009, 2, 28, 19, 4, 35)
+    assert request.date == datetime(2009, 2, 28, 19, 4, 35, tzinfo=timezone.utc)
     assert request.max_forwards == 10
     assert "no-cache" in request.pragma
     assert request.content_encoding == "gzip"
@@ -1419,7 +1421,7 @@ class TestSetCookie:
             (
                 "Set-Cookie",
                 "foo=bar; Domain=example.org;"
-                " Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=60;"
+                " Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=60;"
                 " Secure; Path=/blub",
             ),
         ]
@@ -1442,7 +1444,7 @@ class TestSetCookie:
             (
                 "Set-Cookie",
                 "foo=bar; Domain=example.org;"
-                " Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=60;"
+                " Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=60;"
                 " HttpOnly; Path=/blub",
             ),
         ]
@@ -1465,7 +1467,7 @@ class TestSetCookie:
             (
                 "Set-Cookie",
                 "foo=bar; Domain=example.org;"
-                " Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=60;"
+                " Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=60;"
                 " Secure; HttpOnly; Path=/blub",
             ),
         ]
@@ -1487,7 +1489,7 @@ class TestSetCookie:
             (
                 "Set-Cookie",
                 "foo=bar; Domain=example.org;"
-                " Expires=Thu, 01-Jan-1970 00:00:00 GMT; Max-Age=60;"
+                " Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=60;"
                 " Path=/blub; SameSite=Strict",
             ),
         ]


### PR DESCRIPTION
`parse_date` returns a timezone-aware datetime object, with `tzinfo` set to `timezone.utc`. HTTP dates are always in UTC, and Python's naive datetimes have ambiguous meaning, with some libraries treating them as local and some as UTC. By making values timezone-aware, datetime comparisons work consistently regardless of library or local timezone. However, it does require upgrading any code that was using naive values to be aware as well. The docs have been updated to explain how to do this. This affects the following values:

* `Request`: `date`, `if_modified_since`, and `if_unmodified_since`.
* `parse_if_range_header()` and `IfRange.date`.
* `Response`: `date`, `expires`, `last_modified`, and `retry_after`. These values are typically only set, not read.

Behavior hasn't changed for passing parameters and setting properties, naive datetime values are still assumed to be UTC.

Removes the `_dump_date` function and replaces it with the built-in `email.utils.format_datetime` (and `formatdate` for timestamp values). This does mean that `struct_time` tuples aren't accepted anymore, but that was never publicly documented. Similarly, `parse_date` uses `email.utils.parsedate_to_datetime`.

Deprecated `cookie_date`. I can't find any modern standards stating that `Set-Cookie expires` needs to be `-` delimited, and a survey of various popular sites show them mostly sending standard HTTP dates, or occasionally mixing the two formats. This suggests that the `-` format was for very old browser support, which we've dropped in other places already.

- closes #1900 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
