### PR TITLE
Do not deprecate access to unparsed user_agent

### DIFF
--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -29,7 +29,7 @@ from ..http import parse_range_header
 from ..http import parse_set_header
 from ..urls import url_decode
 from ..user_agent import UserAgent
-from ..useragents import UserAgent as _DeprecatedUserAgent
+from ..useragents import _UserAgent as _DeprecatedUserAgent
 from ..utils import cached_property
 from ..utils import header_property
 from .utils import get_current_url

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -646,18 +646,37 @@ def test_etag_request():
     ),
 )
 def test_user_agent(user_agent, browser, platform, version, language):
-    request = wrappers.Request(
-        {"HTTP_USER_AGENT": user_agent, "SERVER_NAME": "eggs", "SERVER_PORT": "80"}
-    )
+    request = wrappers.Request({"HTTP_USER_AGENT": user_agent})
+
+    assert request.user_agent.to_header() == user_agent
+    assert str(request.user_agent) == user_agent
+    assert request.user_agent.string == user_agent
 
     with pytest.deprecated_call():
         assert request.user_agent.browser == browser
+
+    with pytest.deprecated_call():
         assert request.user_agent.platform == platform
+
+    with pytest.deprecated_call():
         assert request.user_agent.version == version
+
+    with pytest.deprecated_call():
         assert request.user_agent.language == language
+
+    with pytest.deprecated_call():
         assert bool(request.user_agent)
-        assert request.user_agent.to_header() == user_agent
-        assert str(request.user_agent) == user_agent
+
+    from werkzeug import useragents
+
+    with pytest.deprecated_call():
+        useragents.UserAgent("")
+
+    with pytest.deprecated_call(match="environ"):
+        useragents.UserAgent({})
+
+    with pytest.deprecated_call():
+        useragents.UserAgentParser()
 
 
 def test_invalid_user_agent():


### PR DESCRIPTION
I also made the test more explicit to ensure that everything that's deprecated actually needs to trigger a deprecation warning

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
