### PR TITLE
Add missing type hints for cache_control_property

### DIFF
--- a/src/werkzeug/datastructures.pyi
+++ b/src/werkzeug/datastructures.pyi
@@ -420,7 +420,7 @@ class CharsetAccept(Accept):
 _CPT = TypeVar("_CPT", str, int, bool)
 _OptCPT = Optional[_CPT]
 
-def cache_property(key: str, empty: _OptCPT, type: Type[_CPT]) -> property: ...
+def cache_control_property(key: str, empty: _OptCPT, type: Type[_CPT]) -> property: ...
 
 class _CacheControl(UpdateDictMixin[str, _OptCPT], Dict[str, _OptCPT]):
     provided: bool


### PR DESCRIPTION
Added missing type hints for `cache_control_property` in `datastructures.pyi`. 

Checklist:

- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.