### PR TITLE
Use realpath when checking potential library directories

### DIFF
--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -461,7 +461,8 @@ class Frame:
     @cached_property
     def is_library(self) -> bool:
         return any(
-            self.filename.startswith(os.path.realpath(path)) for path in sysconfig.get_paths().values()
+            self.filename.startswith(os.path.realpath(path))
+            for path in sysconfig.get_paths().values()
         )
 
     def render_text(self) -> str:

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -461,7 +461,7 @@ class Frame:
     @cached_property
     def is_library(self) -> bool:
         return any(
-            self.filename.startswith(path) for path in sysconfig.get_paths().values()
+            self.filename.startswith(os.path.realpath(path)) for path in sysconfig.get_paths().values()
         )
 
     def render_text(self) -> str:


### PR DESCRIPTION
Use realpath in `Frame.is_library`, consistent with realpath usage in `Frame.__init__` which sets the `self.filename` path being compared to.

- fixes #2072

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

I'm not too familiar with the werkzeug project, so wasn't sure about the rest of this checklist.  Open to suggestions for what is relevant for this change.
