### PR TITLE
debugger: check both the path and realpath in is_library

### DIFF
--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -361,7 +361,7 @@ class DebugFrameSummary(traceback.FrameSummary):
     @cached_property
     def is_library(self) -> bool:
         return any(
-            self.filename.startswith(os.path.realpath(path))
+            self.filename.startswith((path, os.path.realpath(path)))
             for path in sysconfig.get_paths().values()
         )
 


### PR DESCRIPTION
Since https://github.com/pallets/werkzeug/commit/70a61859d2ab0d628aeb6189b94d0fce45345373 the debugger's `is_library` check hasn't worked the same when symlinks are involved.  If a file is on a symlinked path, previously `self.filename` was the "real" resolved path and now it has the given non-resolved path.

I didn't think we should change `self.filename` now (might affect other things), and it seemed simple to check against both the given and realpath paths within `is_library` so either way it can match.
