### PR TITLE
use _typeshed.wsgi instead of wsgiref.types

### DIFF
--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -13,9 +13,9 @@ from itertools import chain
 from weakref import WeakKeyDictionary
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
     from .wrappers.request import Request  # noqa: F401
 
 _logger: t.Optional[logging.Logger] = None

--- a/src/werkzeug/datastructures.pyi
+++ b/src/werkzeug/datastructures.pyi
@@ -20,7 +20,7 @@ from typing import Tuple
 from typing import Type
 from typing import TypeVar
 from typing import Union
-from wsgiref.types import WSGIEnvironment
+from _typeshed.wsgi import WSGIEnvironment
 
 from typing_extensions import Literal
 

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -25,9 +25,9 @@ from .tbtools import render_console_html
 from .tbtools import Traceback
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 # A week
 PIN_TIME = 60 * 60 * 24 * 7

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -53,8 +53,8 @@ from ._internal import _get_environ
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIEnvironment
     from .datastructures import WWWAuthenticate
     from .sansio.response import Response
     from .wrappers.response import Response as WSGIResponse  # noqa: F401

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -33,7 +33,7 @@ except ImportError:
 
 if t.TYPE_CHECKING:
     import typing as te
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIEnvironment
 
     t_parse_result = t.Tuple[t.BinaryIO, MultiDict, MultiDict]
 

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -26,7 +26,7 @@ from werkzeug._internal import _dt_as_utc
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIEnvironment
 
 # for explanation of "media-range", etc. see Sections 5.3.{1,2} of RFC 7231
 _accept_re = re.compile(

--- a/src/werkzeug/local.py
+++ b/src/werkzeug/local.py
@@ -10,9 +10,9 @@ from functools import update_wrapper
 from .wsgi import ClosingIterator
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 F = t.TypeVar("F", bound=t.Callable[..., t.Any])
 

--- a/src/werkzeug/middleware/dispatcher.py
+++ b/src/werkzeug/middleware/dispatcher.py
@@ -33,9 +33,9 @@ and the static files would be served directly by the HTTP server.
 import typing as t
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class DispatcherMiddleware:

--- a/src/werkzeug/middleware/http_proxy.py
+++ b/src/werkzeug/middleware/http_proxy.py
@@ -17,9 +17,9 @@ from ..urls import url_quote
 from ..wsgi import get_input_stream
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class ProxyMiddleware:

--- a/src/werkzeug/middleware/lint.py
+++ b/src/werkzeug/middleware/lint.py
@@ -22,9 +22,9 @@ from ..http import is_entity_header
 from ..wsgi import FileWrapper
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class WSGIWarning(Warning):

--- a/src/werkzeug/middleware/profiler.py
+++ b/src/werkzeug/middleware/profiler.py
@@ -23,9 +23,9 @@ except ImportError:
     from profile import Profile  # type: ignore
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class ProfilerMiddleware:

--- a/src/werkzeug/middleware/proxy_fix.py
+++ b/src/werkzeug/middleware/proxy_fix.py
@@ -26,9 +26,9 @@ import typing as t
 from ..http import parse_list_header
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class ProxyFix:

--- a/src/werkzeug/middleware/shared_data.py
+++ b/src/werkzeug/middleware/shared_data.py
@@ -31,9 +31,9 @@ _TOpener = t.Callable[[], t.Tuple[t.BinaryIO, datetime, int]]
 _TLoader = t.Callable[[t.Optional[str]], t.Tuple[t.Optional[str], t.Optional[_TOpener]]]
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class SharedDataMiddleware:

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -140,8 +140,8 @@ from .wsgi import get_host
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
     from .wrappers.response import Response
 
 _rule_re = re.compile(

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -75,8 +75,8 @@ _TSSLContextArg = t.Optional[
 
 if t.TYPE_CHECKING:
     import typing_extensions as te  # noqa: F401
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
     from cryptography.hazmat.primitives.asymmetric.rsa import (
         RSAPrivateKeyWithSerialization,
     )

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -46,8 +46,8 @@ from .wsgi import ClosingIterator
 from .wsgi import get_current_url
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 def stream_encode_multipart(

--- a/src/werkzeug/testapp.py
+++ b/src/werkzeug/testapp.py
@@ -13,8 +13,8 @@ from .wrappers.request import Request
 from .wrappers.response import Response
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 logo = Response(

--- a/src/werkzeug/useragents.py
+++ b/src/werkzeug/useragents.py
@@ -5,7 +5,7 @@ import warnings
 from .user_agent import UserAgent as _BaseUserAgent
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class _UserAgentParser:

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -25,7 +25,7 @@ from .urls import url_quote
 from .wsgi import wrap_file
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIEnvironment
     from .wrappers.request import Request
     from .wrappers.response import Response
 

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -23,8 +23,8 @@ from werkzeug.exceptions import BadRequest
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 class Request(_SansIORequest):

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -23,9 +23,9 @@ from werkzeug.wsgi import _RangeWrapper
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
-    from wsgiref.types import StartResponse
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 def _warn_if_string(iterable: t.Iterable) -> None:

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -17,8 +17,8 @@ from .urls import url_parse
 from .urls import url_quote
 
 if t.TYPE_CHECKING:
-    from wsgiref.types import WSGIApplication
-    from wsgiref.types import WSGIEnvironment
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
 
 
 def responder(f: t.Callable[..., "WSGIApplication"]) -> "WSGIApplication":


### PR DESCRIPTION
`wsgiref.types` is a deprecated alias according to https://github.com/pallets/werkzeug/issues/2130#issuecomment-842398916.