### PR TITLE
Don't set a default mimetype for Test Responses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Version 2.2.0
     to sansio/http.py. :issue:`2408`
 -   Extracted utility get_content_length, get_query_string, get_path_info
     functions from wsgi.py. :pr:`2415`
+-   Don't assume a mimetype for test responses. :issue:`2450`
 
 
 Version 2.1.3

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -92,7 +92,7 @@ class Response:
     default_status = 200
 
     #: the default mimetype if none is provided.
-    default_mimetype = "text/plain"
+    default_mimetype: t.Optional[str] = "text/plain"
 
     #: Warn if a cookie header exceeds this size. The default, 4093, should be
     #: safely `supported by most browsers <cookie_>`_. A cookie larger than

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -1280,6 +1280,10 @@ class TestResponse(Response):
     serving a file, call :meth:`close` to close any open files and
     prevent Python showing a ``ResourceWarning``.
 
+    .. versionchanged:: 2.2
+        Set the ``default_mimetype`` to None to prevent a mimetype being
+        assumed if missing.
+
     .. versionchanged:: 2.1
         Removed deprecated behavior for treating the response instance
         as a tuple.
@@ -1287,6 +1291,9 @@ class TestResponse(Response):
     .. versionadded:: 2.0
         Test client methods always return instances of this class.
     """
+
+    default_mimetype = None
+    # Don't assume a mimetype, instead use whatever the response provides
 
     request: Request
     """A request object with the environ used to make the request that

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -876,3 +876,16 @@ def test_raw_request_uri():
 
     response = client.get("/%3f?")  # escaped ? in path, and empty query string
     assert response.text == "/?\n/%3f?"
+
+
+def no_response_headers_app(environ, start_response):
+    """A WSGI application which returns a resposne with no headers."""
+    response = Response("Response")
+    response.headers.clear()
+    return response(environ, start_response)
+
+
+def test_no_content_type_header_addition():
+    c = Client(no_response_headers_app)
+    response = c.open()
+    assert response.headers == Headers([("Content-Length", "8")])


### PR DESCRIPTION
The TestResponse should have a mimetype as defined by the response
itself. If the response is missing a mimetype then it shouldn't assume
one.

See #2450

Closes #2450

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
