### PR TITLE
Set AST node fallback end_lineno & end_col_offset as well

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 2.2.0
 -   Added the ``werkzeug.debug.preserve_context`` mechanism for
     restoring context-local data for a request when running code in the
     debug console. :pr:`2439`
+-   Fix compatibility with Python 3.11 by ensuring that ``end_lineno``
+    and ``end_col_offset`` are present on AST nodes. :issue:`2425`
 
 
 Version 2.1.2

--- a/src/werkzeug/routing.py
+++ b/src/werkzeug/routing.py
@@ -1067,8 +1067,12 @@ class Rule(RuleFactory):
         for node in ast.walk(module):
             if "lineno" in node._attributes:
                 node.lineno = 1
+            if "end_lineno" in node._attributes:
+                node.end_lineno = node.lineno  # type: ignore[attr-defined]
             if "col_offset" in node._attributes:
                 node.col_offset = 0
+            if "end_col_offset" in node._attributes:
+                node.end_col_offset = node.col_offset  # type: ignore[attr-defined]
 
         code = compile(module, "<werkzeug routing>", "exec")
         return self._get_func_code(code, func_ast.name)


### PR DESCRIPTION
When setting the fallback values for lineno & col_offset, set them
also for end_lineno & end_col_offset.  This fixes a regression
in Python 3.11.0b2 where lineno without end_lineno would cause
an exception to be thrown.

Fixes #2425

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] <del>Add or update relevant docs, in the docs folder and in code.</del>
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] <del>Add `.. versionchanged::` entries in any relevant code docs.</del>
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
