### PR TITLE
fix iterating over multidict keys

### DIFF
--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -726,7 +726,8 @@ class OrderedMultiDict(MultiDict):
     def keys(self):
         return (key for key, value in self.items())
 
-    __iter__ = keys
+    def __iter__(self):
+        return iter(self.keys())
 
     def values(self):
         return (value for key, value in self.items())
@@ -1476,7 +1477,8 @@ class CombinedMultiDict(ImmutableMultiDictMixin, MultiDict):
     def keys(self):
         return self._keys_impl()
 
-    __iter__ = keys
+    def __iter__(self):
+        return iter(self.keys())
 
     def items(self, multi=False):
         found = set()


### PR DESCRIPTION
`__iter__ = keys` only works if `keys` returns an iterator, but that's not required, it was failing when `keys` returned a set.

- fixes #2105 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
