### PR TITLE
Fix LocalStack mutable list issue

### DIFF
--- a/src/werkzeug/local.py
+++ b/src/werkzeug/local.py
@@ -219,10 +219,9 @@ class LocalStack:
 
     def push(self, obj: t.Any) -> t.List[t.Any]:
         """Pushes a new item to the stack"""
-        rv = getattr(self._local, "stack", None)
-        if rv is None:
-            self._local.stack = rv = []
+        rv = getattr(self._local, "stack", []).copy()
         rv.append(obj)
+        self._local.stack = rv
         return rv
 
     def pop(self) -> t.Any:

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -107,6 +107,23 @@ def test_local_stack():
 
 
 @pytest.mark.skipif(
+    sys.version_info < (3, 7),
+    reason="Locals are not task local in Python 3.6",
+)
+def test_local_stack_asyncio():
+    ls = local.LocalStack()
+    ls.push(1)
+
+    async def task():
+        ls.push(1)
+        assert len(ls._local.stack) == 2
+
+    loop = asyncio.get_event_loop()
+    futures = [asyncio.ensure_future(task()) for _ in range(3)]
+    loop.run_until_complete(asyncio.gather(*futures))
+
+
+@pytest.mark.skipif(
     sys.version_info > (3, 6),
     reason="The ident is not supported in  Python3.7 or higher",
 )


### PR DESCRIPTION
The stack stored by a LocalStack should be inherited from any parent
context, but crucially and changes to it should be local to its
context. This didn't happen previously as lists are mutable and the
list instance was being shared between the contexts. This change, much
like the local dictionary usage, now takes a copy and more explicitly
separates the contexts.

Thanks to @miguelgrinberg for pointing out this issue. Fixes #2102

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
