### PR TITLE
Handle multiple tokens in Connection header when routing WebSocket

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.0.2
 
 Unreleased
 
+-   Handle multiple tokens in ``Connection`` header when routing
+    WebSocket requests. :issue:`2131`
+
 
 Version 2.0.1
 -------------

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1650,11 +1650,12 @@ class Map:
         environ = _get_environ(environ)
         wsgi_server_name = get_host(environ).lower()
         scheme = environ["wsgi.url_scheme"]
+        upgrade = any(
+            v.strip() == "upgrade"
+            for v in environ.get("HTTP_CONNECTION", "").lower().split(",")
+        )
 
-        if (
-            environ.get("HTTP_CONNECTION", "").lower() == "upgrade"
-            and environ.get("HTTP_UPGRADE", "").lower() == "websocket"
-        ):
+        if upgrade and environ.get("HTTP_UPGRADE", "").lower() == "websocket":
             scheme = "wss" if scheme == "https" else "ws"
 
         if server_name is None:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -73,6 +73,17 @@ def test_basic_routing():
     with pytest.raises(r.WebsocketMismatch):
         adapter.match("/ws", websocket=False)
 
+    adapter = map.bind_to_environ(
+        create_environ(
+            "/ws?foo=bar",
+            "http://example.org/",
+            headers=[("Connection", "keep-alive, Upgrade"), ("upgrade", "websocket")],
+        )
+    )
+    assert adapter.match("/ws") == ("ws", {})
+    with pytest.raises(r.WebsocketMismatch):
+        adapter.match("/ws", websocket=False)
+
 
 def test_merge_slashes_match():
     url_map = r.Map(


### PR DESCRIPTION
Parse the `Connection` header, in case it comes with multiple tokens (as seen in WebSocket requests sent by Firefox).

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2131 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
