### PR TITLE
400 error on bad json content type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,9 @@ Unreleased
 -   ``Response.autocorrect_location_header`` is disabled by default.
     The ``Location`` header URL will remain relative, and exclude the
     scheme and domain, by default. :issue:`2352`
+-   ``Request.get_json()`` will raise a 400 ``BadRequest`` error if the
+    ``Content-Type`` header is not ``application/json``. This makes a
+    very common source of confusion more visible. :issue:`2339`
 
 
 Version 2.0.3

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1346,13 +1346,17 @@ class TestJSON:
         )
         assert response.json == value
 
-    def test_force(self):
+    def test_bad_content_type(self):
         value = [1, 2, 3]
         request = wrappers.Request.from_values(json=value, content_type="text/plain")
-        assert request.json is None
+
+        with pytest.raises(BadRequest):
+            request.get_json()
+
+        assert request.get_json(silent=True) is None
         assert request.get_json(force=True) == value
 
-    def test_silent(self):
+    def test_bad_data(self):
         request = wrappers.Request.from_values(
             data=b'{"a":}', content_type="application/json"
         )


### PR DESCRIPTION
`on_json_loading_failed` is now called when the content type isn't `application/json` (and `silent` isn't true), passing `None` instead of an exception. This makes a very common source of confusion (most JavaScript clients don't have special behavior for submitting JSON) visible to the developer.

fixes #2339