### PR TITLE
`safe_join` keeps `directory=""` as relative path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Unreleased
 -   The ``TestResponse.text`` property is a shortcut for
     ``r.get_data(as_text=True)``, for convenient testing against text
     instead of bytes. :pr:`2337`
+-   ``safe_join`` ensures that the path remains relative if the trusted
+    directory is the empty string. :pr:`2349`
 
 
 Version 2.0.3

--- a/src/werkzeug/security.py
+++ b/src/werkzeug/security.py
@@ -116,6 +116,11 @@ def safe_join(directory: str, *pathnames: str) -> t.Optional[str]:
         base directory.
     :return: A safe path, otherwise ``None``.
     """
+    if not directory:
+        # Ensure we end up with ./path if directory="" is given,
+        # otherwise the first untrusted part could become trusted.
+        directory = "."
+
     parts = [directory]
 
     for filename in pathnames:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -43,3 +43,7 @@ def test_safe_join_os_sep():
     sec._os_alt_seps = "*"
     assert safe_join("foo", "bar/baz*") is None
     sec._os_alt_steps = prev_value
+
+
+def test_safe_join_empty_trusted():
+    assert safe_join("", "c:test.txt") == "./c:test.txt"


### PR DESCRIPTION
When using `send_from_directory`, which uses `safe_join`, if `directory=""` is given, it was discarded and the first untrusted path component could become the first component if it was a Windows drive-relative path.