### PR TITLE
more HTTP/1.1 fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,9 @@ Unreleased
 -   The development server uses ``Transfer-Encoding: chunked`` for
     streaming responses when it is configured for HTTP/1.1.
     :issue:`2090, 1327`, :pr:`2091`
+-   The development server uses HTTP/1.1, which enables keep-alive
+    connections and chunked streaming responses, when ``threaded`` or
+    ``processes`` is enabled. :pr:`2323`
 
 
 Version 2.0.3

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -654,6 +654,14 @@ class BaseWSGIServer(HTTPServer):
         if handler is None:
             handler = WSGIRequestHandler
 
+        # If the handler doesn't directly set a protocol version and
+        # thread or process workers are used, then allow chunked
+        # responses and keep-alive connections by enabling HTTP/1.1.
+        if "protocol_version" not in vars(handler) and (
+            self.multithread or self.multiprocess
+        ):
+            handler.protocol_version = "HTTP/1.1"
+
         self.host = host
         self.port = port
         self.app = app

--- a/tests/live_apps/run.py
+++ b/tests/live_apps/run.py
@@ -4,14 +4,8 @@ from importlib import import_module
 
 from werkzeug.serving import generate_adhoc_ssl_context
 from werkzeug.serving import run_simple
-from werkzeug.serving import WSGIRequestHandler
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
-
-
-class WSGI11RequestHandler(WSGIRequestHandler):
-    protocol_version = "HTTP/1.1"
-
 
 name = sys.argv[1]
 mod = import_module(f"{name}_app")
@@ -29,9 +23,6 @@ kwargs = getattr(mod, "kwargs", {})
 kwargs.update(hostname="127.0.0.1", port=5000, application=app)
 kwargs.update(json.loads(sys.argv[2]))
 ssl_context = kwargs.get("ssl_context")
-
-if kwargs.get("request_handler") == "HTTP/1.1":
-    kwargs["request_handler"] = WSGI11RequestHandler
 
 if ssl_context == "custom":
     kwargs["ssl_context"] = generate_adhoc_ssl_context()

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -259,7 +259,7 @@ def test_streaming_chunked_response(dev_server):
 
     https://tools.ietf.org/html/rfc2616#section-3.6.1
     """
-    r = dev_server("streaming", request_handler="HTTP/1.1").request("/")
+    r = dev_server("streaming", threaded=True).request("/")
     assert r.getheader("transfer-encoding") == "chunked"
     assert r.data == "".join(str(x) + "\n" for x in range(5)).encode()
 
@@ -270,4 +270,4 @@ def test_streaming_chunked_truncation(dev_server):
     content truncated by a prematurely closed connection.
     """
     with pytest.raises(http.client.IncompleteRead):
-        dev_server("streaming", request_handler="HTTP/1.1").request("/crash")
+        dev_server("streaming", threaded=True).request("/crash")


### PR DESCRIPTION
Some more things that I noticed while reviewing #2091.

* The debugger uses `send_file` to serve resources (css, font, icons), which allows calculating etags for caching.
* The initial debugger page uses a standard `Response`, including setting a `Content-Length` header so that the response isn't needlessly treated as streaming.
* Rely on Python's HTTP server code more.
    * Only close the connection or use chunked encoding if a `Content-Length` is not provided, not also for the HEAD method and certain statuses. In HTTP/1.0 mode, the handler will already close every connection, and in HTTP/1.1 it will use keep-alive if requested.
    * Setting the `Connection: close` header already tells the handler to closes the connection.
    * The base implementation of `send_response` already sets the `Server` and `Date` headers.
    * The base implementation of `handle_one_request` handles timeout errors and generally the code looks like it handles more things.
    * `version_string` doesn't need to be overridden to strip trailing space, that already won't happen (and shouldn't matter anyway).
* While defaulting to HTTP/1.1 for the base single-worker server seems to be unreliable when loading multiple resources, it seems to work fine when the server is multithread or multiprocess. If the handler doesn't set `protocol_version` directly, set it to HTTP/1.1 if `threaded` or `processes` is enabled. This is probably how most people run the dev server (Flask sets `threaded=True`). This enables keep-alive connections and chunked streaming responses.