### PR TITLE
fix typos in docstrings and comments

### DIFF
--- a/examples/coolmagic/utils.py
+++ b/examples/coolmagic/utils.py
@@ -69,7 +69,7 @@ class Request(BaseRequest):
 
 class ThreadedRequest:
     """
-    A pseudo request object that always poins to the current
+    A pseudo request object that always points to the current
     context active request.
     """
 

--- a/examples/plnt/sync.py
+++ b/examples/plnt/sync.py
@@ -16,7 +16,7 @@ HTML_MIMETYPES = {"text/html", "application/xhtml+xml"}
 
 def sync():
     """
-    Performs a synchronization. Articles that are already syncronized aren't
+    Performs a synchronization. Articles that are already synchronized aren't
     touched anymore.
     """
     for blog in Blog.query.all():

--- a/examples/simplewiki/application.py
+++ b/examples/simplewiki/application.py
@@ -55,7 +55,7 @@ class SimpleWiki:
         """Dispatch an incoming request."""
         # set up all the stuff we want to have for this request.  That is
         # creating a request object, propagating the application to the
-        # current context and instanciating the database session.
+        # current context and instantiating the database session.
         self.bind_to_context()
         request = Request(environ)
         request.bind_to_context()

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -231,7 +231,7 @@ class DebuggedApplication:
     :param app: the WSGI application to run debugged.
     :param evalex: enable exception evaluation feature (interactive
                    debugging).  This requires a non-forking server.
-    :param request_key: The key that points to the request object in ths
+    :param request_key: The key that points to the request object in this
                         environment.  This parameter is ignored in current
                         versions.
     :param console_path: the URL for a general purpose console.

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -83,7 +83,7 @@ class Request(_SansIORequest):
     #: .. versionadded:: 0.5
     max_form_memory_size: t.Optional[int] = None
 
-    #: The form data parser that shoud be used.  Can be replaced to customize
+    #: The form data parser that should be used.  Can be replaced to customize
     #: the form date parsing.
     form_data_parser_class: t.Type[FormDataParser] = FormDataParser
 

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -796,7 +796,7 @@ class Response(_SansIOResponse):
         if environ["REQUEST_METHOD"] in ("GET", "HEAD"):
             # if the date is not in the headers, add it now.  We however
             # will not override an already existing header.  Unfortunately
-            # this header will be overriden by many WSGI servers including
+            # this header will be overridden by many WSGI servers including
             # wsgiref.
             if "date" not in self.headers:
                 self.headers["Date"] = http_date()

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -293,7 +293,7 @@ class TestMultiPart:
         assert lines[0] == b"'Sellersburg Town Council Meeting 02-22-2010doc.doc'"
 
     def test_end_of_file(self):
-        # This test looks innocent but it was actually timeing out in
+        # This test looks innocent but it was actually timing out in
         # the Werkzeug 0.5 release version (#394)
         data = (
             b"--foo\r\n"
@@ -326,7 +326,7 @@ class TestMultiPart:
         assert data.files["test"].read() == b"file contents"
 
     def test_extra_newline(self):
-        # this test looks innocent but it was actually timeing out in
+        # this test looks innocent but it was actually timing out in
         # the Werkzeug 0.5 release version (#394)
         data = (
             b"\r\n\r\n--foo\r\n"


### PR DESCRIPTION
Fix various English typos in the docstrings or comments of the source code.