### PR TITLE
Support PathLike as type for filename argument in FileStorage class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 .. currentmodule:: werkzeug
 
+-   Add ``os.PathLike`` as a supported type for
+    ``werkzeug.datastructures.FileStorage`` in the typing information
+    file. It was already supported by the code.
+
+
 Version 2.1.2
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 2.1.3
+-------------
+
+Unreleased
+
 -   Add ``os.PathLike`` as a supported type for
     ``werkzeug.datastructures.FileStorage`` in the typing information
-    file. It was already supported by the code.
+    file. It was already supported by the code. :pr:`2418`
 
 
 Version 2.1.2

--- a/docs/datastructures.rst
+++ b/docs/datastructures.rst
@@ -122,7 +122,8 @@ Others
 
    .. attribute:: filename
 
-      The filename of the file on the client.
+      The filename of the file on the client. Can be a ``str``, or an
+      instance of ``os.PathLike``.
 
    .. attribute:: name
 

--- a/src/werkzeug/datastructures.pyi
+++ b/src/werkzeug/datastructures.pyi
@@ -896,7 +896,7 @@ class FileStorage:
     def __init__(
         self,
         stream: Optional[IO[bytes]] = None,
-        filename: Optional[str] = None,
+        filename: Union[str, PathLike, None] = None,
         name: Optional[str] = None,
         content_type: Optional[str] = None,
         content_length: Optional[int] = None,

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -2007,8 +2007,10 @@ class MapAdapter:
                 if isinstance(rule.redirect_to, str):
 
                     def _handle_match(match: t.Match[str]) -> str:
-                        value = rv[match.group(1)]  # type: ignore
-                        return rule._converters[match.group(1)].to_url(value)
+                        value = rv[match.group(1)]  # type: ignore # noqa: B023
+                        return rule._converters[match.group(1)].to_url(  # noqa: B023
+                            value
+                        )
 
                     redirect_url = _simple_rule_re.sub(_handle_match, rule.redirect_to)
                 else:


### PR DESCRIPTION
The code already supports this. Under the hood, it calls `os.fsdecode()` on filename. It's just the types that need updating.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
