### PR TITLE
shortly example opens redis with `decode_responses=True`

### DIFF
--- a/examples/shortly/shortly.py
+++ b/examples/shortly/shortly.py
@@ -37,7 +37,9 @@ def get_hostname(url):
 
 class Shortly:
     def __init__(self, config):
-        self.redis = redis.Redis(config["redis_host"], config["redis_port"])
+        self.redis = redis.Redis(
+            config["redis_host"], config["redis_port"], decode_responses=True
+        )
         template_path = os.path.join(os.path.dirname(__file__), "templates")
         self.jinja_env = Environment(
             loader=FileSystemLoader(template_path), autoescape=True


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2256

According to the [redis-py document](https://github.com/andymccurdy/redis-py)
> If all string responses from a client should be decoded, the user can specify decode_responses=True to Redis.\_\_init\_\_. In this case, any Redis command that returns a string type will be decoded with the encoding specified.

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->