### PR TITLE
Broaden allowed return type of write callable

### DIFF
--- a/src/werkzeug/middleware/lint.py
+++ b/src/werkzeug/middleware/lint.py
@@ -117,7 +117,7 @@ class ErrorStream:
 
 
 class GuardedWrite:
-    def __init__(self, write: t.Callable[[bytes], None], chunks: t.List[int]) -> None:
+    def __init__(self, write: t.Callable[[bytes], object], chunks: t.List[int]) -> None:
         self._write = write
         self._chunks = chunks
 


### PR DESCRIPTION
If you don't care what the callable returns, it's better to use `object` so users can pass a callable that returns something else. For example, some `.write()` methods return the number of bytes written.

Noticed this in python/mypy#12663.