### PR TITLE
test client response.close() closes input stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,9 @@ Unreleased
     add an ``Authorization`` header. It can be an ``Authorization``
     object or a ``(username, password)`` tuple for ``Basic`` auth.
     :pr:`1809`
+-   Calling ``response.close()`` on a response from the test ``Client``
+    will close the request input stream. This matches file behavior
+    and can prevent a ``ResourceWarning`` in some cases. :issue:`1785`
 -   ``EnvironBuilder.from_environ`` decodes values encoded for WSGI, to
     avoid double encoding the new values. :pr:`1959`
 -   The default stat reloader will watch Python files under

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -361,9 +361,9 @@ class Request(_SansIORequest):
         _assert_not_shallow(self)
         return get_input_stream(self.environ)
 
-    input_stream = environ_property(
+    input_stream = environ_property[t.BinaryIO](
         "wsgi.input",
-        """The WSGI input stream.
+        doc="""The WSGI input stream.
 
         In general it's a bad idea to use this one because you can
         easily read past the boundary.  Use the :attr:`stream`


### PR DESCRIPTION
When passing a large amount of data (> 500 KiB) with the test client, it uses a temporary file to store the encoded multipart form data. The test client has no way to close the file, and if it's left open after a test finishes Python may show a `ResourceWarning`. It's not entirely clear when Python decides to do this, pytest doesn't show it but unittest does, but neither show it with the latest Werkzeug code unless `-Walways` is used.

Now, the input stream is closed automatically when following redirects (except for 307 and 308, which preserve the body), and the final request's `stream.close` method is added to the response's `close` callbacks. So calling `response.close()` will close the input stream in addition to the response stream.

I couldn't figure out a reliable way to make a test for this, given how inconsistent the warning is in the first place, but all current tests pass.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #1785 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
