### PR TITLE
Alter the local checking logic

### DIFF
--- a/src/werkzeug/local.py
+++ b/src/werkzeug/local.py
@@ -1,6 +1,7 @@
 import copy
 import math
 import operator
+import sys
 import typing as t
 import warnings
 from functools import partial
@@ -35,14 +36,11 @@ class _CannotUseContextVar(Exception):
 try:
     from contextvars import ContextVar
 
-    # If Greenlet is used, check it has patched ContextVars, Greenlet
-    # <0.4.17 does not.
-    try:
+    if "gevent" in sys.modules or "eventlet" in sys.modules:
+        # Both use greenlet, so first check it has patched
+        # ContextVars, Greenlet <0.4.17 does not.
         import greenlet
-    except ImportError:
-        # Not used
-        pass
-    else:
+
         greenlet_patched = getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False)
 
         if not greenlet_patched:


### PR DESCRIPTION
Pypy ships it's own Greenlet version which does not patch ContextVars,
however if Greenlet isn't used Pypy's ContextVars are fine. Therefore
the logic now checks if eventlet or gevent are imported (which implies
they is used). Thereby allowing real ContextVars to be used in pypy if
available but only if greenlet isn't used by eventlet or gevent. The
other logic remains as now.