### PR TITLE
Expand frame working only for first 10 frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Unreleased
 -   Fix type annotation in ``CallbackDict``, because it is not
     utilizing a bound TypeVar. :issue:`2235`
 -   Fix setting CSP header options on the response. :pr:`2237`
+-   Fix an issue lines not expanding on click in the interactive
+    debugger for very long tracebacks. :pr:`2239`
 
 
 Version 2.0.1

--- a/src/werkzeug/debug/shared/debugger.js
+++ b/src/werkzeug/debug/shared/debugger.js
@@ -21,9 +21,9 @@ docReady(() => {
 });
 
 function addToggleFrameTraceback(frames) {
-  frames.forEach((frame, i) => {
+  frames.forEach((frame) => {
     frame.addEventListener("click", () => {
-      frame.getElementsByTagName("pre")[i].parentElement.classList.toggle("expanded");
+      frame.getElementsByTagName("pre")[0].parentElement.classList.toggle("expanded");
     });
   })
 }


### PR DESCRIPTION
Click handler finds n-th (n is frame depth) line of frame and expands parent. Default are 10 lines visible. If depth is higher browser raises:
```
Uncaught TypeError: frame.getElementsByTagName(...)[i] is undefined
    addToggleFrameTraceback http://localhost:8000/?__debugger__=yes&cmd=resource&f=debugger.js:26
```