### PR TITLE
new proxy_fix helper function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.1.0
 
 Unreleased
 
+-   Add ``proxy_fix(environ, *args, **kwargs)`` an helper function to
+    use ``ProxyFix`` outside of a middleware.
+
 
 Version 2.0.2
 -------------


### PR DESCRIPTION
Hello there, first time contributing to werkzeug, feel free to tell me if I did anything wrong :)

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

We have been using werkzeug for years, it is a great project thanks a lot! We have too many middlewares which bloat our callstack when an exception occurs in our application, we are trying to reduce the overall callstack size by favoring explicit calls to method instead of multiple layers of middlewares.

ProxyFix in one of the middleware we are trying to inline.

In that optic we would like to:

```
def application(environ, start_response):
    proxy_fix(environ)
    ...
```

instead of:

```
@ProxyFix
def application(environ, start_response):
    ...
```

The changes I propose are minimals, I just moved most of `__call__` to a dedicated method `update_environ` and introduced a new module-level function `proxy_fix` that use that method. I adapted the existing `ProxyFix` test so it runs the same test suite on the new `proxy_fix` function.