### PR TITLE
fix connection reset when over max content size

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,6 +174,7 @@ Unreleased
 -   Updated ``UserAgentParser`` to handle more cases. :issue:`1971`
 -   ``werzeug.DechunkedInput.readinto`` will not read beyond the size of
     the buffer. :issue:`2021`
+-   Fix connection reset when exceeding max content size. :pr:`2051`
 
 
 Version 1.0.2

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -84,6 +84,22 @@ class TestFormParser:
         req.max_content_length = 4
         pytest.raises(RequestEntityTooLarge, lambda: req.form["foo"])
 
+        # when the request entity is too large, the input stream should be
+        # drained so that firefox (and others) do not report connection reset
+        # when run through gunicorn
+        # a sufficiently large stream is necessary for block-based reads
+        input_stream = io.BytesIO(b"foo=" + b"x" * 128 * 1024)
+        req = Request.from_values(
+            input_stream=input_stream,
+            content_length=len(data),
+            content_type="multipart/form-data; boundary=foo",
+            method="POST",
+        )
+        req.max_content_length = 4
+        pytest.raises(RequestEntityTooLarge, lambda: req.form["foo"])
+        # ensure that the stream is exhausted
+        assert input_stream.read() == b""
+
         req = Request.from_values(
             input_stream=io.BytesIO(data),
             content_length=len(data),


### PR DESCRIPTION
the current version of werkzeug fails to exhaust the input stream
when it detects that the content exceeds the configured max size.
when run with gunicorn, the stream is never exhausted which leads
to firefox (and others) reporting a connection reset as they
receive the response without the body being uploaded.

here's a sample application:

```python
from flask import Flask, request, redirect, url_for

class Config:
    SECRET_KEY = 'foo'
    MAX_CONTENT_LENGTH = 1024 * 1024 * 1

app = Flask(__name__)
app.config.from_object(Config)

@app.route('/')
def index():
    return '''\
<!doctype html>
<html>
  <head>
    <title>File Upload</title>
  </head>
  <body>
    <h1>File Upload</h1>
    <form method="POST" action="" enctype="multipart/form-data">
      <p><input type="file" name="file"></p>
      <p><input type="submit" value="Submit"></p>
    </form>
  </body>
</html>
'''

@app.route('/', methods=['POST'])
def upload_file():
    request.files['file']
    print('uploaded!')
    return redirect(url_for('index'))
```

when run with gunicorn:

```bash
strace -f gunicorn --bind 127.0.0.1:8080 app:app --access-logfile - 2> log
```

the strace indicates the following happens:

```
[pid 24372] recvfrom(9, "POST / HTTP/1.1\r\nHost: localhost"..., 8192, 0, NULL, NULL) = 8192
...
[pid 24372] sendto(9, "HTTP/1.1 413 REQUEST ENTITY TOO "..., 183, 0, NULL, 0) = 183
[pid 24372] sendto(9, "<!DOCTYPE HTML PUBLIC \"-//W3C//D"..., 196, 0, NULL, 0) = 196
```

in this, werkzeug reads the first 8KB of the request, but then never
any more and starts sending the response

after the fix, werkzeug reads the entire input (and discards it)
before sending a response

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code. **N/A**
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs. **N/A**
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
