### PR TITLE
Tutorial returns bytestring instead of string

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -61,7 +61,7 @@ looks like this::
 
     def application(environ, start_response):
         start_response('200 OK', [('Content-Type', 'text/plain')])
-        return ['Hello World!']
+        return ['Hello World!'.encode('utf-8')]
 
 A WSGI application is something you can call and pass an environ dict
 and a ``start_response`` callable.  The environ contains all incoming


### PR DESCRIPTION
The tutorial page gives an example of a 'basic' WSGI application. This application, however, returns a string instead of a bytestring.

Issues with this:
- Contradicts official WSGI spec.
- Cannot be easily used with servers.
- Does not showcase that Response objects are also able to do this encoding.

This small commit fixes this.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
