### PR TITLE
show instructions for "address already in use" error, and other dev server improvements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,6 +26,8 @@ distlib==0.3.4
     # via virtualenv
 docutils==0.17.1
     # via sphinx
+ephemeral-port-reserve==1.1.4
+    # via -r requirements/tests.in
 filelock==3.4.2
     # via
     #   tox

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -4,3 +4,4 @@ pytest-xprocess
 cryptography
 greenlet ; python_version < "3.11"
 watchdog
+ephemeral-port-reserve

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -10,6 +10,8 @@ cffi==1.15.0
     # via cryptography
 cryptography==36.0.1
     # via -r requirements/tests.in
+ephemeral-port-reserve==1.1.4
+    # via -r requirements/tests.in
 greenlet==1.1.2 ; python_version < "3.11"
     # via -r requirements/tests.in
 iniconfig==1.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,6 @@ where = src
 
 [tool:pytest]
 testpaths = tests
-filterwarnings =
-    error
 
 [coverage:run]
 branch = True

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -892,14 +892,16 @@ def run_simple(
     """
     if not isinstance(port, int):
         raise TypeError("port must be an integer")
-    if use_debugger:
-        from .debug import DebuggedApplication
 
-        application = DebuggedApplication(application, use_evalex)
     if static_files:
         from .middleware.shared_data import SharedDataMiddleware
 
         application = SharedDataMiddleware(application, static_files)
+
+    if use_debugger:
+        from .debug import DebuggedApplication
+
+        application = DebuggedApplication(application, evalex=use_evalex)
 
     def log_startup(sock: socket.socket) -> None:
         all_addresses_message = (


### PR DESCRIPTION
I was originally only going to implement the "address already in use" error instructions, but this led me towards some other refactors/fixes. The messages and docs have been updated, and more code has been extracted from `run_simple`.

```
❯ python example.py                                                                             
 * Running on all addresses (0.0.0.0)
   WARNING: This is a development server. Do not use it in a production deployment.
 * Running on http://127.0.0.1:5000
 * Running on http://192.168.0.179:5000 (Press CTRL+C to quit)
 ```

```
❯ python example.py
Address already in use
Port 5000 is in use by another program. Either identify and stop that program, or start the server with a different port.
On macOS, try disabling the 'AirPlay Receiver' service from System Preferences -> Sharing.
```

* When `run_simple` calls `socket.bind`, it will catch any `OSError` and show only the error message without the traceback. Often, users seem to miss the error message in the traceback, and the traceback is not helpful to resolving the issue in this case. If the error is specifically `EADDRINUSE`, instructions are shown about identify the other program or changing the port. On macOS, additional instructions are shown to disable "AirPlay Receiver" if the port is 5000.
* When passing `0.0.0.0` or `::`, the "Running on all addresses" message also shows the value that was passed in, hopefully making it clearer that "all addresses" means the same thing. Addditionally, an extra "Running on" line is shown with `127.0.0.1` or `::`, hopefully making it clearer that "localhost" and the external IP will both work. There still seems to be some confusion when running in Docker or AWS because users don't understand that the external address still needs to be forwarded to the outside world, but I'm not sure how to resolve that.
* Extract the socket binding code to a separate function, `prepare_socket`. Extract the "Running on" message code to a method on `BaseWSGIServer`. All the difficult code related to `run_simple` is now extracted, making it easier to implement a custom run function.
* `run_simple` always binds the socket, as `socket.fromfd` is available on all supported Python versions and platforms.
* When binding a Unix socket file, if the file already exists it is removed. `HTTPServer.server_close` seems to be unreliable, so it's not possible to remove the socket file on close.
* When initializing the server, binding and listening to the socket is skipped and done manually only if a file descriptor was not passed. This skips some unecessary work, which was also causing issues when trying to share Unix socket files by descriptor.
* The debugger is applied after the static files middleware, so that an error when serving static files will also be handled by the debugger.
* Rewrite the `run_simple` and `make_server` docs.
* Use [ephemeral-port-reserve](https://github.com/Yelp/ephemeral-port-reserve) to find free ports for the dev server tests, instead of the simple check used before. This allows the test environment to be run in parallel with `tox -p`. Previously, simultaneous tests would end up hanging because checking for a free port didn't reserve the port for use by the server subprocess. Running all envs in parallel now finishes in ~25 seconds, instead of the ~4 minutes to run them sequentially.