### PR TITLE
address deprecation warnings from Python 3.10b1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,10 @@ class DevServerClient:
 
         if protocol == "https":
             if "context" not in kwargs:
-                kwargs["context"] = ssl.SSLContext()
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                context.check_hostname = False
+                context.verify_mode = ssl.CERT_NONE
+                kwargs["context"] = context
 
             return http.client.HTTPSConnection(self.addr, **kwargs)
 


### PR DESCRIPTION
* Use `asyncio.run` if available.
* Configure test client's `SSLContext` with protocol, allow self-signed certs.

- fixes #2137 