### PR TITLE
deprecate more 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -187,7 +187,8 @@ Unreleased
     :pr:`2085`
 -   ``Request.disable_data_descriptor`` is deprecated. Create the
     request with ``shallow=True`` instead. :pr:`2085`
-
+-   ``HTTPException.wrap`` is deprecated. Create a subclass manually
+    instead. :pr:`2085`
 
 Version 1.0.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,6 +183,8 @@ Unreleased
     ``hashlib`` and ``hmac`` provide equivalents. :pr:`2083`
 -   ``invalidate_cached_property`` is deprecated. Use ``del obj.name``
     instead. :pr:`2084`
+-   ``Href`` is deprecated. Use ``werkzeug.routing`` instead.
+    :pr:`2085`
 
 
 Version 1.0.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -185,6 +185,8 @@ Unreleased
     instead. :pr:`2084`
 -   ``Href`` is deprecated. Use ``werkzeug.routing`` instead.
     :pr:`2085`
+-   ``Request.disable_data_descriptor`` is deprecated. Create the
+    request with ``shallow=True`` instead. :pr:`2085`
 
 
 Version 1.0.2

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -2,6 +2,7 @@ import base64
 import codecs
 import mimetypes
 import re
+import warnings
 from collections.abc import Collection
 from collections.abc import MutableSet
 from copy import deepcopy
@@ -1072,7 +1073,19 @@ class Headers:
             return False
         return True
 
