### PR TITLE
Record the search position in the multipart parser

### DIFF
--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -70,6 +70,10 @@ LINE_BREAK_RE = re.compile(LINE_BREAK, re.MULTILINE)
 # Header values can be continued via a space or tab after the linebreak, as
 # per RFC2231
 HEADER_CONTINUATION_RE = re.compile(b"%s[ \t]" % LINE_BREAK, re.MULTILINE)
+# This must be long enough to contain any line breaks plus any
+# additional boundary markers (--) such that they will be found in a
+# subsequent search
+SEARCH_EXTRA_LENGTH = 8
 
 
 class MultipartDecoder:
@@ -113,6 +117,7 @@ class MultipartDecoder:
             % (LINE_BREAK, re.escape(boundary), LINE_BREAK, LINE_BREAK),
             re.MULTILINE,
         )
+        self._search_position = 0
 
     def last_newline(self) -> int:
         try:
@@ -141,7 +146,7 @@ class MultipartDecoder:
         event: Event = NEED_DATA
 
         if self.state == State.PREAMBLE:
-            match = self.preamble_re.search(self.buffer)
+            match = self.preamble_re.search(self.buffer, self._search_position)
             if match is not None:
                 if match.group(1).startswith(b"--"):
                     self.state = State.EPILOGUE
@@ -150,9 +155,17 @@ class MultipartDecoder:
                 data = bytes(self.buffer[: match.start()])
                 del self.buffer[: match.end()]
                 event = Preamble(data=data)
+                self._search_position = 0
+            else:
+                # Update the search start position to be equal to the
+                # current buffer length (already searched) minus a
+                # safe buffer for part of the search target.
+                self._search_position = max(
+                    0, len(self.buffer) - len(self.boundary) - SEARCH_EXTRA_LENGTH
+                )
 
         elif self.state == State.PART:
-            match = BLANK_LINE_RE.search(self.buffer)
+            match = BLANK_LINE_RE.search(self.buffer, self._search_position)
             if match is not None:
                 headers = self._parse_headers(self.buffer[: match.start()])
                 del self.buffer[: match.end()]
@@ -177,6 +190,12 @@ class MultipartDecoder:
                         name=name,
                     )
                 self.state = State.DATA
+                self._search_position = 0
+            else:
+                # Update the search start position to be equal to the
+                # current buffer length (already searched) minus a
+                # safe buffer for part of the search target.
+                self._search_position = max(0, len(self.buffer) - SEARCH_EXTRA_LENGTH)
 
         elif self.state == State.DATA:
             if self.buffer.find(b"--" + self.boundary) == -1:


### PR DESCRIPTION
This prevents the parser continually searching the same data, which
improves the performance of the parser and mitigates against a
potential attack vector.

The search position is only required for the PREAMBLE and PART states
as the DATA and EPILOGUE states consume the data as it is parsed.

fixes #2430 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
