### PR TITLE
DechunkedInput.readinto will not read more than size of the buffer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -172,6 +172,8 @@ Unreleased
 -   URL matching assumes ``websocket=True`` mode for WebSocket upgrade
     requests. :issue:`2052`
 -   Updated ``UserAgentParser`` to handle more cases. :issue:`1971`
+-   ``werzeug.DechunkedInput.readinto`` will not read beyond the size of
+    the buffer. :issue:`2021`
 
 
 Version 1.0.2


### PR DESCRIPTION
Added a check in `DechunkedInput.readinto` to see if `read + chunk size` exceeds the buffer length. If it exceeds, then only read as much data as can fit inside the buffer without growing the buffer to accommodate extra bytes. The `client-server` example mentioned in the issue, now runs successfully.

- fixes #2021 

Checklist:

- [x] Add tests that demonstrate the correct behaviour of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
