### PR TITLE
Deprecate user agent parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Unreleased
     :issue:`1834`
 -   Deprecate the ``environ["werkzeug.server.shutdown"]`` function
     that is available when running the development server. :issue:`1752`
+-   Deprecate the ``useragents`` module and the built-in user agent
+    parser. Use a dedicated parser library instead by subclassing
+    ``user_agent.UserAgent`` and setting ``Request.user_agent_class``.
+    :issue:`2078`
 -   Remove the unused, internal ``posixemulation`` module. :issue:`1759`
 -   All ``datetime`` values are timezone-aware with
     ``tzinfo=timezone.utc``. This applies to anything using

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,8 @@ extensions = [
     "sphinx_issues",
     "sphinxcontrib.log_cabinet",
 ]
+autoclass_content = "both"
+autodoc_typehints = "description"
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 issues_github_path = "pallets/werkzeug"
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -124,7 +124,6 @@ so that we can play with it:
 
 >>> environ = create_environ()
 >>> environ.update(
-...     HTTP_USER_AGENT='Mozilla/5.0 (Macintosh; U; Mac OS X 10.5; en-US; ) Firefox/3.1',
 ...     HTTP_ACCEPT='text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
 ...     HTTP_ACCEPT_LANGUAGE='de-at,en-us;q=0.8,en;q=0.5',
 ...     HTTP_ACCEPT_ENCODING='gzip,deflate',
@@ -136,20 +135,9 @@ so that we can play with it:
 ...
 >>> request = Request(environ)
 
-Let's start with the most useless header: the user agent:
-
->>> request.user_agent.browser
-'firefox'
->>> request.user_agent.platform
-'macos'
->>> request.user_agent.version
-'3.1'
->>> request.user_agent.language
-'en-US'
-
-A more useful header is the accept header.  With this header the browser
-informs the web application what mimetypes it can handle and how well.  All
-accept headers are sorted by the quality, the best item being the first:
+With the accept header the browser informs the web application what
+mimetypes it can handle and how well. All accept headers are sorted by
+the quality, the best item being the first:
 
 >>> request.accept_mimetypes.best
 'text/html'

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -51,13 +51,31 @@ URL Helpers
 
 Please refer to :doc:`urls`.
 
-UserAgent Parsing
-=================
+
+User Agent API
+==============
+
+.. module:: werkzeug.user_agent
+
+.. autoclass:: UserAgent
+    :members:
+    :member-order: bysource
+
+
+UserAgent Parsing (deprecated)
+==============================
 
 .. module:: werkzeug.useragents
 
+.. deprecated:: 2.0.0
+    This module will be removed in Werkzeug 2.1. Subclass
+    :class:`werkzeug.user_agent.UserAgent` to use a dedicated parser
+    instead.
+
 .. autoclass:: UserAgent
-   :members:
+    :members:
+    :inherited-members:
+    :member-order: bysource
 
 
 Security Helpers

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -28,7 +28,8 @@ from ..http import parse_options_header
 from ..http import parse_range_header
 from ..http import parse_set_header
 from ..urls import url_decode
-from ..useragents import UserAgent
+from ..user_agent import UserAgent
+from ..useragents import UserAgent as _DeprecatedUserAgent
 from ..utils import cached_property
 from ..utils import header_property
 from .utils import get_current_url
@@ -93,6 +94,16 @@ class Request:
     #:
     #: .. versionadded:: 0.6
     list_storage_class: t.Type[t.List] = ImmutableList
+
+    user_agent_class = _DeprecatedUserAgent
+    """The class used and returned by the :attr:`user_agent` property to
+    parse the header. Defaults to
+    :class:`~werkzeug.user_agent.UserAgent`, which does no parsing. An
+    extension can provide a subclass that uses a parser to provide other
+    data.
+
+    .. versionadded:: 2.0.0
+    """
 
     #: Valid host names when handling requests. By default all hosts are
     #: trusted, which means that whatever the client says the host is
@@ -470,8 +481,16 @@ class Request:
 
     @cached_property
     def user_agent(self) -> UserAgent:
-        """The current user agent."""
-        return UserAgent(self.headers.get("User-Agent", ""))  # type: ignore
+        """The user agent. Use ``user_agent.string`` to get the header
+        value. Set :attr:`user_agent_class` to a subclass of
+        :class:`~werkzeug.user_agent.UserAgent` to provide parsing for
+        the other properties or other extended data.
+
+        .. versionchanged:: 2.0.0
+            The built in parser is deprecated, a ``UserAgent`` subclass
+            must be set to parse data from the string.
+        """
+        return self.user_agent_class(t.cast(str, self.headers.get("User-Agent", "")))
 
     # Authorization
 

--- a/src/werkzeug/user_agent.py
+++ b/src/werkzeug/user_agent.py
@@ -1,0 +1,47 @@
+import typing as t
+
+
+class UserAgent:
+    """Represents a parsed user agent header value.
+
+    The default implementation does no parsing, only the :attr:`string`
+    attribute is set. A subclass may parse the string to set the
+    common attributes or expose other information. Set
+    :attr:`werkzeug.wrappers.Request.user_agent_class` to use a
+    subclass.
+
+    :param string: The header value to parse.
+
+    .. versionadded:: 2.0.0
+        This replaces the previous ``useragents`` module, but does not
+        provide a built-in parser.
+    """
+
+    platform: t.Optional[str] = None
+    """The OS name, if it could be parsed from the string."""
+
+    browser: t.Optional[str] = None
+    """The browser name, if it could be parsed from the string."""
+
+    version: t.Optional[str] = None
+    """The browser version, if it could be parsed from the string."""
+
+    language: t.Optional[str] = None
+    """The browser language, if it could be parsed from the string."""
+
+    def __init__(self, string: str) -> None:
+        self.string: str = string
+        """The original header value."""
+
+    def __repr__(self):
+        return f"<{type(self).__name__} {self.browser}/{self.version}>"
+
+    def __str__(self) -> str:
+        return self.string
+
+    def __bool__(self) -> bool:
+        return bool(self.browser)
+
+    def to_header(self) -> str:
+        """Convert to a header value."""
+        return self.string

--- a/tests/test_useragents.py
+++ b/tests/test_useragents.py
@@ -46,5 +46,7 @@ from werkzeug import useragents
     ),
 )
 def test_edge_browsers(user_agent, platform, browser, version, language):
