### PR TITLE
Handle an Exception without a traceback.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ Unreleased
 -   Fix setting CSP header options on the response. :pr:`2237`
 -   Fix an issue with with the interactive debugger where lines would
     not expand on click for very long tracebacks. :pr:`2239`
+-   The interactive debugger handles displaying an exception that does
+    not have a traceback, such as from ``ProcessPoolExecutor``.
+    :issue:`2217`
 
 
 Version 2.0.1

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -357,6 +357,11 @@ class Group:
             tb = tb.tb_next  # type: ignore
 
     def filter_hidden_frames(self) -> None:
+        # An exception may not have a traceback to filter frames, such
+        # as one re-raised from ProcessPoolExecutor.
+        if not self.frames:
+            return
+
         new_frames: t.List[Frame] = []
         hidden = False
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -6,6 +6,7 @@ import pytest
 
 from werkzeug.debug import console
 from werkzeug.debug import DebuggedApplication
+from werkzeug.debug import get_current_traceback
 from werkzeug.debug import get_machine_id
 from werkzeug.debug.console import HTMLStringO
 from werkzeug.debug.repr import debug_repr
@@ -350,3 +351,12 @@ def test_non_hashable_exception():
     except MutableException:
         # previously crashed: `TypeError: unhashable type 'MutableException'`
         Traceback(*sys.exc_info())
+
+
+def test_exception_without_traceback():
+    try:
+        raise Exception("msg1")
+    except Exception as e:
+        # filter_hidden_frames should skip this since it has no traceback
+        e.__context__ = Exception("msg2")
+        get_current_traceback()


### PR DESCRIPTION
When an exception does not have a traceback there are no frames
to filter, but there's an explicit check for the last frame which
will fail if there are no frames.

An example exception with this problem can be seen when using
concurrent.futures.ProcessPoolExecutor.  When it reconstitutes a
remote exception it has serialized the traceback to a string it
includes as the error message instead of an object that can be
inspected.

- fixes #2217 
