### PR TITLE
Add dataclasses to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Werkzeug",
+    setup_requires=["dataclasses; python_version < '3.7'"],
     install_requires=["dataclasses; python_version < '3.7'"],
     extras_require={"watchdog": ["watchdog"]},
 )


### PR DESCRIPTION
It is a followup of cbb446fdcada7685fce936ded01b76c08dbd6eb5.
dataclasses is also required during config for Python 3.6.

The build error with Python 3.6 is as follows:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "setup.py", line 7, in <module>
    extras_require={"watchdog": ["watchdog"]},
  File "/usr/local/lib/python3.6/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python3.6/distutils/core.py", line 121, in setup
    dist.parse_config_files()
  File "/usr/local/lib/python3.6/site-packages/setuptools/dist.py", line 702, in parse_config_files
    ignore_option_errors=ignore_option_errors)
  File "/usr/local/lib/python3.6/site-packages/setuptools/config.py", line 121, in parse_configuration
    meta.parse()
  File "/usr/local/lib/python3.6/site-packages/setuptools/config.py", line 426, in parse
    section_parser_method(section_options)
  File "/usr/local/lib/python3.6/site-packages/setuptools/config.py", line 399, in parse_section
    self[name] = value
  File "/usr/local/lib/python3.6/site-packages/setuptools/config.py", line 184, in __setitem__
    value = parser(value)
  File "/usr/local/lib/python3.6/site-packages/setuptools/config.py", line 515, in _parse_version
    version = self._parse_attr(value, self.package_dir)
  File "/usr/local/lib/python3.6/site-packages/setuptools/config.py", line 349, in _parse_attr
    module = import_module(module_name)
  File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/wrkdirs/usr/ports/www/py-werkzeug/work-py36/Werkzeug-2.0.1/src/werkzeug/__init__.py", line 2, in <module>
    from .test import Client as Client
  File "/wrkdirs/usr/ports/www/py-werkzeug/work-py36/Werkzeug-2.0.1/src/werkzeug/test.py", line 30, in <module>
    from .sansio.multipart import Data
  File "/wrkdirs/usr/ports/www/py-werkzeug/work-py36/Werkzeug-2.0.1/src/werkzeug/sansio/multipart.py", line 2, in <module>
    from dataclasses import dataclass
ModuleNotFoundError: No module named 'dataclasses'
*** Error code 1
```

Stop.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
