### PR TITLE
Lowercase the parsed options names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,9 @@ Version 2.2.0
 -   Fix compatibility with Python 3.11 by ensuring that ``end_lineno``
     and ``end_col_offset`` are present on AST nodes. :issue:`2425`
 -   Add a new faster matching router based on a state
-    machine. :pr:`2433`.
+    machine. :pr:`2433`
+-   Names within options headers are always converted to lowercase. This
+    matches :rfc:`6266` that the case is not relevant. :issue:`2442`
 
 
 Version 2.1.2

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -390,6 +390,9 @@ def parse_options_header(
 
     :param value: The header value to parse.
 
+    .. versionchanged:: 2.2
+        Option names are always converted to lowercase.
+
     .. versionchanged:: 2.1
         The ``multiple`` parameter is deprecated and will be removed in
         Werkzeug 2.2.
@@ -440,7 +443,7 @@ def parse_options_header(
                 if not encoding:
                     encoding = continued_encoding
                 continued_encoding = encoding
-            option = unquote_header_value(option)
+            option = unquote_header_value(option).lower()
 
             if option_value is not None:
                 option_value = unquote_header_value(option_value, option == "filename")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -358,6 +358,10 @@ class TestHTTPUtility:
         assert http.parse_options_header(" , a ") == ("", {})
         assert http.parse_options_header(" ; a ") == ("", {})
 
+    def test_parse_options_header_case_insensitive(self):
+        _, options = http.parse_options_header(r'something; fileName="File.ext"')
+        assert options["filename"] == "File.ext"
+
     def test_dump_options_header(self):
         assert http.dump_options_header("foo", {"bar": 42}) == "foo; bar=42"
         assert http.dump_options_header("foo", {"bar": 42, "fizz": None}) in (


### PR DESCRIPTION
I cannot find a RFC that indicates that the option names are case
sensitive whereas RFC6266 states that the `filename` option name is
case insensitive. Therefore the best user experience is to lowercase
the names.

This will cause breaking changes if case sensitivity is relied upon,
and hence users will need to use the lowercase name if so.

closes #2422 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
