### PR TITLE
Restore the 2.1 strict_slashes == False routing behaviour

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: werkzeug
 
+Version 2.2.2
+-------------
+
+Unreleased
+
+-   Fix router to restore the 2.1 ``strict_slashes == False`` behaviour
+    whereby leaf-requests match branch rules and vice
+    versa. :pr:`2489`
+
 Version 2.2.1
 -------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Fix router to restore the 2.1 ``strict_slashes == False`` behaviour
     whereby leaf-requests match branch rules and vice
     versa. :pr:`2489`
+-   Fix router to identify invalid rules rather than hang parsing them,
+    and to correctly parse ``/`` within converter arguments. :pr:`2489`
 
 Version 2.2.1
 -------------

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -99,12 +99,13 @@ class StateMachineMatcher:
                 # that matching is possible with an additional slash
                 if "" in state.static:
                     for rule in state.static[""].rules:
-                        if (
-                            rule.strict_slashes
-                            and websocket == rule.websocket
-                            and (rule.methods is None or method in rule.methods)
+                        if websocket == rule.websocket and (
+                            rule.methods is None or method in rule.methods
                         ):
-                            raise SlashRequired()
+                            if rule.strict_slashes:
+                                raise SlashRequired()
+                            else:
+                                return rule, values
                 return None
 
             part = parts[0]

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1427,3 +1427,19 @@ def test_weighting():
         "uuid",
         {"value": uuid.UUID("2b5b0911-fdcf-4dd2-921b-28ace88db8a0")},
     )
+
+
+def test_strict_slashes_false():
+    map = r.Map(
+        [
+            r.Rule("/path1", endpoint="leaf_path", strict_slashes=False),
+            r.Rule("/path2/", endpoint="branch_path", strict_slashes=False),
+        ],
+    )
+
+    adapter = map.bind("example.org", "/")
+
+    assert adapter.match("/path1", method="GET") == ("leaf_path", {})
+    assert adapter.match("/path1/", method="GET") == ("leaf_path", {})
+    assert adapter.match("/path2", method="GET") == ("branch_path", {})
+    assert adapter.match("/path2/", method="GET") == ("branch_path", {})


### PR DESCRIPTION
In 2.1 if strict_slashes was False leaf-requests to a branch would
match as would branch-requests to a leaf. This is counter to the
likely original intention of `strict_slashes` which would not match
either.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
