### PR TITLE
`any` converter validates the value to `url_for`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Version 2.2.0
     machine. :pr:`2433`
 -   Names within options headers are always converted to lowercase. This
     matches :rfc:`6266` that the case is not relevant. :issue:`2442`
+-   ``AnyConverter`` validates the value passed for it when building
+    URLs. :issue:`2388`
 
 
 Version 2.1.2

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -81,13 +81,24 @@ class AnyConverter(BaseConverter):
     :param map: the :class:`Map`.
     :param items: this function accepts the possible items as positional
                   arguments.
+
+    .. versionchanged:: 2.2
+        Value is validated when building a URL.
     """
 
     part_isolating = True
 
     def __init__(self, map: "Map", *items: str) -> None:
         super().__init__(map)
+        self.items = set(items)
         self.regex = f"(?:{'|'.join([re.escape(x) for x in items])})"
+
+    def to_url(self, value: t.Any) -> str:
+        if value in self.items:
+            return str(value)
+
+        valid_values = ", ".join(f"'{item}'" for item in sorted(self.items))
+        raise ValueError(f"'{value}' is not one of {valid_values}")
 
 
 class PathConverter(BaseConverter):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -757,6 +757,19 @@ def test_anyconverter():
     assert a.match("/a.2") == ("yes_dot", {"a": "a.2"})
 
 
+def test_any_converter_build_validates_value() -> None:
+    m = r.Map([r.Rule("/<any(patient, provider):value>", endpoint="actor")])
+    a = m.bind("localhost")
+
+    assert a.build("actor", {"value": "patient"}) == "/patient"
+    assert a.build("actor", {"value": "provider"}) == "/provider"
+
+    with pytest.raises(ValueError) as exc:
+        a.build("actor", {"value": "invalid"})
+
+    assert str(exc.value) == "'invalid' is not one of 'patient', 'provider'"
+
+
 @pytest.mark.parametrize(
     ("endpoint", "value", "expect"),
     [


### PR DESCRIPTION
Add method for to_url for AnyConverter. Add protection for AnyConverter to raise a ValueError for items not specified in the rule when the build method is called by running a `value in set(items)` check.

Add test for assertions where values do match to items in the rule, and assertions for something invalid.

- fixes #2388 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
