### PR TITLE
use chunked encoding for streaming responses with HTTP/1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ Unreleased
 -   Optimize the stat reloader to avoid watching unnecessary files in
     more cases. The watchdog reloader is still recommended for
     performance and accuracy. :issue:`2141`
+-   The development server uses ``Transfer-Encoding: chunked`` for
+    streaming responses when it is configured for HTTP/1.1.
+    :issue:`2090, 1327`, :pr:`2091`
 
 
 Version 2.0.3

--- a/tests/live_apps/run.py
+++ b/tests/live_apps/run.py
@@ -4,8 +4,14 @@ from importlib import import_module
 
 from werkzeug.serving import generate_adhoc_ssl_context
 from werkzeug.serving import run_simple
+from werkzeug.serving import WSGIRequestHandler
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
+
+
+class WSGI11RequestHandler(WSGIRequestHandler):
+    protocol_version = "HTTP/1.1"
+
 
 name = sys.argv[1]
 mod = import_module(f"{name}_app")
@@ -23,6 +29,9 @@ kwargs = getattr(mod, "kwargs", {})
 kwargs.update(hostname="127.0.0.1", port=5000, application=app)
 kwargs.update(json.loads(sys.argv[2]))
 ssl_context = kwargs.get("ssl_context")
+
+if kwargs.get("request_handler") == "HTTP/1.1":
+    kwargs["request_handler"] = WSGI11RequestHandler
 
 if ssl_context == "custom":
     kwargs["ssl_context"] = generate_adhoc_ssl_context()

--- a/tests/live_apps/streaming_app.py
+++ b/tests/live_apps/streaming_app.py
@@ -1,0 +1,14 @@
+from werkzeug.wrappers import Request
+from werkzeug.wrappers import Response
+
+
+@Request.application
+def app(request):
+    def gen():
+        for x in range(5):
+            yield f"{x}\n"
+
+        if request.path == "/crash":
+            raise Exception("crash requested")
+
+    return Response(gen())


### PR DESCRIPTION
This approach differs a bit from the approach in PR#1328, in that it is completely contained in the server without any change in the application. (As per RFC, no reliance on hop-by-hop headers). It is triggered if HTTP/1.1 is configured (such as by specifying a subclass of request_handler), at which point `Connection: close` behavior is always replaced with `Transfer-Encoding: chunked`. The rationale is that any spec-compliant HTTP client must support this, so it should not cause any unjustifiable regressions for clients. From what I've seen, this seems to also match behavior in other WSGI-servers to ensure the apps behave consistently across test/prod.

- fixes #1327
- fixes #2090
- previous attempt: #1328

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
