### PR TITLE
`MapAdapter.build` does not flatten list value from plain dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,9 +56,11 @@ Unreleased
     convert the value to an int. :issue:`2230`
 -   Always use ``socket.fromfd`` when restarting the dev server.
     :pr:`2287`
--   The behavior of the ``build`` function has been changed,
-    it is no longer flatten a value passed as single-item-list.
-    :issue:`2249`
+-   When passing a dict of URL values to ``Map.build``, list values do
+    not filter out ``None`` or collapse to a single value. Passing a
+    ``MultiDict`` does collapse single items. This undoes a previous
+    change that made it difficult to pass a list, or ``None`` values in
+    a list, to custom URL converters. :issue:`2249`
 
 
 Version 2.0.3

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ Unreleased
     convert the value to an int. :issue:`2230`
 -   Always use ``socket.fromfd`` when restarting the dev server.
     :pr:`2287`
+-   The behavior of the ``build`` function has been changed,
+    it is no longer flatten a value passed as single-item-list.
+    :issue:`2249`
 
 
 Version 2.0.3

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -2301,7 +2301,8 @@ class MapAdapter:
                         continue
 
                     if len(value) == 1:
-                        value = value[0]
+                        if always_list:
+                            value = value[0]
 
                 temp_values[key] = value
 


### PR DESCRIPTION
It should be possible to pass a list value to a custom URL converter when building. However, after some other changes to the code to support `MultiDict`, a regression was introduced that made that difficult.

This changes the behavior so flattening single-item lists only happens when passing `MultiDict`, where values will always be lists, and are mainly coming from `request.args` where this behavior makes sense. For plain dicts, neither of these things are done, it is assumed that the user will intentionally pass a list or single item depending on what's appropriate.

Additionally, `build` no longer filters `None` items from list values. Either the list will be passed to a URL converter, where it's the converter's job to handle the value passed to it, or it's a query arg, and `url_encode` already filters out `None`.

fixes #2249 
continues #2261 