### PR TITLE
Ensure that the asyncio locals test works with pypy3

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -58,6 +58,7 @@ def test_basic_local_asyncio(monkeypatch):
     # Reload the module to reset the patched change
     reload(local)
 
+
 def _test_basic_local_asyncio():
     ns = local.Local()
     ns.foo = 0


### PR DESCRIPTION
greenlet with pypy3 doesn't indicate that ContextVars are patched, yet
as greenlet is installed Werkzeug correctly falls back. This commit
forces stdlib ContextVars to be used by patching greenlet and then
reloading the local module (before resetting and reloading).
