### PR TITLE
clearer error message when ssl is not available

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -39,7 +39,10 @@ except ImportError:
 
     class _SslDummy:
         def __getattr__(self, name: str) -> t.Any:
-            raise RuntimeError("SSL support unavailable")  # noqa: B904
+            raise RuntimeError(  # noqa: B904
+                "SSL is unavailable because this Python was not"
+                " compiled with SSL support."
+            )
 
     ssl = _SslDummy()  # type: ignore
 


### PR DESCRIPTION
As pointed out by @cooperlees in https://github.com/PyCQA/flake8-bugbear/issues/190, the error message when SSL was unavailable was not very clear. Now it explains that Python wasn't compiled with SSL support.