-    has_key = __contains__
+    def has_key(self, key):
+        """
+        .. deprecated:: 2.0
+            Will be removed in Werkzeug 2.1. Use ``key in data``
+            instead.
+        """
+        warnings.warn(
+            "'has_key' is deprecated and will be removed in Werkzeug"
+            " 2.1. Use 'key in data' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return key in self
 
     def __iter__(self):
         """Yield ``(key, value)`` tuples."""
@@ -1525,7 +1538,19 @@ class CombinedMultiDict(ImmutableMultiDictMixin, MultiDict):
                 return True
         return False
 
-    has_key = __contains__
+    def has_key(self, key):
+        """
+        .. deprecated:: 2.0
+            Will be removed in Werkzeug 2.1. Use ``key in data``
+            instead.
+        """
+        warnings.warn(
+            "'has_key' is deprecated and will be removed in Werkzeug"
+            " 2.1. Use 'key in data' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return key in self
 
     def __repr__(self):
         return f"{type(self).__name__}({self.dicts!r})"

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -1966,15 +1966,29 @@ class CharsetAccept(Accept):
         return item == "*" or _normalize(value) == _normalize(item)
 
 
-def cache_property(key, empty, type):
-    """Return a new property object for a cache header.  Useful if you
-    want to add support for a cache extension in a subclass."""
+def cache_control_property(key, empty, type):
+    """Return a new property object for a cache header. Useful if you
+    want to add support for a cache extension in a subclass.
+
+    .. versionchanged:: 2.0
+        Renamed from ``cache_property``.
+    """
     return property(
         lambda x: x._get_cache_value(key, empty, type),
         lambda x, v: x._set_cache_value(key, v, type),
         lambda x: x._del_cache_value(key),
         f"accessor for {key!r}",
     )
+
+
+def cache_property(key, empty, type):
+    warnings.warn(
+        "'cache_property' is renamed to 'cache_control_property'. The"
+        " old name is deprecated and will be removed in Werkzeug 2.1.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return cache_control_property(key, empty, type)
 
 
 class _CacheControl(UpdateDictMixin, dict):
@@ -2009,10 +2023,10 @@ class _CacheControl(UpdateDictMixin, dict):
        no longer existing `CacheControl` class.
     """
 
-    no_cache = cache_property("no-cache", "*", None)
-    no_store = cache_property("no-store", None, bool)
-    max_age = cache_property("max-age", -1, int)
-    no_transform = cache_property("no-transform", None, None)
+    no_cache = cache_control_property("no-cache", "*", None)
+    no_store = cache_control_property("no-store", None, bool)
+    max_age = cache_control_property("max-age", -1, int)
+    no_transform = cache_control_property("no-transform", None, None)
 
     def __init__(self, values=(), on_update=None):
         dict.__init__(self, values or ())
@@ -2066,7 +2080,7 @@ class _CacheControl(UpdateDictMixin, dict):
         kv_str = " ".join(f"{k}={v!r}" for k, v in sorted(self.items()))
         return f"<{type(self).__name__} {kv_str}>"
 
-    cache_property = staticmethod(cache_property)
+    cache_property = staticmethod(cache_control_property)
 
 
 class RequestCacheControl(ImmutableDictMixin, _CacheControl):
@@ -2083,9 +2097,9 @@ class RequestCacheControl(ImmutableDictMixin, _CacheControl):
        both for request and response.
     """
 
-    max_stale = cache_property("max-stale", "*", int)
-    min_fresh = cache_property("min-fresh", "*", int)
-    only_if_cached = cache_property("only-if-cached", None, bool)
+    max_stale = cache_control_property("max-stale", "*", int)
+    min_fresh = cache_control_property("min-fresh", "*", int)
+    only_if_cached = cache_control_property("only-if-cached", None, bool)
 
 
 class ResponseCacheControl(_CacheControl):
@@ -2103,12 +2117,12 @@ class ResponseCacheControl(_CacheControl):
        both for request and response.
     """
 
-    public = cache_property("public", None, bool)
-    private = cache_property("private", "*", None)
-    must_revalidate = cache_property("must-revalidate", None, bool)
-    proxy_revalidate = cache_property("proxy-revalidate", None, bool)
-    s_maxage = cache_property("s-maxage", None, None)
-    immutable = cache_property("immutable", None, bool)
+    public = cache_control_property("public", None, bool)
+    private = cache_control_property("private", "*", None)
+    must_revalidate = cache_control_property("must-revalidate", None, bool)
+    proxy_revalidate = cache_control_property("proxy-revalidate", None, bool)
+    s_maxage = cache_control_property("s-maxage", None, None)
+    immutable = cache_control_property("immutable", None, bool)
 
 
 def csp_property(key):

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -885,8 +885,6 @@ def url_decode_stream(
     directly fed to the `cls` so you can consume the data while it's
     parsed.
 
-    .. versionadded:: 0.8
-
     :param stream: a stream with the encoded querystring
     :param charset: the charset of the query string.  If set to `None`
         no decoding will take place.
@@ -898,13 +896,10 @@ def url_decode_stream(
                        or `None` the default :class:`MultiDict` is used.
     :param limit: the content length of the URL data.  Not necessary if
                   a limited stream is provided.
-    :param return_iterator: if set to `True` the `cls` argument is ignored
-                            and an iterator over all decoded pairs is
-                            returned
 
     .. versionchanged:: 2.0
-        The ``decode_keys`` parameter is deprecated and will be removed
-        in Werkzeug 2.1.
+        The ``decode_keys`` and ``return_iterator`` parameters are
+        deprecated and will be removed in Werkzeug 2.1.
 
     .. versionadded:: 0.8
     """
@@ -921,6 +916,11 @@ def url_decode_stream(
     decoder = _url_decode_impl(pair_iter, charset, include_empty, errors)
 
     if return_iterator:
+        warnings.warn(
+            "'return_iterator' is deprecated and will be removed in Werkzeug 2.1.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return decoder  # type: ignore
 
     if cls is None:

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -1152,11 +1152,22 @@ class Href:
     >>> href(a=1, b=2, c=3)
     '/?a=1&b=2&c=3'
 
+    .. deprecated:: 2.0
+        Will be removed in Werkzeug 2.1. Use :mod:`werkzeug.routing`
+        instead.
+
     .. versionadded:: 0.5
         `sort` and `key` were added.
     """
 
     def __init__(self, base="./", charset="utf-8", sort=False, key=None):
+        warnings.warn(
+            "'Href' is deprecated and will be removed in Werkzeug 2.1."
+            " Use 'werkzeug.routing' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if not base:
             base = "./"
         self.base = base

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -356,8 +356,18 @@ def detect_utf_encoding(data: bytes) -> str:
     :param data: Bytes in unknown UTF encoding.
     :return: UTF encoding name
 
+    .. deprecated:: 2.0
+        Will be removed in Werkzeug 2.1. This is built in to
+        :func:`json.loads`.
+
     .. versionadded:: 0.15
     """
+    warnings.warn(
+        "'detect_utf_encoding' is deprecated and will be removed in"
+        " Werkzeug 2.1. This is built in to 'json.loads'.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     head = data[:4]
 
     if head[:3] == codecs.BOM_UTF8:

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -274,41 +274,6 @@ def test_multidict_encoding():
     )
 
 
-def test_href():
-    x = urls.Href("http://www.example.com/")
-    assert x("foo") == "http://www.example.com/foo"
-    assert x.foo("bar") == "http://www.example.com/foo/bar"
-    assert x.foo("bar", x=42) == "http://www.example.com/foo/bar?x=42"
-    assert x.foo("bar", class_=42) == "http://www.example.com/foo/bar?class=42"
-    assert x.foo("bar", {"class": 42}) == "http://www.example.com/foo/bar?class=42"
-    pytest.raises(AttributeError, lambda: x.__blah__)
-
-    x = urls.Href("blah")
-    assert x.foo("bar") == "blah/foo/bar"
-
-    pytest.raises(TypeError, x.foo, {"foo": 23}, x=42)
-
-    x = urls.Href("")
-    assert x("foo") == "foo"
-
-
-def test_href_url_join():
-    x = urls.Href("test")
-    assert x("foo:bar") == "test/foo:bar"
-    assert x("http://example.com/") == "test/http://example.com/"
-    assert x.a() == "test/a"
-
-
-def test_href_past_root():
-    base_href = urls.Href("http://www.blagga.com/1/2/3")
-    assert base_href("../foo") == "http://www.blagga.com/1/2/foo"
-    assert base_href("../../foo") == "http://www.blagga.com/1/foo"
-    assert base_href("../../../foo") == "http://www.blagga.com/foo"
-    assert base_href("../../../../foo") == "http://www.blagga.com/foo"
-    assert base_href("../../../../../foo") == "http://www.blagga.com/foo"
-    assert base_href("../../../../../../foo") == "http://www.blagga.com/foo"
-
-
 def test_url_unquote_plus_unicode():
     # was broken in 0.6
     assert urls.url_unquote_plus("\x6d") == "\x6d"

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -104,19 +104,6 @@ def test_url_bytes_decoding():
     assert x[b"uni"] == "Hänsel".encode()
 
 
-def test_streamed_url_decoding():
-    item1 = "a" * 100000
-    item2 = "b" * 400
-    string = (f"a={item1}&b={item2}&c={item2}").encode("ascii")
-    gen = urls.url_decode_stream(
-        io.BytesIO(string), limit=len(string), return_iterator=True
-    )
-    assert next(gen) == ("a", item1)
-    assert next(gen) == ("b", item2)
-    assert next(gen) == ("c", item2)
-    pytest.raises(StopIteration, lambda: next(gen))
-
-
 def test_stream_decoding_string_fails():
     pytest.raises(TypeError, urls.url_decode_stream, "testing")
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1021,7 +1021,9 @@ def test_shallow_mode():
         shallow=True,
     )
     assert request.args["foo"] == "bar"
-    pytest.raises(RuntimeError, lambda: request.form["foo"])
+    pytest.raises(RuntimeError, lambda: request.stream)
+    pytest.raises(RuntimeError, lambda: request.data)
+    pytest.raises(RuntimeError, lambda: request.form)
 
 
 def test_form_parsing_failed():


### PR DESCRIPTION
Deprecate various things I came across while adding typing to the code. These either seem unused or caused issues with typing, or both.

* `urls.Href` seems to have been replaced by `werkzeug.routing`.
* `utils.detect_utf_encoding` was probably used by Flask, so I'm issuing a deprecation warning just in case someone uses an older Flask with Werkzeug 2.0. This function is part of Python's `json.loads` now.
* `CombinedMultiDict` and `Headers` both had a `has_key` alias for `__contains__`. `has_key` has been deprecated since Python 2.
* `Request.disable_data_descriptor` class attribute. There's an old comment about deprecating the `request.data` attribute, but I don't think that should be done. `shallow=True` can be used to the same effect.
* There's an (internal) helper called `cache_property`, renamed it `cache_control_property` to avoid confusion with `cached_property`, especially when using IDEs to find names.
* `url_decode_stream` had a `return_iterator` flag that was unused anywhere in the code.
* `HTTPException.wrap` seems to only be used to create the `BadRequestKeyError` class. It's more straightforward to create the class manually, and the type system understands it better too.

One that I did not remove was the `parse_option_header` `multiple` parameter. It's not used anywhere, but it's the majority of the function, and I think it could be refactored differently later.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
