### PR TITLE
fix max_age typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.0.1
 
 Unreleased
 
+-   Fix type annotation for ``send_file`` ``max_age`` callable. Don't
+    pass ``pathlib.Path`` to ``max_age``. :issue:`2119`
+
 
 Version 2.0.0
 -------------


### PR DESCRIPTION
`max_age` doesn't accept `pathlib.Path`, and may return `None`. Update `send_file` to use a string path instead of `pathlib.Path` internally, the `Path` object was more trouble than the string. `Path` is still supported, just not used internally.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2119 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
