### PR TITLE
Add a new slash_behavior option to replace strict_slashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Version 2.3.0
 
 Unreleased
 
+-   Deprecate the ``strict_slashes`` option replacing it with a
+    ``slash_behavior`` option. ``strict_slashes == True`` is
+    equivalent to ``SlashBehavior.REDIRECT`` and ``strict_slashes ==
+    False`` is equivalent to ``SlashBehavior.EXACT``. :pr:`2487`
+
 
 Version 2.2.1
 -------------

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -74,10 +74,6 @@ format ``<converter(arguments):name>``. ``converter`` and ``arguments``
 ``default`` converter is used (``string`` by default). The available
 converters are discussed below.
 
-Rules that end with a slash are "branches", others are "leaves". If
-``strict_slashes`` is enabled (the default), visiting a branch URL
-without a trailing slash will redirect to the URL with a slash appended.
-
 Many HTTP servers merge consecutive slashes into one when receiving
 requests. If ``merge_slashes`` is enabled (the default), rules will
 merge slashes in non-variable parts when matching and building. Visiting
@@ -85,6 +81,27 @@ a URL with consecutive slashes will redirect to the URL with slashes
 merged. If you want to disable ``merge_slashes`` for a :class:`Rule` or
 :class:`Map`, you'll also need to configure your web server
 appropriately.
+
+
+Trailing slashes
+================
+
+Rules that end with a slash are "branches", others are "leaves". There
+are different :class:`SlashBehavior` available to define how requests
+should (or not) match.
+
+- ``SlashBehavior.REDIRECT_BRANCH`` A request without a trailing slash will
+  redirect to a matching branch rule.
+- ``SlashBehavior.MATCH_ALL`` A request will match a leaf if there is a
+  trailing slash included, and will match a branch if one is omitted.
+- ``SlashBehavior.EXACT`` A request will have to match the rule. Only
+  requests without trailing slashes will match leaves and only
+  requests with trailing slashes will match branches.
+
+This behavior can be set on the :class:`Map` or overidden for
+individual :class:`Rule`.
+
+The ``SlashBehavior.REDIRECT_BRANCH`` is the default.
 
 
 Built-in Converters

--- a/src/werkzeug/routing/__init__.py
+++ b/src/werkzeug/routing/__init__.py
@@ -129,5 +129,6 @@ from .rules import Rule
 from .rules import RuleFactory
 from .rules import RuleTemplate
 from .rules import RuleTemplateFactory
+from .rules import SlashBehavior
 from .rules import Subdomain
 from .rules import Submount


### PR DESCRIPTION
The strict_slashes behavior is confusing and there are three aspects
people expect, MATCH_ALL matching, EXACT matching, or REDIRECT_BRANCH
matching. Therefore the strict_slashes option is replaced by these
three behaviors as options.

- ``SlashBehavior.MATCH_ALL`` A request will match a leaf if there is a
  trailing slash included, and will match a branch if one is omitted.
- ``SlashBehavior.EXACT`` A request will have to match the rule. Only
  requests without trailing slashes will match leaves and only
  requests with trailing slashes will match branches.
- ``SlashBehavior.REDIRECT_BRANCH`` A request without a trailing slash will
  be redirect to a matching branch rule.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
