### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/examples/cupoftee/application.py
+++ b/examples/cupoftee/application.py
@@ -84,7 +84,7 @@ class Cup:
         self.db = Database(database)
         self.master = ServerBrowser(self)
         self.updater = Thread(None, self.update_master)
-        self.updater.setDaemon(True)
+        self.updater.daemon = True
         self.updater.start()
 
     def update_master(self):

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -417,7 +417,7 @@ def run_with_reloader(
         if os.environ.get("WERKZEUG_RUN_MAIN") == "true":
             ensure_echo_on()
             t = threading.Thread(target=main_func, args=())
-            t.setDaemon(True)
+            t.daemon = True
 
             # Enter the reloader to set up initial state, then start
             # the app thread and reloader update loop.


### PR DESCRIPTION
- fixes #2087 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
