### PR TITLE
use markupsafe for escaping values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 Version 2.2.0
 -------------
 
+-   Add MarkupSafe as a dependency and use it to escape values when
+    rendering HTML. :issue:`2419`
 -   Added the ``werkzeug.debug.preserve_context`` mechanism for
     restoring context-local data for a request when running code in the
     debug console. :pr:`2439`

--- a/docs/levels.rst
+++ b/docs/levels.rst
@@ -19,7 +19,7 @@ user with the name entered.
 
 .. code-block:: python
 
-    from html import escape
+    from markupsafe import escape
     from werkzeug.wrappers import Request, Response
 
     @Request.application
@@ -38,7 +38,7 @@ user with the name entered.
 Alternatively the same application could be used without request and response
 objects but by taking advantage of the parsing functions werkzeug provides::
 
-    from html import escape
+    from markupsafe import escape
     from werkzeug.formparser import parse_form_data
 
     def hello_world(environ, start_response):

--- a/examples/plnt/sync.py
+++ b/examples/plnt/sync.py
@@ -1,8 +1,8 @@
 """Does the synchronization. Called by "manage-plnt.py sync"."""
 from datetime import datetime
-from html import escape
 
 import feedparser
+from markupsafe import escape
 
 from .database import Blog
 from .database import Entry

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ from setuptools import setup
 # Metadata goes in setup.cfg. These are here for GitHub's dependency graph.
 setup(
     name="Werkzeug",
+    install_requires=["MarkupSafe>=2.1.1"],
     extras_require={"watchdog": ["watchdog"]},
 )

--- a/src/werkzeug/debug/console.py
+++ b/src/werkzeug/debug/console.py
@@ -2,8 +2,9 @@ import code
 import sys
 import typing as t
 from contextvars import ContextVar
-from html import escape
 from types import CodeType
+
+from markupsafe import escape
 
 from .repr import debug_repr
 from .repr import dump
@@ -172,7 +173,7 @@ class _InteractiveConsole(code.InteractiveInterpreter):
                 del self.buffer[:]
         finally:
             output = ThreadedStream.fetch()
-        return prompt + escape(source) + output
+        return f"{prompt}{escape(source)}{output}"
 
     def runcode(self, code: CodeType) -> None:
         try:

--- a/src/werkzeug/debug/repr.py
+++ b/src/werkzeug/debug/repr.py
@@ -9,8 +9,9 @@ import re
 import sys
 import typing as t
 from collections import deque
-from html import escape
 from traceback import format_exception_only
+
+from markupsafe import escape
 
 missing = object()
 _paragraph_re = re.compile(r"(?:\r\n|\r|\n){2,}")

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -6,7 +6,8 @@ import sys
 import sysconfig
 import traceback
 import typing as t
-from html import escape
+
+from markupsafe import escape
 
 from ..utils import cached_property
 from .console import Console

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -45,7 +45,9 @@ code, you can add a second except for a specific subclass of an error:
 """
 import typing as t
 from datetime import datetime
-from html import escape
+
+from markupsafe import escape
+from markupsafe import Markup
 
 from ._internal import _get_environ
 
@@ -101,7 +103,7 @@ class HTTPException(Exception):
         else:
             description = self.description
 
-        description = escape(description).replace("\n", "<br>")
+        description = escape(description).replace("\n", Markup("<br>"))
         return f"<p>{description}</p>"
 
     def get_body(

--- a/src/werkzeug/testapp.py
+++ b/src/werkzeug/testapp.py
@@ -5,8 +5,9 @@ import base64
 import os
 import sys
 import typing as t
-from html import escape
 from textwrap import wrap
+
+from markupsafe import escape
 
 from . import __version__ as _werkzeug_version
 from .wrappers.request import Request
@@ -181,8 +182,8 @@ def render_testapp(req: Request) -> bytes:
     wsgi_env = []
     sorted_environ = sorted(req.environ.items(), key=lambda x: repr(x[0]).lower())
     for key, value in sorted_environ:
-        value = "".join(wrap(escape(repr(value))))
-        wsgi_env.append(f"<tr><th>{escape(str(key))}<td><code>{value}</code>")
+        value = "".join(wrap(str(escape(repr(value)))))
+        wsgi_env.append(f"<tr><th>{escape(key)}<td><code>{value}</code>")
 
     sys_path = []
     for item, virtual, expanded in iter_sys_path():

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -10,6 +10,8 @@ from datetime import datetime
 from time import time
 from zlib import adler32
 
+from markupsafe import escape
+
 from ._internal import _DictAccessorProperty
 from ._internal import _missing
 from ._internal import _TAccessorValue
@@ -261,12 +263,10 @@ def redirect(
         response. The default is :class:`werkzeug.wrappers.Response` if
         unspecified.
     """
-    import html
-
     if Response is None:
         from .wrappers import Response  # type: ignore
 
-    display_location = html.escape(location)
+    display_location = escape(location)
     if isinstance(location, str):
         # Safe conversion is necessary here as we might redirect
         # to a broken URI scheme (for instance itms-services).
