### PR TITLE
remove contextvars compat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Version 2.1.0
 Unreleased
 
 -   Drop support for Python 3.6. :pr:`2277`
+-   Using gevent or eventlet requires greenlet>=1.0 or PyPy>=7.3.7.
+    ``werkzeug.locals`` and ``contextvars`` will not work correctly with
+    older versions. :pr:`2278`
 -   Remove previously deprecated code. :pr:`2276`
 
     -   Remove the non-standard ``shutdown`` function from the WSGI

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,6 +31,18 @@ detect and use them if you install them.
 .. _Watchdog: https://pypi.org/project/watchdog/
 
 
+greenlet
+~~~~~~~~
+
+You may choose to use gevent or eventlet with your application. In this
+case, greenlet>=1.0 is required. When using PyPy, PyPy>=7.3.7 is
+required.
+
+These are not minimum supported versions, they only indicate the first
+versions that added necessary features. You should use the latest
+versions of each.
+
+
 Virtual environments
 --------------------
 


### PR DESCRIPTION
After dropping support for Python 3.6, all supported versions of Python have `contextvars`.

Using gevent or eventlet requires greenlet>=1.0, which added support for `contextvars`. Using PyPy as well requires PyPy>=7.3.7, which has its own implementation of greenlet. Added documentation to the install page about this.

Unfortunately, it's not really useful to check for this from Werkzeug, as we don't know if gevent or eventlet are in use (they may not have been imported yet) or if they are used in a way that would mess with contextvars (they may not be used to serve the WSGI application).

I'll mention this in Flask's deploying docs, which show how to use gevent.

@miguelgrinberg it may be a good idea to add something like the following to Flask-SocketIO when it's using the eventlet or gevent servers, and to mention the version requirement in the docs.

```python
import sys
import warnings

import greenlet

if not getattr(greenlet, "GREENLET_USE_CONTEXT_VARS", False):
    # pypy provides its own implementation of greenlet
    if sys.implementation.name == "pypy" and sys.implementation.version < (7, 3, 7):
        require = "PyPy>=7.3.7"
    else:
        require = "greenlet>=1.0"

    warnings.warn(f"Context locals require {require} when using eventlet or gevent.")
```
