### PR TITLE
is_json is a property, not a method

### DIFF
--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -546,7 +546,7 @@ class Request(_SansIORequest):
     @property
     def json(self) -> t.Optional[t.Any]:
         """The parsed JSON data if :attr:`mimetype` indicates JSON
-        (:mimetype:`application/json`, see :meth:`is_json`).
+        (:mimetype:`application/json`, see :attr:`is_json`).
 
         Calls :meth:`get_json` with default arguments.
         """
@@ -562,7 +562,7 @@ class Request(_SansIORequest):
         """Parse :attr:`data` as JSON.
 
         If the mimetype does not indicate JSON
-        (:mimetype:`application/json`, see :meth:`is_json`), this
+        (:mimetype:`application/json`, see :attr:`is_json`), this
         returns ``None``.
 
         If parsing fails, :meth:`on_json_loading_failed` is called and

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -640,7 +640,7 @@ class Response(_SansIOResponse):
     @property
     def json(self) -> t.Optional[t.Any]:
         """The parsed JSON data if :attr:`mimetype` indicates JSON
-        (:mimetype:`application/json`, see :meth:`is_json`).
+        (:mimetype:`application/json`, see :attr:`is_json`).
 
         Calls :meth:`get_json` with default arguments.
         """
@@ -650,7 +650,7 @@ class Response(_SansIOResponse):
         """Parse :attr:`data` as JSON. Useful during testing.
 
         If the mimetype does not indicate JSON
-        (:mimetype:`application/json`, see :meth:`is_json`), this
+        (:mimetype:`application/json`, see :attr:`is_json`), this
         returns ``None``.
 
         Unlike :meth:`Request.get_json`, the result is not cached.


### PR DESCRIPTION
Correcting the documentation: `is_json` is a property, but the documetation as some places uses `:meth:`, which incorrectly adds parentheses.