### PR TITLE
Fix type annotations of RuleFactory classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Unreleased
 -   Fix type annotations for ``TypeConversionDict.get`` to not return an
     ``Optional`` value if both ``default`` and ``type`` are not
     ``None``. :issue:`2169`
+-   Fix type annotation for routing rule factories to accept
+    ``Iterable[RuleFactory]`` instead of ``Iterable[Rule]`` for the
+    ``rules`` parameter. :issue:`2183`
 
 
 Version 2.0.1

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -403,7 +403,7 @@ class Subdomain(RuleFactory):
     for the current request.
     """
 
-    def __init__(self, subdomain: str, rules: t.Iterable["Rule"]) -> None:
+    def __init__(self, subdomain: str, rules: t.Iterable[RuleFactory]) -> None:
         self.subdomain = subdomain
         self.rules = rules
 
@@ -429,7 +429,7 @@ class Submount(RuleFactory):
     Now the rule ``'blog/show'`` matches ``/blog/entry/<entry_slug>``.
     """
 
-    def __init__(self, path: str, rules: t.Iterable["Rule"]) -> None:
+    def __init__(self, path: str, rules: t.Iterable[RuleFactory]) -> None:
         self.path = path.rstrip("/")
         self.rules = rules
 
@@ -454,7 +454,7 @@ class EndpointPrefix(RuleFactory):
         ])
     """
 
-    def __init__(self, prefix: str, rules: t.Iterable["Rule"]) -> None:
+    def __init__(self, prefix: str, rules: t.Iterable[RuleFactory]) -> None:
         self.prefix = prefix
         self.rules = rules
 
@@ -499,7 +499,9 @@ class RuleTemplateFactory(RuleFactory):
     :internal:
     """
 
-    def __init__(self, rules: t.Iterable["Rule"], context: t.Dict[str, t.Any]) -> None:
+    def __init__(
+        self, rules: t.Iterable[RuleFactory], context: t.Dict[str, t.Any]
+    ) -> None:
         self.rules = rules
         self.context = context
 


### PR DESCRIPTION
This PR fixes #2183 by changing the respective type annotations from `Iterable[Rule]` to `Iterable[RuleFactory]`.
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.


The docs for the respective classes are auto-generated, so there's nothing for me to change there.