### PR TITLE
set cache_control with none type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
     for 1xx, 204, 304, and HEAD responses. :issue:`2375`
 -   Response HTML for exceptions and redirects starts with
     ``<!doctype html>`` and ``<html lang=en>``. :issue:`2390`
+-   Fix ability to set some ``cache_control`` attributes to ``False``.
+    :issue:`2379`
 
 
 Version 2.1.1

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -2036,7 +2036,10 @@ class _CacheControl(UpdateDictMixin, dict):
             elif value is True:
                 self[key] = None
             else:
-                self[key] = type(value)
+                if type is not None:
+                    self[key] = type(value)
+                else:
+                    self[key] = value
 
     def _del_cache_value(self, key):
         """Used internally by the accessor properties."""

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -973,6 +973,8 @@ class TestCacheControl:
         assert cc.no_cache is None
         cc.no_cache = None
         assert cc.no_cache is None
+        cc.no_cache = False
+        assert cc.no_cache is False
 
 
 class TestContentSecurityPolicy:


### PR DESCRIPTION
`cache_control` properties that had a `None` type weren't checking that before attempting to cast the value while setting. Another type issue came up in #2364, need to transition to using bool type for bool attributes.

fixes #2379 