### PR TITLE
optimize stat reloader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,9 @@ Unreleased
     in use" errors, including extra instructions for macOS. :pr:`2321`
 -   Extend list of characters considered always safe in URLs based on
     :rfc:`3986`. :issue:`2319`
+-   Optimize the stat reloader to avoid watching unnecessary files in
+    more cases. The watchdog reloader is still recommended for
+    performance and accuracy. :issue:`2141`
 
 
 Version 2.0.3

--- a/tests/live_apps/reloader_app.py
+++ b/tests/live_apps/reloader_app.py
@@ -8,8 +8,8 @@ from werkzeug.wrappers import Response
 # Tox puts the tmp dir in the venv sys.prefix, patch the reloader so
 # it doesn't skip real_app.
 if "TOX_ENV_DIR" in os.environ:
-    _reloader._ignore_prefixes = tuple(
-        set(_reloader._ignore_prefixes) - {sys.prefix, sys.exec_prefix}
+    _reloader._stat_ignore_scan = tuple(
+        set(_reloader._stat_ignore_scan) - {sys.prefix, sys.exec_prefix}
     )
 
 


### PR DESCRIPTION
* Both reloaders, in addition to `.git` and `.hg` folders, always ignore `__pycache__`, `.tox`, `.nox`, `.pytest_cache`, and `.mypy_cache`. Changes to these files are never relevant to reloading.
* The stat reloader stops walking a directory if neither it nor its parent contained any Python files. For example, this will prevent scanning most files in a `node_modules` directory.
* Both reloaders ignore imported modules if they are in `sys.base_prefix`, which indicates they are installed to the system Python location instead of the current virtualenv.
* The stat reloader does not walk directories in `sys.base_prefix` or `sys.prefix` (a subsequent step picks up imported modules in `sys.prefix`, assuming it's in a virtualenv).

closes #2141