### PR TITLE
routing match includes newline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,9 @@ Unreleased
     instead of bytes. :pr:`2337`
 -   ``safe_join`` ensures that the path remains relative if the trusted
     directory is the empty string. :pr:`2349`
+-   Percent-encoded newlines (``%0a``), which are decoded by WSGI
+    servers, are considered when routing instead of terminating the
+    match early. :pr:`2350`
 
 
 Version 2.0.3

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -666,6 +666,11 @@ class Rule(RuleFactory):
         ``wss://``) requests. By default, rules will only match for HTTP
         requests.
 
+    .. versionchanged:: 2.1
+        Percent-encoded newlines (``%0a``), which are decoded by WSGI
+        servers, are considered when routing instead of terminating the
+        match early.
+
     .. versionadded:: 1.0
         Added ``websocket``.
 
@@ -892,7 +897,9 @@ class Rule(RuleFactory):
         else:
             tail = ""
 
-        regex = f"^{''.join(regex_parts)}{tail}$"
+        # Use \Z instead of $ to avoid matching before a %0a decoded to
+        # a \n by WSGI.
+        regex = rf"^{''.join(regex_parts)}{tail}$\Z"
         self._regex = re.compile(regex)
 
     def match(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1346,3 +1346,11 @@ def test_rule_websocket_methods():
             methods=["get", "head", "options", "post"],
         )
     r.Rule("/ws", endpoint="ws", websocket=True, methods=["get", "head", "options"])
+
+
+def test_newline_match():
+    m = r.Map([r.Rule("/hello", endpoint="hello")])
+    a = m.bind("localhost")
+
+    with pytest.raises(r.NotFound):
+        a.match("/hello\n")


### PR DESCRIPTION
The `$` in regular expressions will match *before and after* a newline character. WSGI requires the server to decode `PATH_INFO`, which can result in a requested URL `/hello%0a` looking like `/hello\n` to the application. If you have some middleware that intercepts `/hello`, depending on how it does that, this could result in the application handling the URL instead.

Use `\Z` instead of `$` to match only the true end of the string.