### PR TITLE
Use provided `cn` for subjAltName

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Unreleased
 -   Type annotations use ``IO[bytes]`` and ``IO[str]`` instead of
     ``BinaryIO`` and ``TextIO`` for wider type compatibility.
     :issue:`2130`
+-   Ad-hoc TLS certs are generated with SAN matching CN. :issue:`2158`
 
 
 Version 2.0.1

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -495,7 +495,7 @@ def generate_adhoc_ssl_pair(
         .not_valid_before(dt.now(timezone.utc))
         .not_valid_after(dt.now(timezone.utc) + timedelta(days=365))
         .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
-        .add_extension(x509.SubjectAlternativeName([x509.DNSName("*")]), critical=False)
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(cn)]), critical=False)
         .sign(pkey, hashes.SHA256(), backend)
     )
     return cert, pkey


### PR DESCRIPTION
As the comment in line 477 suggests, `*` is not accepted by a lot of implementations.

However, even providing a `cn` parameter to `generate_adhoc_ssl_pair()` doesn't solve the problem, since a subjAltName of `*` was hardcoded in line 498.
For example python stdlib `ssl` module function `match_hostname()` will check subjAltName using `_dnsname_match()` *before* checking the common name, and then raise `CertificateError("sole wildcard without additional labels are not support")` when encountering a subjAltName of `*`.

This change should be backwards safe, since the local value of `cn` still defaults to `*` (e.g. the previous behaviour), if parameter `cn` is not provided.

- fixes #2158
