### PR TITLE
Fix handling of defaults in Header objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.1.0
 
 Unreleased
 
+-   Default values passed to ``Headers`` are validated the same way
+    values added later are. :issue:`1608`
+
 
 Version 2.0.2
 -------------

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -857,11 +857,14 @@ class Headers:
     `None` for ``headers['missing']``, whereas :class:`Headers` will raise
     a :class:`KeyError`.
 
-    To create a new :class:`Headers` object pass it a list or dict of headers
-    which are used as default values.  This does not reuse the list passed
-    to the constructor for internal usage.
+    To create a new ``Headers`` object, pass it a list, dict, or
+    other ``Headers`` object with default values. These values are
+    validated the same way values added later are.
 
     :param defaults: The list of default values for the :class:`Headers`.
+
+    .. versionchanged:: 2.1.0
+        Default values are validated the same as values added later.
 
     .. versionchanged:: 0.9
        This data structure now stores unicode values similar to how the
@@ -876,10 +879,7 @@ class Headers:
     def __init__(self, defaults=None):
         self._list = []
         if defaults is not None:
-            if isinstance(defaults, (list, Headers)):
-                self._list.extend(defaults)
-            else:
-                self.extend(defaults)
+            self.extend(defaults)
 
     def __getitem__(self, key, _get_mode=False):
         if not _get_mode:


### PR DESCRIPTION
Fix the handling of defaults passed to the `Headers` constructor. It now has uniform behavior with headers added with `Headers.add`

This fix uses `Headers.extend` to add defaults as opposed to `List.extend` used previously. Using the Headers' extend method allows all internal checks and conversions to be done on the default values passed.

For an example, newlines are not allowed in headers. 
```python3
    h1 = Headers([('X-Example', 'foo\r\n bar')])
    h2 = Headers()
    h2.add('X-Example', 'foo\r\n bar')
```
Before this fix `h1` would get created while `h2` would fail. Now they would both fail.

- fixes #1608 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
