### PR TITLE
Change `try/except` to `if sys.platform` in `debug`

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -90,11 +90,9 @@ def get_machine_id() -> t.Optional[t.Union[str, bytes]]:
             pass
 
         # On Windows, use winreg to get the machine guid.
-        try:
+        if sys.platform == "win32":
             import winreg
-        except ImportError:
-            pass
-        else:
+
             try:
                 with winreg.OpenKey(
                     winreg.HKEY_LOCAL_MACHINE,
@@ -107,7 +105,7 @@ def get_machine_id() -> t.Optional[t.Union[str, bytes]]:
                     guid, guid_type = winreg.QueryValueEx(rk, "MachineGuid")
 
                     if guid_type == winreg.REG_SZ:
-                        return guid.encode("utf-8")  # type: ignore
+                        return guid.encode("utf-8")
 
                     return guid
             except OSError:


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

Hi! Sorry for not opening a new issue, but I believe this is a minor refactoring, so it is not really required 🙂 

While working on better `typeshed` types for `mypy`, I found that `winreg` was not marked as Windows only. Now it will be: https://github.com/python/typeshed/pull/6735

But, our primer bot identified, that this package will receive a false-positive in the next mypy release. So, I am fixing it for you! 👍 

A bit of theory: `try/except` is not recognised by mypy right now, it only understands `if sys.platform` to mark parts that are platform (Windows) specific. With this setup, you won't see any errors here from mypy in the future.

I am also pretty sure that `if sys.platform == "win32":` is suitable here, because it is a standard check we use for all Windows-specific code.

I hope it helps! 🎉 

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->


<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
