### PR TITLE
ignore formatting commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,19 @@
+# Since version 2.23 (released in August 2019), git-blame has a feature
+# to ignore or bypass certain commits.
+#
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# github ignores commits specified in this file by default on blame view.
+
+
+
+# Apply code style - formatting with black
+ab6150fa49afc61b0c5eed6d9545d03d1958e384
+
+# use f-strings
+0c013a04d6d8a850e249f49aa1b4cf545f109c67


### PR DESCRIPTION
I was reading some code and while trying to check history I found 2 formatting commits, these were made long time ago but git now supports ignoring them in `git blame`. 

Git 2.23 added option to ignore certain commits from `git blame` like formatting, style
changes which aren't interesting when browsing blame.

GitHub's web view also supports this from few months now: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

You can preview how github handles it on the head branch: Example: https://github.com/ankush/werkzeug/blame/ignore_format_revs/src/werkzeug/_reloader.py 

This change adds 2 known bulk format commits to .git-blame-ignore-revs file.

fixes: https://github.com/pallets/werkzeug/issues/2454 

Signed-off-by: Ankush Menat <ankush@frappe.io>
