### PR TITLE
http_date accepts date and struct_time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,8 +98,6 @@ Unreleased
 -   ``utils.cookie_date`` is deprecated, use ``utils.http_date``
     instead. The value for ``Set-Cookie expires`` is no longer "-"
     delimited. :pr:`2040`
--   ``utils.http_date``, and attributes and values that use it, no
-    longer accept ``time.struct_time`` tuples. :pr:`2040`
 -   Use ``request.headers`` instead of ``request.environ`` to look up
     header attributes. :pr:`1808`
 -   The test ``Client`` request methods (``client.get``, etc.) always

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import date
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -713,6 +714,7 @@ def test_parse_date(value, expect):
         (datetime(999, 1, 1), "Tue, 01 Jan 0999 00:00:00 GMT"),
         (datetime(1000, 1, 1), "Wed, 01 Jan 1000 00:00:00 GMT"),
         (datetime(2020, 1, 1), "Wed, 01 Jan 2020 00:00:00 GMT"),
+        (date(2020, 1, 1), "Wed, 01 Jan 2020 00:00:00 GMT"),
     ],
 )
 def test_http_date(value, expect):


### PR DESCRIPTION
#2040 removed support for `struct_time` from `http_date`. This adds it back in, along with support for `date` objects. It assumes plain dates are midnight UTC.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- related to pallets/flask#3917

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
