### PR TITLE
`UUIDConverter` supports strings without hyphens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 .. currentmodule:: werkzeug
 
+Version 2.0.4
+-------------
+-   ``UUIDConverter`` accepts strings without hyphens. :issue:`2343`
+
+
 Version 2.0.3
 -------------
 

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1380,14 +1380,17 @@ class UUIDConverter(BaseConverter):
 
         Rule('/object/<uuid:identifier>')
 
+    .. versionchanged:: 2.0.4
+        Support for strings without hyphens.
+
     .. versionadded:: 0.10
 
     :param map: the :class:`Map`.
     """
 
     regex = (
-        r"[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-"
-        r"[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}"
+        r"[A-Fa-f0-9]{8}-?[A-Fa-f0-9]{4}-?"
+        r"[A-Fa-f0-9]{4}-?[A-Fa-f0-9]{4}-?[A-Fa-f0-9]{12}"
     )
 
     def to_python(self, value: str) -> uuid.UUID:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -709,8 +709,10 @@ def test_default_converters():
 def test_uuid_converter():
     m = r.Map([r.Rule("/a/<uuid:a_uuid>", endpoint="a")])
     a = m.bind("example.org", "/")
-    route, kwargs = a.match("/a/a8098c1a-f86e-11da-bd1a-00112444be1e")
-    assert type(kwargs["a_uuid"]) == uuid.UUID
+    _, kwargs_with_hyphens = a.match("/a/a8098c1a-f86e-11da-bd1a-00112444be1e")
+    _, kwargs_without_hyphens = a.match("/a/a8098c1af86e11dabd1a00112444be1e")
+    assert type(kwargs_with_hyphens["a_uuid"]) == uuid.UUID
+    assert type(kwargs_without_hyphens["a_uuid"]) == uuid.UUID
 
 
 def test_converter_with_tuples():


### PR DESCRIPTION
- fixes #2343 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
