### PR TITLE
fix typo and grammar mistake

### DIFF
--- a/src/werkzeug/filesystem.py
+++ b/src/werkzeug/filesystem.py
@@ -37,7 +37,7 @@ def get_filesystem_encoding() -> str:
     because it might be different. See :ref:`filesystem-encoding` for the exact
     behavior.
 
-    The concept of a filesystem encoding in generally is not something you
+    The concept of a filesystem encoding in general is not something you
     should rely on. As such if you ever need to use this function except for
     writing wrapper code reconsider.
     """

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -322,7 +322,7 @@ class EnvironBuilder:
 
     .. versionadded:: 0.15
         The environ has keys ``REQUEST_URI`` and ``RAW_URI`` containing
-        the path before perecent-decoding. This is not part of the WSGI
+        the path before percent-decoding. This is not part of the WSGI
         PEP, but many WSGI servers include it.
 
     .. versionchanged:: 0.6


### PR DESCRIPTION
`perecent` should be `percent`
`in generally` should be `in general`