### PR TITLE
Update typing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
     pass ``pathlib.Path`` to ``max_age``. :issue:`2119`
 -   Mark top-level names as exported so type checking understands
     imports in user projects. :issue:`2122`
+-   Fix some types that weren't available in Python 3.6.0. :issue:`2123`
 
 
 Version 2.0.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Fix type annotation for ``send_file`` ``max_age`` callable. Don't
     pass ``pathlib.Path`` to ``max_age``. :issue:`2119`
+-   Mark top-level names as exported so type checking understands
+    imports in user projects. :issue:`2122`
 
 
 Version 2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,9 +102,6 @@ warn_unused_ignores = True
 warn_return_any = True
 # warn_unreachable = True
 
-[mypy-werkzeug]
-no_implicit_reexport = False
-
 [mypy-werkzeug.wrappers]
 no_implicit_reexport = False
 

--- a/src/werkzeug/__init__.py
+++ b/src/werkzeug/__init__.py
@@ -1,6 +1,6 @@
-from .serving import run_simple
-from .test import Client
-from .wrappers import Request
-from .wrappers import Response
+from .serving import run_simple as run_simple
+from .test import Client as Client
+from .wrappers import Request as Request
+from .wrappers import Response as Response
 
 __version__ = "2.0.1.dev0"

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -52,6 +52,7 @@ from html import escape
 from ._internal import _get_environ
 
 if t.TYPE_CHECKING:
+    import typing_extensions as te
     from wsgiref.types import StartResponse
     from wsgiref.types import WSGIEnvironment
     from .datastructures import WWWAuthenticate
@@ -903,7 +904,7 @@ class Aborter:
 
     def __call__(
         self, code: t.Union[int, "Response"], *args: t.Any, **kwargs: t.Any
-    ) -> t.NoReturn:
+    ) -> "te.NoReturn":
         from .sansio.response import Response
 
         if isinstance(code, Response):
@@ -917,7 +918,7 @@ class Aborter:
 
 def abort(
     status: t.Union[int, "Response"], *args: t.Any, **kwargs: t.Any
-) -> t.NoReturn:
+) -> "te.NoReturn":
     """Raises an :py:exc:`HTTPException` for the given status code or WSGI
     application.
 

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -32,11 +32,12 @@ except ImportError:
     SpooledTemporaryFile = None  # type: ignore
 
 if t.TYPE_CHECKING:
+    import typing as te
     from wsgiref.types import WSGIEnvironment
 
     t_parse_result = t.Tuple[t.BinaryIO, MultiDict, MultiDict]
 
-    class TStreamFactory(t.Protocol):
+    class TStreamFactory(te.Protocol):
         def __call__(
             self,
             total_content_length: t.Optional[int],
@@ -402,7 +403,7 @@ class MultiPartParser:
 
         self.buffer_size = buffer_size
 
-    def fail(self, message: str) -> "t.NoReturn":
+    def fail(self, message: str) -> "te.NoReturn":
         raise ValueError(message)
 
     def get_part_charset(self, headers: Headers) -> str:

--- a/src/werkzeug/wrappers/__init__.py
+++ b/src/werkzeug/wrappers/__init__.py
@@ -8,9 +8,9 @@ from .common_descriptors import CommonResponseDescriptorsMixin
 from .etag import ETagRequestMixin
 from .etag import ETagResponseMixin
 from .request import PlainRequest
-from .request import Request
+from .request import Request as Request
 from .request import StreamOnlyMixin
-from .response import Response
+from .response import Response as Response
 from .response import ResponseStream
 from .response import ResponseStreamMixin
 from .user_agent import UserAgentMixin


### PR DESCRIPTION
- Mark top-level names as exported. fixes #2122
- Fix some types that weren't available in Python 3.6.0. fixes #2123