### PR TITLE
add mechanism for restoring context-local data in the debug console

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,9 @@
 Version 2.2.0
 -------------
 
-Unreleased
+-   Added the ``werkzeug.debug.preserve_context`` mechanism for
+    restoring context-local data for a request when running code in the
+    debug console. :pr:`2439`
 
 
 Version 2.1.2


### PR DESCRIPTION
In https://github.com/pallets/flask/issues/2836, it was discovered that Flask's context locals (`request`, `current_app`, etc.) were not being restored correctly in the debug console. They could be incorrect or unset.

This is because the debugger only preserves the frames, but if the server is not single threaded then any context-local data will never be active again when new workers handles subsequent console requests.

This adds a mechanism for recording extra context with a traceback's frames. When `evalex` is enabled, the debugger will set `environ["werkzeug.debug.preserve_context"]` to a callable. This takes a context manager and can be called multiple times during a request. All context managers registered in such a way are stored with the traceback frames. When a console request comes in, the context managers are activated using a `with` block around the eval call.

Now Flask can do something like the following to preserve app and request contexts for each error:

```python
try:
    ...
except:
    if "werkzeug.debug.preserve_context" in environ:
        environ["werkzeug.debug.preserve_context"](_app_ctx_stack.top)
        environ["werkzeug.debug.preserve_context"](_request_ctx_stack.top)
```

I'm pretty pleased with this design, it feels very "WSGI". The callable is injected by the middleware to be visible to the wrapped application, and it can be called from anywhere down the stack to communicate information back to the middleware.