### PR TITLE
Updated UserAgentParser to handle more use cases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -178,9 +178,10 @@ Version 1.0.2
 
 Unreleased
 
--   Add new "edg" identifier for Edge in UserAgentPreparser.
+-   Add new "edg" identifier for Edge in ``UserAgentParser``.
     :issue:`1797`
 -   Upgrade the debugger to jQuery 3.5.1. :issue:`1802`
+-   Updated ``UserAgentParser`` to handle more cases. :issue:`1971`
 
 
 Version 1.0.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,6 +171,7 @@ Unreleased
     useful for handling a WebSocket upgrade request. :issue:`2052`
 -   URL matching assumes ``websocket=True`` mode for WebSocket upgrade
     requests. :issue:`2052`
+-   Updated ``UserAgentParser`` to handle more cases. :issue:`1971`
 
 
 Version 1.0.2
@@ -181,7 +182,6 @@ Unreleased
 -   Add new "edg" identifier for Edge in ``UserAgentParser``.
     :issue:`1797`
 -   Upgrade the debugger to jQuery 3.5.1. :issue:`1802`
--   Updated ``UserAgentParser`` to handle more cases. :issue:`1971`
 
 
 Version 1.0.1

--- a/src/werkzeug/useragents.py
+++ b/src/werkzeug/useragents.py
@@ -84,8 +84,18 @@ class UserAgentParser:
                 break
         else:
             platform = None
+
+        # Except for Trident, all browser key words come after the last ')'
+        i = 0
+        if (
+            not re.compile(r"trident/.+? rv:", re.I).search(user_agent)
+            and ")" in user_agent
+            and user_agent[-1] != ")"
+        ):
+            i = user_agent.rindex(")")
+
         for browser, regex in self.browsers:  # noqa: B007
-            match = regex.search(user_agent)
+            match = regex.search(user_agent[i:])
             if match is not None:
                 version = match.group(1)
                 break

--- a/src/werkzeug/useragents.py
+++ b/src/werkzeug/useragents.py
@@ -86,16 +86,16 @@ class UserAgentParser:
             platform = None
 
         # Except for Trident, all browser key words come after the last ')'
-        i = 0
+        last_closing_paren = 0
         if (
             not re.compile(r"trident/.+? rv:", re.I).search(user_agent)
             and ")" in user_agent
             and user_agent[-1] != ")"
         ):
-            i = user_agent.rindex(")")
+            last_closing_paren = user_agent.rindex(")")
 
         for browser, regex in self.browsers:  # noqa: B007
-            match = regex.search(user_agent[i:])
+            match = regex.search(user_agent[last_closing_paren:])
             if match is not None:
                 version = match.group(1)
                 break

--- a/tests/test_useragents.py
+++ b/tests/test_useragents.py
@@ -30,7 +30,7 @@ from werkzeug import useragents
             None,
         ),
         (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4123.0 Safari/537.36 Edg/84.0.499.0 Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36",  # noqa B950
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4123.0 Safari/537.36 Edg/84.0.499.0",  # noqa B950
             "windows",
             "edge",
             "84.0.499.0",

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -446,8 +446,9 @@ def test_etag_request():
     assert request.if_unmodified_since == dt
 
 
-def test_user_agent():
-    user_agents = [
+@pytest.mark.parametrize(
+    ("user_agent", "browser", "platform", "version", "language"),
+    (
         (
             "Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US; rv:1.8.1.11) "
             "Gecko/20071127 Firefox/2.0.0.11",
@@ -626,19 +627,38 @@ def test_user_agent():
             "51.0.2704.106",
             None,
         ),
-    ]
-    for ua, browser, platform, version, lang in user_agents:
-        request = wrappers.Request(
-            {"HTTP_USER_AGENT": ua, "SERVER_NAME": "eggs", "SERVER_PORT": "80"}
-        )
-        assert request.user_agent.browser == browser
-        assert request.user_agent.platform == platform
-        assert request.user_agent.version == version
-        assert request.user_agent.language == lang
-        assert bool(request.user_agent)
-        assert request.user_agent.to_header() == ua
-        assert str(request.user_agent) == ua
+        (
+            "Mozilla/5.0 (Linux; Android; motorola edge) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36",
+            "chrome",
+            "android",
+            "85.0.4183.81",
+            None,
+        ),
+        (
+            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; "
+            ".NET CLR 1.1.4322)",
+            "msie",
+            "windows",
+            "7.0",
+            None,
+        ),
+    ),
+)
+def test_user_agent(user_agent, browser, platform, version, language):
+    request = wrappers.Request(
+        {"HTTP_USER_AGENT": user_agent, "SERVER_NAME": "eggs", "SERVER_PORT": "80"}
+    )
+    assert request.user_agent.browser == browser
+    assert request.user_agent.platform == platform
+    assert request.user_agent.version == version
+    assert request.user_agent.language == language
+    assert bool(request.user_agent)
+    assert request.user_agent.to_header() == user_agent
+    assert str(request.user_agent) == user_agent
 
+
+def test_invalid_user_agent():
     request = wrappers.Request(
         {"HTTP_USER_AGENT": "foo", "SERVER_NAME": "eggs", "SERVER_PORT": "80"}
     )


### PR DESCRIPTION
Upon examining the test cases from #1971, the last 2 work as expected. Since the `platform` part of the user agent contains `edge`, the incorrect browser and browser version are being matched. 

Except for `Trident`, browser-related key-words occur after the last closing parenthesis. So I've updated the parser to check if `Trident` isn't there then check for browsers after the platform part is over. I've also updated the tests related to user agents.

- fixes #1971 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
