### PR TITLE
prerelease version 2.2.0a1

### DIFF
--- a/src/werkzeug/__init__.py
+++ b/src/werkzeug/__init__.py
@@ -3,4 +3,4 @@ from .test import Client as Client
 from .wrappers import Request as Request
 from .wrappers import Response as Response
 
-__version__ = "2.2.0.dev0"
+__version__ = "2.2.0a1"


### PR DESCRIPTION
Releasing this so Flask 2.2.0 dev can bump its dependency. Flask 2.2 will use the new debug context and local features from Werkzeug 2.2.