### PR TITLE
typing: MultiDict.update accepts Iterable Mapping values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Handle multiple tokens in ``Connection`` header when routing
     WebSocket requests. :issue:`2131`
 -   Set the debugger pin cookie secure flag when on https. :pr:`2150`
+-   Fix type annotation for ``MultiDict.update`` to accept iterable values
+    :pr:`2142`
 
 
 Version 2.0.1

--- a/src/werkzeug/datastructures.pyi
+++ b/src/werkzeug/datastructures.pyi
@@ -115,7 +115,7 @@ class MultiDict(TypeConversionDict[K, V]):
     def __init__(
         self,
         mapping: Optional[
-            Union[Mapping[K, Union[V, Iterable[V]]], Iterable[Tuple[K, V]]]
+            Union[Mapping[K, Union[Iterable[V], V]], Iterable[Tuple[K, V]]]
         ] = None,
     ) -> None: ...
     def __getitem__(self, item: K) -> V: ...
@@ -141,7 +141,7 @@ class MultiDict(TypeConversionDict[K, V]):
     @overload
     def to_dict(self, flat: Literal[False]) -> Dict[K, List[V]]: ...
     def update(  # type: ignore
-        self, mapping: Union[Mapping[K, V], Iterable[Tuple[K, V]]]
+        self, mapping: Union[Mapping[K, Union[Iterable[V], V]], Iterable[Tuple[K, V]]]
     ) -> None: ...
     @overload
     def pop(self, key: K) -> V: ...


### PR DESCRIPTION
`MultiDict.__init__` correctly represents it, however the update was missing the `iterable` variant.

Also, flipped the order of `Iterable[V]` and `V` fixes PyCharm's naive matching for generics. Mypy would accept both versions, however PyCharm would only try to infer `Mapping`'s `V` as the `List`. By listing it second it will first try to map to the Iterable[V].

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
