### PR TITLE
Fix memory usage with the non-stdlib ContextVar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Unreleased
     ``BinaryIO`` and ``TextIO`` for wider type compatibility.
     :issue:`2130`
 -   Ad-hoc TLS certs are generated with SAN matching CN. :issue:`2158`
+-   Fix memory usage for locals when using Python 3.6 or pre 0.4.17
+    greenlet versions. :pr:`2212`
 
 
 Version 2.0.1


### PR DESCRIPTION
The release functionality used before this commit would replace the
value in the storage for a given greenlet ident with an empty
dictionary, which was problematic as it means the storage would grow
with each greenlet used until eventually consisting of many empty
dictionaries. The fix is to restore the Werkzeug 1.0 behaviour of
poping from the storage instead.

Note that stdlib ContextVars (as I understand them) are released when
the relevant task completes, and hence assigning an empty dictionary
releases references to anything stored whilst in the context as
desired (with the dictionary being release when the task completed).

It will be nice when we can drop Python 3.6 and exclusively use the stdlib ContextVars.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
