### PR TITLE
add `TestResponse.text` property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ Unreleased
     corresponding ``_cache_{name}`` slot is added. :pr:`2332`
 -   Refactor the debugger traceback formatter to use Python's built-in
     ``traceback`` module as much as possible. :issue:`1753`
+-   The ``TestResponse.text`` property is a shortcut for
+    ``r.get_data(as_text=True)``, for convenient testing against text
+    instead of bytes. :pr:`2337`
 
 
 Version 2.0.3

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -38,6 +38,7 @@ from .urls import url_fix
 from .urls import url_parse
 from .urls import url_unparse
 from .urls import url_unquote
+from .utils import cached_property
 from .utils import get_content_type
 from .wrappers.request import Request
 from .wrappers.response import Response
@@ -1306,3 +1307,12 @@ class TestResponse(Response):
         self.request = request
         self.history = history
         self._compat_tuple = response, status, headers
+
+    @cached_property
+    def text(self) -> str:
+        """The response data as text. A shortcut for
+        ``response.get_data(as_text=True)``.
+
+        .. versionadded:: 2.1
+        """
+        return self.get_data(as_text=True)


### PR DESCRIPTION
Pretty much every test I write about the body of a response, I want to treat the response data as text, not as bytes. This adds a shortcut property `TestResponse.text` that does `response.get_data(as_text=True)`. The property matches the name used in requests and httpx. I opted to only implement this for tests, not on `Response`, since I think it only really makes sense during testing.