### PR TITLE
fix resource warning in test on pypy3.8

### DIFF
--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1162,13 +1162,15 @@ class TestFileStorage:
         for name in ("fileno", "writable", "readable", "seekable"):
             assert hasattr(file_storage, name)
 
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_save_to_pathlib_dst(self, tmp_path):
         src = tmp_path / "src.txt"
         src.write_text("test")
-        storage = self.storage_class(src.open("rb"))
         dst = tmp_path / "dst.txt"
-        storage.save(dst)
+
+        with src.open("rb") as f:
+            storage = self.storage_class(f)
+            storage.save(dst)
+
         assert dst.read_text() == "test"
 
     def test_save_to_bytes_io(self):


### PR DESCRIPTION
For some reason this caused a warning that wasn't ignored on PyPy 3.8 only, but it turned out to be a simple fix.