### PR TITLE
Fix dict interop regression for MultiDicts.

### DIFF
--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -355,6 +355,12 @@ class MultiDict(TypeConversionDict):
         dict.clear(self)
         dict.update(self, value)
 
+    def __iter__(self):
+        # Work around https://bugs.python.org/issue43246.
+        # (`return super().__iter__()` also works here, which makes this look
+        # even more like it should be a no-op, yet it isn't.)
+        return dict.__iter__(self)
+
     def __getitem__(self, key):
         """Return the first data value for this key;
         raises KeyError if not found.

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -70,6 +70,14 @@ class _MutableMultiDictTests:
             ud[b"newkey"] = b"bla"
             assert ud != d
 
+    def test_multidict_dict_interop(self):
+        # This would have caught the regression in Werkzeug 2.0.0rc1
+        # (see https://github.com/pallets/werkzeug/pull/2043).
+        md = self.storage_class([("a", 1), ("a", 2)])
+        assert dict(md)["a"] != [1, 2]
+        assert dict(md)["a"] == 1
+        assert dict(md) == {**md} == {"a": 1}
+
     def test_basic_interface(self):
         md = self.storage_class()
         assert isinstance(md, dict)


### PR DESCRIPTION
This issue was originally raised by @pgjones in https://github.com/pallets/werkzeug/pull/2042/commits/9b5e0d357e6ffe202c62f97c2de93d45e8a9afd7. I believe that the proposed fix in #2042 conflates the real issue, which is the `__iter__` implementation, by getting `keys()` and generators involved, which muddies the waters, and is not necessary to fix this. The explanation there also does not seem correct ("I think the PEP 448 implementation assumes that if the keys method is the standard dict method it can take an optimised code path that skips the overriden values/items methods"):
1. This PR demonstrates that `MultiDict.keys` can continue to resolve to `dict.keys` without triggering this behavior; this PR only makes `MultiDict.__iter__` resolve to its own implementation, rather than directly to dict's.
2. That said, since this new `MultiDict.__iter__` implementation just ends up calling dict’s `__iter__` implementation, it does seem plausible that merely the resolution of `MultiDict.__iter__` to its own implementation rather than directly to dict's is defeating some attempt to take an optimized code path that ends up causing incorrect results. This really seems like a gotcha (if not an outright bug?) in the language. It seems like an object’s behavior should remain exactly the same when a subclass implements a method that merely delegates to super()’s implementation. Fast-path optimizations should not cause entirely different results.

Added dedicated unit tests just for this, since it's super subtle and error-prone.