### PR TITLE
Demonstrate MultiDict inconsistency in PyPy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,10 +28,13 @@ jobs:
           - {name: Windows, python: '3.10', os: windows-latest, tox: py310}
           - {name: Mac, python: '3.10', os: macos-latest, tox: py310}
           - {name: '3.11-dev', python: '3.11-dev', os: ubuntu-latest, tox: py311}
+          - {name: '3.10', python: '3.10', os: ubuntu-latest, tox: py310}
           - {name: '3.9', python: '3.9', os: ubuntu-latest, tox: py39}
           - {name: '3.8', python: '3.8', os: ubuntu-latest, tox: py38}
           - {name: '3.7', python: '3.7', os: ubuntu-latest, tox: py37}
-          - {name: 'PyPy', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
+          - {name: 'PyPy-3.9', python: 'pypy-3.9', os: ubuntu-latest, tox: pypy39}
+          - {name: 'PyPy-3.8', python: 'pypy-3.8', os: ubuntu-latest, tox: pypy38}
+          - {name: 'PyPy-3.7', python: 'pypy-3.7', os: ubuntu-latest, tox: pypy37}
           - {name: Typing, python: '3.10', os: ubuntu-latest, tox: typing}
     steps:
       - uses: actions/checkout@v3

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -79,6 +79,7 @@ class _MutableMultiDictTests:
 
     def test_multidict_kwargs(self):
         result = None
+
         def _inner(**k):
             nonlocal result
             result = k
@@ -86,7 +87,6 @@ class _MutableMultiDictTests:
         md = self.storage_class([("a", 1)])
         _inner(**md)
         assert result == {"a": 1}
-
 
     def test_basic_interface(self):
         md = self.storage_class()

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -77,6 +77,17 @@ class _MutableMultiDictTests:
         assert dict(md)["a"] == 1
         assert dict(md) == {**md} == {"a": 1}
 
+    def test_multidict_kwargs(self):
+        result = None
+        def _inner(**k):
+            nonlocal result
+            result = k
+
+        md = self.storage_class([("a", 1)])
+        _inner(**md)
+        assert result == {"a": 1}
+
+
     def test_basic_interface(self):
         md = self.storage_class()
         assert isinstance(md, dict)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{11,10,9,8,7},pypy3{8,7}
+    py3{11,10,9,8,7},pypy3{9,8,7}
     style
     typing
     docs


### PR DESCRIPTION
I think most Python implementations utilise `.items()` when unpacking
in a function call `func(**md)` but pypy39 does something
else. Therefore there is inconsistency in the result of,

    def func(**k):
        print(k)

    md = MultDict([("a", 1)])
    func(**md)

Currently in most Python versions `{"a": 1}` is printed. In PyPy39
`{"a": [1]}` is printed, which I think is more correct.

I'm unsure what to do - maybe `**md` is the bad practice? @jab 

A usecase is in Flask/Quart `jsonify(**md)`

See the CI tests for PyPy.