### PR TITLE
convert `HTTPException.description` to string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
     characters. :issue:`2125`
 -   Type checking understands that calling ``headers.get`` with a string
     default will always return a string. :issue:`2128`
+-   If ``HTTPException.description`` is not a string,
+    ``get_description`` will convert it to a string. :issue:`2115`
 
 
 Version 2.0.0

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -156,7 +156,14 @@ class HTTPException(Exception):
         scope: t.Optional[dict] = None,
     ) -> str:
         """Get the description."""
-        description = escape(self.description).replace("\n", "<br>")  # type: ignore
+        if self.description is None:
+            description = ""
+        elif not isinstance(self.description, str):
+            description = str(self.description)
+        else:
+            description = self.description
+
+        description = escape(description).replace("\n", "<br>")
         return f"<p>{description}</p>"
 
     def get_body(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -142,3 +142,7 @@ def test_passing_response(cls):
     exc = cls(response=TestResponse())
     rp = exc.get_response({})
     assert isinstance(rp, TestResponse)
+
+
+def test_description_none():
+    HTTPException().get_response()


### PR DESCRIPTION
Allows `HTTPDescription` to be `None` again. Additionally allows it to be another object like a dict, which seems to a pattern that is used to pass structured information to turn into a JSON response. I'm not sure that's actually documented as supported, so I'm not changing the type annotations for now.

- fixes #2115 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
