### PR TITLE
setting CacheControl int property enforces type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Default values passed to ``Headers`` are validated the same way
     values added later are. :issue:`1608`
+-   Setting ``CacheControl`` int properties, such as ``max_age``, will
+    convert the value to an int. :issue:`2230`
 
 
 Version 2.0.2

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -2014,6 +2014,10 @@ class _CacheControl(UpdateDictMixin, dict):
     to subclass it and add your own items have a look at the sourcecode for
     that class.
 
+    .. versionchanged:: 2.1.0
+        Setting int properties such as ``max_age`` will convert the
+        value to an int.
+
     .. versionchanged:: 0.4
 
        Setting `no_cache` or `private` to boolean `True` will set the implicit
@@ -2072,7 +2076,7 @@ class _CacheControl(UpdateDictMixin, dict):
             elif value is True:
                 self[key] = None
             else:
-                self[key] = value
+                self[key] = type(value)
 
     def _del_cache_value(self, key):
         """Used internally by the accessor properties."""
@@ -2102,6 +2106,10 @@ class RequestCacheControl(ImmutableDictMixin, _CacheControl):
     you plan to subclass it and add your own items have a look at the sourcecode
     for that class.
 
+    .. versionchanged:: 2.1.0
+        Setting int properties such as ``max_age`` will convert the
+        value to an int.
+
     .. versionadded:: 0.5
        In previous versions a `CacheControl` class existed that was used
        both for request and response.
@@ -2121,6 +2129,10 @@ class ResponseCacheControl(_CacheControl):
     convert the object into a string or call the :meth:`to_header` method.  If
     you plan to subclass it and add your own items have a look at the sourcecode
     for that class.
+
+    .. versionchanged:: 2.1.0
+        Setting int properties such as ``max_age`` will convert the
+        value to an int.
 
     .. versionadded:: 0.5
        In previous versions a `CacheControl` class existed that was used

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -115,6 +115,10 @@ class TestHTTPUtility:
         assert c.private == "*"
         del c.private
         assert c.private is None
+        # max_age is an int, other types are converted
+        c.max_age = 3.1
+        assert c.max_age == 3
+        del c.max_age
         assert c.to_header() == "no-cache"
 
     def test_csp_header(self):


### PR DESCRIPTION
Type information was mostly being used to handle boolean options, and conversion from string was only happening when getting values. Set values are also converted to the type now.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2230 
- closes #2231 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
