### PR TITLE
disable keep-alive connections in dev server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Unreleased
     ``<!doctype html>`` and ``<html lang=en>``. :issue:`2390`
 -   Fix ability to set some ``cache_control`` attributes to ``False``.
     :issue:`2379`
+-   Disable ``keep-alive`` connections in the development server, which
+    are not supported sufficiently by Python's ``http.server``.
+    :issue:`2397`
 
 
 Version 2.1.1


### PR DESCRIPTION
Always send `Connection: close`, even in HTTP/1.1 mode. This disables keep-alive connections, while still allowing `Transfer-Encoding: chunked`. HTTP/1.1 is still only enabled in threaded/processes mode, since it exhibits some weird blocking issue in single threaded mode.

fixes #2397