### PR TITLE
Fix the CSP header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ Unreleased
     greenlet versions. :pr:`2212`
 -   Fix type annotation in ``CallbackDict``, because it is not
     utilizing a bound TypeVar. :issue:`2235`
+-   Fix setting CSP header options on the response. :pr:`2237`
 
 
 Version 2.0.1

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1343,6 +1343,20 @@ def test_ranges():
     assert resp.content_range.length == 1000
 
 
+def test_csp():
+    resp = wrappers.Response()
+    resp.content_security_policy.default_src = "'self'"
+    assert resp.headers["Content-Security-Policy"] == "default-src 'self'"
+    resp.content_security_policy.script_src = "'self' palletsprojects.com"
+    assert (
+        resp.headers["Content-Security-Policy"]
+        == "default-src 'self'; script-src 'self' palletsprojects.com"
+    )
+
+    resp.content_security_policy = None
+    assert "Content-Security-Policy" not in resp.headers
+
+
 def test_auto_content_length():
     resp = wrappers.Response("Hello World!")
     assert resp.content_length == 12


### PR DESCRIPTION
The header_property does not set the on_update method in the CSP
datastructure which means any changes wouldn't be set in the
headers. This fixes the issue by specifying the properties directly
and including tests to ensure it works.

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
