### PR TITLE
Ensure that rules without strict slashes match paths with slashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.2.1
 
 Unreleased
 
+-   Fix router so that ``/path/`` will match a rule ``/path`` if strict
+    slashes mode is disabled for the rule. :issue:`2467`
+
 
 Version 2.2.0
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Fix router so that ``/path/`` will match a rule ``/path`` if strict
     slashes mode is disabled for the rule. :issue:`2467`
+-   Restore ``ValidationError`` to be importable from
+    ``werkzeug.routing``. :issue:`2465`
 
 
 Version 2.2.0

--- a/src/werkzeug/routing/__init__.py
+++ b/src/werkzeug/routing/__init__.py
@@ -112,6 +112,7 @@ from .converters import IntegerConverter
 from .converters import PathConverter
 from .converters import UnicodeConverter
 from .converters import UUIDConverter
+from .converters import ValidationError
 from .exceptions import BuildError
 from .exceptions import NoMatch
 from .exceptions import RequestAliasRedirect

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -129,6 +129,22 @@ class StateMachineMatcher:
                     rv = _match(new_state, remaining, values + list(match.groups()))
                     if rv is not None:
                         return rv
+
+            # If there is no match and the only part left is a
+            # trailing slash ("") consider rules that aren't
+            # strict-slashes as these should match if there is a final
+            # slash part.
+            if parts == [""]:
+                for rule in state.rules:
+                    if rule.strict_slashes:
+                        continue
+                    if rule.methods is not None and method not in rule.methods:
+                        have_match_for.update(rule.methods)
+                    elif rule.websocket != websocket:
+                        websocket_mismatch = True
+                    else:
+                        return rule, values
+
             return None
 
         try:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -219,6 +219,7 @@ def test_strict_slashes_leaves_dont_consume():
             r.Rule("/path3/", endpoint="branch", strict_slashes=False),
             r.Rule("/path4", endpoint="leaf", strict_slashes=False),
             r.Rule("/path4/", endpoint="branch", strict_slashes=False),
+            r.Rule("/path5", endpoint="leaf"),
         ],
         strict_slashes=False,
     )
@@ -233,6 +234,7 @@ def test_strict_slashes_leaves_dont_consume():
     assert adapter.match("/path3/", method="GET") == ("branch", {})
     assert adapter.match("/path4", method="GET") == ("leaf", {})
     assert adapter.match("/path4/", method="GET") == ("branch", {})
+    assert adapter.match("/path5/", method="GET") == ("leaf", {})
 
 
 def test_environ_defaults():


### PR DESCRIPTION
A rule defined as `/path` with strict-slashes == False should match a
path `/path/` but only if there isn't a rule that directly matches
`/path/`. This restores the previous 2.2.0 behaviour.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.

This closes #2467.
This closes #2465.