### PR TITLE
`del` invalidates `cached_property`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,6 +181,8 @@ Unreleased
 -   Fix connection reset when exceeding max content size. :pr:`2051`
 -   ``pbkdf2_hex``, ``pbkdf2_bin``, and ``safe_str_cmp`` are deprecated.
     ``hashlib`` and ``hmac`` provide equivalents. :pr:`2083`
+-   ``invalidate_cached_property`` is deprecated. Use ``del obj.name``
+    instead. :pr:`2084`
 
 
 Version 1.0.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,40 +94,30 @@ def test_can_set_cached_property():
     assert a._prop == "value"
 
 
-def test_can_invalidate_cached_property():
-    foo = []
+def test_invalidate_cached_property():
+    accessed = 0
 
     class A:
+        @utils.cached_property
         def prop(self):
-            foo.append(42)
+            nonlocal accessed
+            accessed += 1
             return 42
-
-        prop = utils.cached_property(prop)
 
     a = A()
     p = a.prop
     q = a.prop
     assert p == q == 42
-    assert foo == [42]
+    assert accessed == 1
 
-    utils.invalidate_cached_property(a, "prop")
+    a.prop = 16
+    assert a.prop == 16
+    assert accessed == 1
+
+    del a.prop
     r = a.prop
     assert r == 42
-    assert foo == [42, 42]
-
-    s = a.prop
-    assert s == 42
-    assert foo == [42, 42]
-
-
-def test_invalidate_cached_property_on_non_property():
-    class A:
-        def __init__(self):
-            self.prop = 42
-
-    a = A()
-    with pytest.raises(TypeError):
-        utils.invalidate_cached_property(a, "prop")
+    assert accessed == 2
 
 
 def test_inspect_treats_cached_property_as_property():


### PR DESCRIPTION
I think using `del obj.name` makes more sense than `invalidate_cached_property(obj, "name")`, and doesn't require importing a separate function. I don't expect users to be invalidating/deleting non-cached-properties anyway, I don't think the extra check was giving us much.

Updated the test to test get, set, and delete.

cc @singingwolfboy

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