@@ -280,7 +280,7 @@ def redirect(
         "<title>Redirecting...</title>\n"
         "<h1>Redirecting...</h1>\n"
         "<p>You should be redirected automatically to the target URL: "
-        f'<a href="{html.escape(location)}">{display_location}</a>. If'
+        f'<a href="{escape(location)}">{display_location}</a>. If'
         " not, click the link.\n",
         code,
         mimetype="text/html",

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -24,20 +24,20 @@ class TestDebugRepr:
         )
         assert debug_repr([1, "test"]) == (
             '[<span class="number">1</span>,'
-            ' <span class="string">&#x27;test&#x27;</span>]'
+            ' <span class="string">&#39;test&#39;</span>]'
         )
         assert debug_repr([None]) == '[<span class="object">None</span>]'
 
     def test_string_repr(self):
-        assert debug_repr("") == '<span class="string">&#x27;&#x27;</span>'
-        assert debug_repr("foo") == '<span class="string">&#x27;foo&#x27;</span>'
+        assert debug_repr("") == '<span class="string">&#39;&#39;</span>'
+        assert debug_repr("foo") == '<span class="string">&#39;foo&#39;</span>'
         assert debug_repr("s" * 80) == (
-            f'<span class="string">&#x27;{"s" * 69}'
-            f'<span class="extended">{"s" * 11}&#x27;</span></span>'
+            f'<span class="string">&#39;{"s" * 69}'
+            f'<span class="extended">{"s" * 11}&#39;</span></span>'
         )
         assert debug_repr("<" * 80) == (
-            f'<span class="string">&#x27;{"&lt;" * 69}'
-            f'<span class="extended">{"&lt;" * 11}&#x27;</span></span>'
+            f'<span class="string">&#39;{"&lt;" * 69}'
+            f'<span class="extended">{"&lt;" * 11}&#39;</span></span>'
         )
 
     def test_string_subclass_repr(self):
@@ -46,7 +46,7 @@ class TestDebugRepr:
 
         assert debug_repr(Test("foo")) == (
             '<span class="module">test_debug.</span>'
-            'Test(<span class="string">&#x27;foo&#x27;</span>)'
+            'Test(<span class="string">&#39;foo&#39;</span>)'
         )
 
     def test_sequence_repr(self):
@@ -67,7 +67,7 @@ class TestDebugRepr:
     def test_mapping_repr(self):
         assert debug_repr({}) == "{}"
         assert debug_repr({"foo": 42}) == (
-            '{<span class="pair"><span class="key"><span class="string">&#x27;foo&#x27;'
+            '{<span class="pair"><span class="key"><span class="string">&#39;foo&#39;'
             '</span></span>: <span class="value"><span class="number">42'
             "</span></span></span>}"
         )
@@ -105,8 +105,8 @@ class TestDebugRepr:
             "</span></span></span></span>}"
         )
         assert debug_repr((1, "zwei", "drei")) == (
-            '(<span class="number">1</span>, <span class="string">&#x27;'
-            'zwei&#x27;</span>, <span class="string">&#x27;drei&#x27;</span>)'
+            '(<span class="number">1</span>, <span class="string">&#39;'
+            'zwei&#39;</span>, <span class="string">&#39;drei&#39;</span>)'
         )
 
     def test_custom_repr(self):
@@ -139,10 +139,10 @@ class TestDebugRepr:
     def test_set_repr(self):
         assert (
             debug_repr(frozenset("x"))
-            == 'frozenset([<span class="string">&#x27;x&#x27;</span>])'
+            == 'frozenset([<span class="string">&#39;x&#39;</span>])'
         )
         assert debug_repr(set("x")) == (
-            'set([<span class="string">&#x27;x&#x27;</span>])'
+            'set([<span class="string">&#39;x&#39;</span>])'
         )
 
     def test_recursive_repr(self):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from html import escape
 
 import pytest
+from markupsafe import escape
+from markupsafe import Markup
 
 from werkzeug import exceptions
 from werkzeug.datastructures import Headers
@@ -50,6 +51,13 @@ def test_aborter_general(test):
     with pytest.raises(exc_type) as exc_info:
         exceptions.abort(*args)
     assert type(exc_info.value) is exc_type
+
+
+def test_abort_description_markup():
+    with pytest.raises(HTTPException) as exc_info:
+        exceptions.abort(400, Markup("<b>&lt;</b>"))
+
+    assert "<b>&lt;</b>" in str(exc_info.value)
 
 
 def test_aborter_custom():


### PR DESCRIPTION
In Werkzeug 2.0, #1758, Werkzeug's own implementation of `escape` was replaced with `html.escape`. However, we maintain MarkupSafe as a faster alternative to that, and most users of Werkzeug will already have it installed through Flask. Add a dependency on MarkupSafe, and use it to escape values when rendering HTML for HTTP errors, the debugger, etc.

fixes #2419 