### PR TITLE
Fix type annotation for `reqeust_or_environ` parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Version 2.0.3
 Unreleased
 
 -   ``ProxyFix`` supports IPv6 addresses. :issue:`2262`
+-   Type annotation for ``Response.make_conditional``,
+    ``HTTPException.get_response``, and ``Map.bind_to_environ`` accepts
+    ``Request`` in addition to ``WSGIEnvironment`` for the first
+    parameter. :pr:`2290`
 
 
 Version 2.0.2

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -57,6 +57,7 @@ if t.TYPE_CHECKING:
     from _typeshed.wsgi import WSGIEnvironment
     from .datastructures import WWWAuthenticate
     from .sansio.response import Response
+    from .wrappers.request import Request as WSGIRequest  # noqa: F401
     from .wrappers.response import Response as WSGIResponse  # noqa: F401
 
 
@@ -189,7 +190,7 @@ class HTTPException(Exception):
 
     def get_response(
         self,
-        environ: t.Optional["WSGIEnvironment"] = None,
+        environ: t.Optional[t.Union["WSGIEnvironment", "WSGIRequest"]] = None,
         scope: t.Optional[dict] = None,
     ) -> "Response":
         """Get a response object.  If one was passed to the exception

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -26,6 +26,7 @@ if t.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse
     from _typeshed.wsgi import WSGIApplication
     from _typeshed.wsgi import WSGIEnvironment
+    from .request import Request
 
 
 def _warn_if_string(iterable: t.Iterable) -> None:
@@ -749,7 +750,7 @@ class Response(_SansIOResponse):
 
     def make_conditional(
         self,
-        request_or_environ: "WSGIEnvironment",
+        request_or_environ: t.Union["WSGIEnvironment", "Request"],
         accept_ranges: t.Union[bool, str] = False,
         complete_length: t.Optional[int] = None,
     ) -> "Response":


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->
Small update to the type annotation of the `request_or_environ` parameter of `Request.make_conditional` to accept a `Request` in addition to a `WSGIEnvironment` (as the name suggests).

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
