### PR TITLE
Attempt to enforce max-age as an integer in `send_file`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Default values passed to ``Headers`` are validated the same way
     values added later are. :issue:`1608`
+-   In `send_file` an integer value is attempted to be enforced for
+    max-age. :issue:`2230`
 
 
 Version 2.0.2

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -781,7 +781,7 @@ def send_file(
             rv.cache_control.no_cache = None
             rv.cache_control.public = True
 
-        rv.cache_control.max_age = max_age
+        rv.cache_control.max_age = int(max_age)
         rv.expires = int(time() + max_age)  # type: ignore
 
     if isinstance(etag, str):


### PR DESCRIPTION
This change attempts to enforce an integer value for max-age in send_file in order to comply with the specification for `Cache-Control: max-age=<value>`.

- fixes #2230

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
