### PR TITLE
Replace NBSP by space

### DIFF
--- a/src/werkzeug/debug/shared/style.css
+++ b/src/werkzeug/debug/shared/style.css
@@ -108,7 +108,7 @@ pre.console div.traceback pre.syntaxerror { background: inherit; border: none;
 pre.console div.noframe-traceback pre.syntaxerror { margin-top: -10px; border: none; }
 
 pre.console div.box pre.repr { padding: 0; margin: 0; background-color: white; border: none; }
-pre.console div.box table { margin-top: 6px; }
+pre.console div.box table { margin-top: 6px; }
 pre.console div.box pre { border: none; }
 pre.console div.box pre.help { background-color: white; }
 pre.console div.box pre.help:hover { cursor: default; }


### PR DESCRIPTION
Hi,

Found a NBSP in my codebase, and decided to search for others and replace by a space. The search expanded across my `venv` folder, where `werkzeug` was also brought by `grep`. Pretty harmless since most browsers will parse correctly NBSP or space, but can be confusing if parsing or if used by a tool/browser that treats these spaces differently.

Thanks!

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue. (pretty small, I think it doesn't deserve an entry?)
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
