### PR TITLE
debugger uses traceback module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ Unreleased
     ``processes`` is enabled. :pr:`2323`
 -   ``cached_property`` works for classes with ``__slots__`` if a
     corresponding ``_cache_{name}`` slot is added. :pr:`2332`
+-   Refactor the debugger traceback formatter to use Python's built-in
+    ``traceback`` module as much as possible. :issue:`1753`
 
 
 Version 2.0.3

--- a/src/werkzeug/debug/console.py
+++ b/src/werkzeug/debug/console.py
@@ -176,16 +176,18 @@ class _InteractiveConsole(code.InteractiveInterpreter):
             self.showtraceback()
 
     def showtraceback(self) -> None:
-        from .tbtools import get_current_traceback
+        from .tbtools import DebugTraceback
 
-        tb = get_current_traceback(skip=1)
-        sys.stdout._write(tb.render_summary())  # type: ignore
+        exc = t.cast(BaseException, sys.exc_info()[1])
+        te = DebugTraceback(exc, skip=1)
+        sys.stdout._write(te.render_traceback_html())  # type: ignore
 
     def showsyntaxerror(self, filename: t.Optional[str] = None) -> None:
-        from .tbtools import get_current_traceback
+        from .tbtools import DebugTraceback
 
-        tb = get_current_traceback(skip=4)
-        sys.stdout._write(tb.render_summary())  # type: ignore
+        exc = t.cast(BaseException, sys.exc_info()[1])
+        te = DebugTraceback(exc, skip=4)
+        sys.stdout._write(te.render_traceback_html())  # type: ignore
 
     def write(self, data: str) -> None:
         sys.stdout.write(data)


### PR DESCRIPTION
The debugger now relies on Python's built-in `traceback` module as much as possible. Unfortunately, the `traceback` classes aren't as easy to subclass as they should be, some higher-level classes don't allow overriding the lower-level classes they create. So this takes the approach of generating a `TracebackException` instance then re-iterating over the results to replace the `FrameSummary` objects with `DebugFrameSummary` which stores the `globals` and `locals` and allows evaluating code against them. The `TracebackException` is wrapped in a `DebugTraceback`, which has the methods for rendering the HTML debugger page.

closes #1753 

Some things which I noticed while working on this, that we can address in the future:

* Remove the font and icon files. They contribute about 75K to the total wheel size of 264K, so it would save a significant amount of bandwidth for PyPI. The font is the majority of that, and it would be fine to specify fonts provided by each OS in the CSS. The favicon can be replaced with an emoji in an SVG.
* Remove the extra `__traceback_hide__` and `__traceback_info__` behavior. I always forget, and I'm sure no one else is even aware, that Werkzeug implements Paste's `__traceback_hide__` algorithm. While we could keep the `True` behavior, all the before/after/this strings could probably go. They're not even documented in Paste anymore, I can't find reference to them anywhere else except a single SO answer, and Paste itself is in emergency-only maintenance status at this point.
* Show error arrows on Python 3.11. The algorithm is there in the `traceback` module, but I didn't investigate it fully yet.
* Add a way for Flask to preserve the request context when the server is threaded. There is already a `console_init_func` (which Flask should also use to push an app context), the debugger could also have save/restore state callbacks that would associate extra data with a traceback when it happens.
* Don't use `sys.exc_info()` anywhere.
* Better HTML layout of chained exceptions.
* Button that uses JavaScript to copy traceback text to clipboard, so people might not copy the HTML version so much.