### PR TITLE
Fix cached_property not overriding correctly

### DIFF
--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -91,7 +91,7 @@ class cached_property(property, t.Generic[_T]):
                 res = {}
                 setattr(obj, self.slot_name, res)
             return res
-        
+
     def __set__(self, obj: object, value: _T) -> None:
         self._get_cache(obj)[self] = value
 


### PR DESCRIPTION
Instead of storing the cache directly on the instance I propose to use a dict with the property instance as the key.

- fixes #2452

TODO:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
