### PR TITLE
Align use of HTML5 doctype throughout code base

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   The development server does not set ``Transfer-Encoding: chunked``
     for 1xx, 204, 304, and HEAD responses. :issue:`2375`
+-   Response HTML for exceptions and redirects starts with
+    ``<!doctype html>`` and ``<html lang=en>``. :issue:`2390`
 
 
 Version 2.1.1

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -21,7 +21,7 @@ requests.
 >>> resp.headers
 Headers([('Content-Type', 'text/html; charset=utf-8'), ('Content-Length', '6658')])
 >>> response.get_data(as_text=True)
-'<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"...'
+'<!doctype html>...'
 
 The client's request methods return instances of :class:`TestResponse`.
 This provides extra attributes and methods on top of

--- a/examples/coolmagic/templates/layout.html
+++ b/examples/coolmagic/templates/layout.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-  "http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
 <html>
   <head>
     <title>{{ page_title }} &mdash; Cool Magic!</title>

--- a/examples/couchy/templates/layout.html
+++ b/examples/couchy/templates/layout.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
- "http://www.w3.org/TR/html4/strict.dtd">
+<!doctype html>
 <html>
 <head>
   <title>Shorty</title>

--- a/examples/cupoftee/templates/layout.html
+++ b/examples/cupoftee/templates/layout.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-  "http://www.w3.org/TR/html4/strict.dtd">
+<!doctype html>
 <html>
   <head>
     <title>Teeworlds Server Browser</title>

--- a/examples/i18nurls/templates/layout.html
+++ b/examples/i18nurls/templates/layout.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-  "http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
 <html>
   <head>
     <title>{{ title }} | Example Application</title>

--- a/examples/plnt/templates/layout.html
+++ b/examples/plnt/templates/layout.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-  "http://www.w3.org/TR/html4/strict.dtd">
+<!doctype html>
 <title>Plnt Planet</title>
 <link rel="stylesheet" type="text/css" href="{{ url_for('shared', file='style.css') }}">
 

--- a/examples/shorty/templates/layout.html
+++ b/examples/shorty/templates/layout.html
@@ -1,5 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
- "http://www.w3.org/TR/html4/strict.dtd">
+<!doctype html>
 <html>
 <head>
   <title>Shorty</title>

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -523,8 +523,8 @@ mj2Z/FM1vQWgDynsRwNvrWnJHlespkrp8+vO1jNaibm+PhqXPPv30YwDZ6jApe3wUjFQobghvW9p
         injecting_start_response("200 OK", [("Content-Type", "text/html")])
         return [
             f"""\
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang=en>
 <head>
 <title>About Werkzeug</title>
 <style type="text/css">

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -12,8 +12,8 @@ from ..utils import cached_property
 from .console import Console
 
 HEADER = """\
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang=en>
   <head>
     <title>%(title)s // Werkzeug Debugger</title>
     <link rel="stylesheet" href="?__debugger__=yes&amp;cmd=resource&amp;f=style.css">

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -111,7 +111,8 @@ class HTTPException(Exception):
     ) -> str:
         """Get the HTML body."""
         return (
-            '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n'
+            "<!doctype html>\n"
+            "<html lang=en>\n"
             f"<title>{self.code} {escape(self.name)}</title>\n"
             f"<h1>{escape(self.name)}</h1>\n"
             f"{self.get_description(environ)}\n"

--- a/src/werkzeug/testapp.py
+++ b/src/werkzeug/testapp.py
@@ -60,8 +60,8 @@ kiIzwKucd0wsEHlLpe5yHXuc6FrNelOl7pY2+11kTWx7VpRu97dXA3DO1vbkhcb4zyvERYajQgAADs
 
 
 TEMPLATE = """\
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-  "http://www.w3.org/TR/html4/loose.dtd">
+<!doctype html>
+<html lang=en>
 <title>WSGI Information</title>
 <style type="text/css">
   @import url(https://fonts.googleapis.com/css?family=Ubuntu);

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -273,13 +273,15 @@ def redirect(
         from .urls import iri_to_uri
 
         location = iri_to_uri(location, safe_conversion=True)
+
     response = Response(  # type: ignore
-        '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n'
+        "<!doctype html>\n"
+        "<html lang=en>\n"
         "<title>Redirecting...</title>\n"
         "<h1>Redirecting...</h1>\n"
-        "<p>You should be redirected automatically to target URL: "
+        "<p>You should be redirected automatically to the target URL: "
         f'<a href="{html.escape(location)}">{display_location}</a>. If'
-        " not click the link.",
+        " not, click the link.\n",
         code,
         mimetype="text/html",
     )

--- a/tests/res/index.html
+++ b/tests/res/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from html import escape
 
 import pytest
 
@@ -146,3 +147,18 @@ def test_passing_response(cls):
 
 def test_description_none():
     HTTPException().get_response()
+
+
+@pytest.mark.parametrize(
+    "cls",
+    sorted(
+        (e for e in HTTPException.__subclasses__() if e.code),
+        key=lambda e: e.code,  # type: ignore
+    ),
+)
+def test_response_body(cls):
+    exc = cls()
+    response_body = exc.get_body()
+    assert response_body.startswith("<!doctype html>\n<html lang=en>\n")
+    assert f"{exc.code} {escape(exc.name)}" in response_body
+    assert exc.get_description() in response_body

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,18 +14,43 @@ from werkzeug.wrappers import Response
 
 def test_redirect():
     resp = utils.redirect("/füübär")
-    assert b"/f%C3%BC%C3%BCb%C3%A4r" in resp.get_data()
     assert resp.headers["Location"] == "/f%C3%BC%C3%BCb%C3%A4r"
     assert resp.status_code == 302
+    assert resp.get_data() == (
+        b"<!doctype html>\n"
+        b"<html lang=en>\n"
+        b"<title>Redirecting...</title>\n"
+        b"<h1>Redirecting...</h1>\n"
+        b"<p>You should be redirected automatically to the target URL: "
+        b'<a href="/f%C3%BC%C3%BCb%C3%A4r">/f\xc3\xbc\xc3\xbcb\xc3\xa4r</a>. '
+        b"If not, click the link.\n"
+    )
 
     resp = utils.redirect("http://☃.net/", 307)
-    assert b"http://xn--n3h.net/" in resp.get_data()
     assert resp.headers["Location"] == "http://xn--n3h.net/"
     assert resp.status_code == 307
+    assert resp.get_data() == (
+        b"<!doctype html>\n"
+        b"<html lang=en>\n"
+        b"<title>Redirecting...</title>\n"
+        b"<h1>Redirecting...</h1>\n"
+        b"<p>You should be redirected automatically to the target URL: "
+        b'<a href="http://xn--n3h.net/">http://\xe2\x98\x83.net/</a>. '
+        b"If not, click the link.\n"
+    )
 
     resp = utils.redirect("http://example.com/", 305)
     assert resp.headers["Location"] == "http://example.com/"
     assert resp.status_code == 305
+    assert resp.get_data() == (
+        b"<!doctype html>\n"
+        b"<html lang=en>\n"
+        b"<title>Redirecting...</title>\n"
+        b"<h1>Redirecting...</h1>\n"
+        b"<p>You should be redirected automatically to the target URL: "
+        b'<a href="http://example.com/">http://example.com/</a>. '
+        b"If not, click the link.\n"
+    )
 
 
 def test_redirect_xss():


### PR DESCRIPTION
Align doctypes throughout the code base to `<!doctype html>`.

- fixes #2390

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
