### PR TITLE
Cleanup b42d1a4b57b8aba5c38fb8a030848db71004e2c5 and 81d2ed03ecf27d64…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,10 +18,10 @@ Version 2.2.0
     URLs. :issue:`2388`
 -   The debugger shows enhanced error locations in tracebacks in Python
     3.11. :issue:`2407`
--   Extracted is_resource_modified and parse_cookie from http.py
-    to sansio/http.py. :issue:`2408`
--   Extracted utility get_content_length, get_query_string, get_path_info
-    functions from wsgi.py. :pr:`2415`
+-   Added Sans-IO ``is_resource_modified`` and ``parse_cookie`` functions
+    based on WSGI versions. :issue:`2408`
+-   Added Sans-IO ``get_content_length``, ``get_query_string``,
+    ``extract_path_info`` functions. :pr:`2415`
 -   Don't assume a mimetype for test responses. :issue:`2450`
 
 

--- a/src/werkzeug/sansio/http.py
+++ b/src/werkzeug/sansio/http.py
@@ -38,15 +38,8 @@ def is_resource_modified(
     :param ignore_if_range: If `False`, `If-Range` header will be taken into
                             account.
     :return: `True` if the resource was modified, otherwise `False`.
-    .. versionchanged:: 2.2
-        Made arguments explicit to support ASGI.
 
-    .. versionchanged:: 2.0
-        SHA-1 is used to generate an etag value for the data. MD5 may
-        not be available in some environments.
-
-    .. versionchanged:: 1.0.0
-        The check is run for methods other than ``GET`` and ``HEAD``.
+    .. versionadded:: 2.2
     """
     if etag is None and data is not None:
         etag = generate_etag(data)
@@ -120,16 +113,7 @@ def parse_cookie(
     :param cls: A dict-like class to store the parsed cookies in.
         Defaults to :class:`MultiDict`.
 
-    .. versionchanged:: 2.2
-        Uses explicit cookie string argument
-
-    .. versionchanged:: 1.0.0
-        Returns a :class:`MultiDict` instead of a
-        ``TypeConversionDict``.
-
-    .. versionchanged:: 0.5
-       Returns a :class:`TypeConversionDict` instead of a regular dict.
-       The ``cls`` parameter was added.
+    .. versionadded:: 2.2
     """
     # PEP 3333 sends headers through the environ as latin1 decoded
     # strings. Encode strings back to bytes for parsing.

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -1,7 +1,6 @@
 import typing as t
 
 from .._internal import _encode_idna
-from .._internal import _to_str
 from ..exceptions import SecurityError
 from ..urls import _URLTuple
 from ..urls import uri_to_iri
@@ -156,10 +155,7 @@ def get_content_length(
     :param http_content_length: The Content-Length HTTP header.
     :param http_transfer_encoding: The Transfer-Encoding HTTP header.
 
-    .. versionchanged:: 2.2
-        Using explicit header parameters to support ASGI.
-
-    .. versionadded:: 0.9
+    .. versionadded:: 2.2
     """
     if http_transfer_encoding == "chunked":
         return None
@@ -177,35 +173,13 @@ def get_query_string(query_string: str = "") -> str:
 
     :param query_string: The (potentially unsafe) query string.
 
-    .. versionchanged: 2.2
-        Using explicit string parameter to support ASGI.
-
-    .. versionadded:: 0.9
+    .. versionadded:: 2.2
     """
     qs = query_string.encode("latin1")
     # QUERY_STRING really should be ascii safe but some browsers
     # will send us some unicode stuff (I am looking at you IE).
     # In that case we want to urllib quote it badly.
     return url_quote(qs, safe=":&%=+$!*'(),")
-
-
-def get_path_info(
-    path: str = "", charset: str = "utf-8", errors: str = "replace"
-) -> str:
-    """Return the decoded ``path`` unless ``charset`` is ``None``.
-
-    :param path_info: The URL path.
-    :param charset: The charset for the path info, or ``None`` if no
-        decoding should be performed.
-    :param errors: The decoding error handling.
-
-    .. versionchanged: 2.2
-        Using explicit string parameter to support ASGI.
-
-    .. versionadded:: 0.9
-    """
-    path = path.encode("latin1")
-    return _to_str(path, charset, errors, allow_none_charset=True)
 
 
 def extract_path_info(
@@ -244,14 +218,7 @@ def extract_path_info(
                                   same server point to the same
                                   resource.
 
-    .. versionchanged: 2.2
-        Using explicit baseurl string parameter to support ASGI.
-
-    .. versionchanged:: 0.15
-        The ``errors`` parameter defaults to leaving invalid bytes
-        quoted instead of replacing them.
-
-    .. versionadded:: 0.6
+    .. versionadded:: 2.2
     """
 
     def _normalize_netloc(scheme: str, netloc: str) -> str:

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -118,9 +118,6 @@ def get_content_length(environ: "WSGIEnvironment") -> t.Optional[int]:
     integer. If it's not available or chunked transfer encoding is used,
     ``None`` is returned.
 
-    .. versionchanged:: 2.2
-        Extracted this to sansio/util.py
-
     .. versionadded:: 0.9
 
     :param environ: the WSGI environ to fetch the content length from.
@@ -176,9 +173,6 @@ def get_query_string(environ: "WSGIEnvironment") -> str:
 
     :param environ: WSGI environment to get the query string from.
 
-    .. versionchanged:: 2.2
-        Extracted this to sansio/util.py
-
     .. versionadded:: 0.9
     """
     return _sansio_utils.get_query_string(query_string=environ.get("QUERY_STRING", ""))
@@ -195,14 +189,10 @@ def get_path_info(
         decoding should be performed.
     :param errors: The decoding error handling.
 
-    .. versionchanged:: 2.2
-        Extracted this to sansio/util.py
-
     .. versionadded:: 0.9
     """
-    return _sansio_utils.get_path_info(
-        path=environ.get("PATH_INFO", ""), charset=charset, errors=errors
-    )
+    path = environ.get("PATH_INFO", "").encode("latin1")
+    return _to_str(path, charset, errors, allow_none_charset=True)  # type: ignore
 
 
 def get_script_name(
@@ -216,14 +206,10 @@ def get_script_name(
         should be performed.
     :param errors: The decoding error handling.
 
-    .. versionchanged:: 2.2
-        Extracted this to sansio/util.py
-
     .. versionadded:: 0.9
     """
-    return _sansio_utils.get_path_info(
-        path=environ.get("SCRIPT_NAME", ""), charset=charset, errors=errors
-    )
+    path = environ.get("SCRIPT_NAME", "").encode("latin1")
+    return _to_str(path, charset, errors, allow_none_charset=True)  # type: ignore
 
 
 def pop_path_info(
@@ -353,9 +339,6 @@ def extract_path_info(
                                   not assume that http and https on the
                                   same server point to the same
                                   resource.
-
-    .. versionchanged:: 2.2
-        Extracted this to sansio/util.py
 
     .. versionchanged:: 0.15
         The ``errors`` parameter defaults to leaving invalid bytes


### PR DESCRIPTION
…0b3a6fe84c736a3639544874

The version markers are corrected along with the CHANGES.

The get_path_info function is WSGI specific and hence there is no
reason to extract it to the Sans-IO part.
