### PR TITLE
Handle IPv6 Addreess in X-Forwarded-For Proxy Fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ Released 2021-10-05
 -   The interactive debugger handles displaying an exception that does
     not have a traceback, such as from ``ProcessPoolExecutor``.
     :issue:`2217`
+-   ``ProxyFix`` supports IPv6 addresses. :issue:`2262`
 
 
 Version 2.0.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 2.0.3
+-------------
+
+Unreleased
+
+-   ``ProxyFix`` supports IPv6 addresses. :issue:`2262`
+
+
 Version 2.0.2
 -------------
 
@@ -42,7 +50,6 @@ Released 2021-10-05
 -   The interactive debugger handles displaying an exception that does
     not have a traceback, such as from ``ProcessPoolExecutor``.
     :issue:`2217`
--   ``ProxyFix`` supports IPv6 addresses. :issue:`2262`
 
 
 Version 2.0.1

--- a/src/werkzeug/middleware/proxy_fix.py
+++ b/src/werkzeug/middleware/proxy_fix.py
@@ -163,18 +163,18 @@ class ProxyFix:
 
         x_host = self._get_real_value(self.x_host, environ_get("HTTP_X_FORWARDED_HOST"))
         if x_host:
-            environ["HTTP_HOST"] = x_host
-            parts = x_host.split(":", 1)
-            environ["SERVER_NAME"] = parts[0]
-            if len(parts) == 2:
-                environ["SERVER_PORT"] = parts[1]
+            environ["HTTP_HOST"] = environ["SERVER_NAME"] = x_host
+            # "]" to check for IPv6 address without port
+            if ":" in x_host and not x_host.endswith("]"):
+                environ["SERVER_NAME"], environ["SERVER_PORT"] = x_host.rsplit(":", 1)
 
         x_port = self._get_real_value(self.x_port, environ_get("HTTP_X_FORWARDED_PORT"))
         if x_port:
             host = environ.get("HTTP_HOST")
             if host:
-                parts = host.split(":", 1)
-                host = parts[0] if len(parts) == 2 else host
+                # "]" to check for IPv6 address without port
+                if ":" in host and not host.endswith("]"):
+                    host = host.rsplit(":", 1)[0]
                 environ["HTTP_HOST"] = f"{host}:{x_port}"
             environ["SERVER_PORT"] = x_port
 

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -138,6 +138,24 @@ from werkzeug.wrappers import Request
             "http://spam/eggs/",
             id="prefix < for",
         ),
+        pytest.param(
+            {"x_host": 1},
+            {"HTTP_HOST": "spam", "HTTP_X_FORWARDED_HOST": "[2001:db8::a]"},
+            "http://[2001:db8::a]/",
+            id="ipv6 host",
+        ),
+        pytest.param(
+            {"x_port": 1},
+            {"HTTP_HOST": "[2001:db8::a]", "HTTP_X_FORWARDED_PORT": "8080"},
+            "http://[2001:db8::a]:8080/",
+            id="ipv6 port, host without port",
+        ),
+        pytest.param(
+            {"x_port": 1},
+            {"HTTP_HOST": "[2001:db8::a]:9000", "HTTP_X_FORWARDED_PORT": "8080"},
+            "http://[2001:db8::a]:8080/",
+            id="ipv6 - port, host with port",
+        ),
     ),
 )
 def test_proxy_fix(kwargs, base, url_root):


### PR DESCRIPTION
Use rsplit() to split host/port, this will work for both
IPv4, IPV6 and hostnames. Only rsplit() if ':' in string
and the string does not end with closing bracket.

Fixes: #2262