-    parsed = useragents.UserAgentParser()(user_agent)
+    with pytest.deprecated_call():
+        parsed = useragents.UserAgentParser()(user_agent)
+
     assert parsed == (platform, browser, version, language)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -649,20 +649,24 @@ def test_user_agent(user_agent, browser, platform, version, language):
     request = wrappers.Request(
         {"HTTP_USER_AGENT": user_agent, "SERVER_NAME": "eggs", "SERVER_PORT": "80"}
     )
-    assert request.user_agent.browser == browser
-    assert request.user_agent.platform == platform
-    assert request.user_agent.version == version
-    assert request.user_agent.language == language
-    assert bool(request.user_agent)
-    assert request.user_agent.to_header() == user_agent
-    assert str(request.user_agent) == user_agent
+
+    with pytest.deprecated_call():
+        assert request.user_agent.browser == browser
+        assert request.user_agent.platform == platform
+        assert request.user_agent.version == version
+        assert request.user_agent.language == language
+        assert bool(request.user_agent)
+        assert request.user_agent.to_header() == user_agent
+        assert str(request.user_agent) == user_agent
 
 
 def test_invalid_user_agent():
     request = wrappers.Request(
         {"HTTP_USER_AGENT": "foo", "SERVER_NAME": "eggs", "SERVER_PORT": "80"}
     )
-    assert not request.user_agent
+
+    with pytest.deprecated_call():
+        assert not request.user_agent
 
 
 def test_stream_wrapping():


### PR DESCRIPTION
When accessed through `Request.user_agent`, only the properties show warnings. When `UserAgent` or `UserAgentParser` is created by a user an additional warning is shown.

The new module is `user_agent` and contains the `UserAgent` base class that extensions should subclass to use dedicated parser library. It only accepts a string, not an environ, and sets the four existing attributes to `None`. `Request.user_agent_class` can be set to use a subclass.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2078 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
