### PR TITLE
Extend default set of always safe characters in url_quote

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ Unreleased
     a list, to custom URL converters. :issue:`2249`
 -   ``run_simple`` shows instructions for dealing with "address already
     in use" errors, including extra instructions for macOS. :pr:`2321`
+-   Extend list of characters considered always safe in URLs based on
+    :rfc:`3986`. :issue:`2319`
 
 
 Version 2.0.3

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -27,6 +27,7 @@ _always_safe = frozenset(
         b"ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         b"0123456789"
         b"-._~"
+        b"$!'()*+,;"  # RFC3986 sub-delims set, not including query string delimiters &=
     )
 )
 

--- a/tests/middleware/test_http_proxy.py
+++ b/tests/middleware/test_http_proxy.py
@@ -45,3 +45,7 @@ def test_http_proxy(standard_app):
     assert "HTTP_X_SPECIAL" not in r.json
     assert r.json["HTTP_HOST"] == "127.0.0.1"
     assert r.json["PATH_INFO"] == "/autohost/aha"
+
+    # test if characters allowed in URL are not encoded by proxy
+    r = client.get("/autohost/$")
+    assert r.json["REQUEST_URI"] == "/autohost/$"


### PR DESCRIPTION
Extend `_always_safe` set according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986).

Query string delimiters `&` and `=` are not included into the set, as that set used by `uri_to_iri()` and `url_encode()`. Including them in the set will make those functions to unquote `&` and `=` in query string keys and values. Will fix this in following PR and add them to the set.

- fixes #2319

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
