### PR TITLE
improve use of `ContextVar` in `local`

### DIFF
--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -3,6 +3,7 @@ import copy
 import math
 import operator
 import time
+from contextvars import ContextVar
 from functools import partial
 from threading import Thread
 
@@ -10,9 +11,23 @@ import pytest
 
 from werkzeug import local
 
+# Since the tests are creating local instances, use global context vars
+# to avoid accumulating anonymous context vars that can't be collected.
+_cv_ns = ContextVar("werkzeug.tests.ns")
+_cv_stack = ContextVar("werkzeug.tests.stack")
+
+
+@pytest.fixture(autouse=True)
+def reset_context_vars():
+    ns_token = _cv_ns.set({})
+    stack_token = _cv_stack.set([])
+    yield
+    _cv_ns.reset(ns_token)
+    _cv_stack.reset(stack_token)
+
 
 def test_basic_local():
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     ns.foo = 0
     values = []
 
@@ -40,7 +55,7 @@ def test_basic_local():
 
 
 def test_basic_local_asyncio():
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     ns.foo = 0
     values = []
 
@@ -68,19 +83,19 @@ def test_basic_local_asyncio():
 
 
 def test_local_release():
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     ns.foo = 42
     local.release_local(ns)
     assert not hasattr(ns, "foo")
 
-    ls = local.LocalStack()
+    ls = local.LocalStack(_cv_stack)
     ls.push(42)
     local.release_local(ls)
     assert ls.top is None
 
 
 def test_local_stack():
-    ls = local.LocalStack()
+    ls = local.LocalStack(_cv_stack)
     assert ls.top is None
     ls.push(42)
     assert ls.top == 42
@@ -104,12 +119,12 @@ def test_local_stack():
 
 
 def test_local_stack_asyncio():
-    ls = local.LocalStack()
+    ls = local.LocalStack(_cv_stack)
     ls.push(1)
 
     async def task():
         ls.push(1)
-        assert len(ls._local.stack) == 2
+        assert len(ls._storage.get()) == 2
 
     async def main():
         futures = [asyncio.ensure_future(task()) for _ in range(3)]
@@ -119,7 +134,7 @@ def test_local_stack_asyncio():
 
 
 def test_proxy_local():
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     ns.foo = []
     p = local.LocalProxy(ns, "foo")
     p.append(42)
@@ -160,7 +175,7 @@ def test_proxy_wrapped():
     partial_proxy = local.LocalProxy(partial_lookup_func)
     assert partial_proxy.__wrapped__ == partial_lookup_func
 
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     ns.foo = SomeClassWithWrapped()
     ns.bar = 42
 
@@ -178,7 +193,7 @@ def test_proxy_doc():
 
 
 def test_proxy_fallback():
-    local_stack = local.LocalStack()
+    local_stack = local.LocalStack(_cv_stack)
     local_proxy = local_stack()
 
     assert repr(local_proxy) == "<LocalProxy unbound>"
@@ -195,7 +210,7 @@ def test_proxy_fallback():
 
 
 def test_proxy_unbound():
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     p = ns("value")
     assert repr(p) == "<LocalProxy unbound>"
     assert not p
@@ -203,7 +218,7 @@ def test_proxy_unbound():
 
 
 def _make_proxy(value):
-    ns = local.Local()
+    ns = local.Local(_cv_ns)
     ns.value = value
     p = ns("value")
     return ns, p


### PR DESCRIPTION
After doing some more research on [`ContextVar`](https://docs.python.org/3/library/contextvars.html) recently, I identified some changes to make to Werkzeug's `local` module. The `contextvars` module is documented accurately but lacks a lot of good examples, and there are almost no blogs or other discussions about it.

---

Context vars should only be created at the global scope. If it's within a function, especially a class `__init__` method, it will cause reference cycles that cannot be garbage collected. For example, all the `test_local` tests created `Local` objects, which created `ContextVar` objects internally, and if I printed out `list(contextvars.copy_context().keys())` I got a huge list of objects.

`Local` and `LocalStack` only make sense defined globally (except in our own tests), so I think it's ok for them to continue creating a `ContextVar` internally. I wouldn't expect a local to be garbage collected anyway. I've added a `context_var` argument to both to allow passing in an externally created `ContextVar`.

---

`asyncio` uses `copy_context()` internally to pass a copy of the current context to child tasks. `asgiref` goes the other direction too and copies changes to that nested context back to the calling task when the child is finished. The copy is shallow, so if a context var had a mutable value, mutations to that value (rather than setting a new value) are _not_ context safe.

We already recognized this in the original refactor to use `ContextVar`, but I don't think we discussed exactly _why_ it was an issue before. I'm convinced that we should try to move away from `LocalStack` in Flask. Instead `RequestContext.push` should use `ContextVar.set`, store the token, then `RequestContext.pop` should do `ContextVar.reset(token)`. This makes it a single-linked list instead of a stack, and I think would remove the need for copying a stack if managed correctly. I'll have to look into this more.

I did remove some indirection by having `LocalStack` use a `ContextVar` directly instead of a `Local`. This also means that only the list needs to be copied instead of both the list and the `Local` dict.

---

Context vars are named, and share a single namespace, regardless of where or when they are created. Using the same name isn't an error, but makes it impossible to reference both when using the `Context` object returned by `contextvars.copy_context()`.

Therefore, the context vars created by `Local` and `LocalStack` should have unique names. I've used the pattern `werkzeug.ClassName<id(self)>.storage`.

I also replaced a `Local` used by the debugger console with two context vars, each with unique names indicating they're part of Werkzeug.

---

`LocalProxy` can now proxy a `ContextVar` or `LocalStack` directly. This makes working with `ContextVar` a lot easier. You still need to do `var.set(value)`, but never need to do `var.get(None)` to check if its bound. Instead, you just treat it like the object it will be set to. This is related to my discussion above about moving away from `LocalStack`.

```python
_user = ContextVar("user")
user = LocalProxy(_user)
_user.set(User(id))
```

`_get_current_object` is also replaced based on the type being proxied, so it does not require an `isinstance` check on every proxied call.

---

`LocalProxy` will use the `name` parameter for other objects besides `Local`, although it's only required for `Local`. It can also show a custom error message for unbound objects. This makes the pattern in Flask where we had to define a bunch of functions to access attributes on `RequestContext` unnecessary.

```python
_req_ctx_stack_var = ContextVar("flask.request_ctx_stack")
_req_ctx_stack = LocalStack(_req_ctx_stack_var)
_req_ctx = _req_ctx()  # no idea why Flask doesn't already do this instead of _stack.top everywhere

_no_req_msg = "This can only be used while handling a request."

request = _req_ctx_stack("request", unbound_message=_no_req_msg)
session = _req_ctx_stack("session", unbound_message=_no_req_msg)
```