### PR TITLE
always use `socket.fromfd`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,8 @@ Unreleased
     values added later are. :issue:`1608`
 -   Setting ``CacheControl`` int properties, such as ``max_age``, will
     convert the value to an int. :issue:`2230`
+-   Always use ``socket.fromfd`` when restarting the dev server.
+    :pr:`2287`
 
 
 Version 2.0.2


### PR DESCRIPTION
All supported versions of Python have `socket.fromfd`. The check for Windows from #1081 for #993 doesn't appear to be required any longer, I tested `socket.fromfd` on Python 3.7 on Windows and it works fine.