### PR TITLE
try int instead of str.isdigit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
 -   Update subpackage imports in :mod:`werkzeug.routing` to use the
     ``import as`` syntax for explicitly re-exporting public attributes.
     :pr:`2493`
+-   Parsing of some invalid header characters is more robust. :pr:`2494`
 
 
 Version 2.2.1

--- a/src/werkzeug/datastructures.py
+++ b/src/werkzeug/datastructures.py
@@ -2947,7 +2947,10 @@ class FileStorage:
     @property
     def content_length(self):
         """The content-length sent in the header.  Usually not available"""
-        return int(self.headers.get("content-length") or 0)
+        try:
+            return int(self.headers.get("content-length") or 0)
+        except ValueError:
+            return 0
 
     @property
     def mimetype(self):

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -153,7 +153,7 @@ def get_pin_and_cookie_name(
         return None, None
 
     # Pin was provided explicitly
-    if pin is not None and pin.replace("-", "").isdigit():
+    if pin is not None and pin.replace("-", "").isdecimal():
         # If there are separators in the pin, return it directly
         if "-" in pin:
             rv = pin
@@ -421,12 +421,16 @@ class DebuggedApplication:
         val = parse_cookie(environ).get(self.pin_cookie_name)
         if not val or "|" not in val:
             return False
-        ts, pin_hash = val.split("|", 1)
-        if not ts.isdigit():
+        ts_str, pin_hash = val.split("|", 1)
+
+        try:
+            ts = int(ts_str)
+        except ValueError:
             return False
+
         if pin_hash != hash_pin(self.pin):
             return None
-        return (time.time() - PIN_TIME) < int(ts)
+        return (time.time() - PIN_TIME) < ts
 
     def _fail_pin_auth(self) -> None:
         time.sleep(5.0 if self._failed_pin_auth > 5 else 0.5)

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -760,15 +760,20 @@ def parse_range_header(
             begin_str, end_str = item.split("-", 1)
             begin_str = begin_str.strip()
             end_str = end_str.strip()
-            if not begin_str.isdigit():
+
+            try:
+                begin = int(begin_str)
+            except ValueError:
                 return None
-            begin = int(begin_str)
+
             if begin < last_end or last_end < 0:
                 return None
             if end_str:
-                if not end_str.isdigit():
+                try:
+                    end = int(end_str) + 1
+                except ValueError:
                     return None
-                end = int(end_str) + 1
+
                 if begin >= end:
                     return None
             else:
@@ -806,10 +811,11 @@ def parse_content_range_header(
     rng, length_str = rangedef.split("/", 1)
     if length_str == "*":
         length = None
-    elif length_str.isdigit():
-        length = int(length_str)
     else:
-        return None
+        try:
+            length = int(length_str)
+        except ValueError:
+            return None
 
     if rng == "*":
         return ds.ContentRange(units, None, None, length, on_update=on_update)

--- a/src/werkzeug/middleware/lint.py
+++ b/src/werkzeug/middleware/lint.py
@@ -288,7 +288,7 @@ class LintMiddleware:
         check_type("status", status, str)
         status_code_str = status.split(None, 1)[0]
 
-        if len(status_code_str) != 3 or not status_code_str.isdigit():
+        if len(status_code_str) != 3 or not status_code_str.isdecimal():
             warn("Status code must be three digits.", WSGIWarning, stacklevel=3)
 
         if len(status) < 4 or status[3] != " ":

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -698,8 +698,13 @@ class EnvironBuilder:
     def server_port(self) -> int:
         """The server port as integer (read-only, use :attr:`host` to set)"""
         pieces = self.host.split(":", 1)
-        if len(pieces) == 2 and pieces[1].isdigit():
-            return int(pieces[1])
+
+        if len(pieces) == 2:
+            try:
+                return int(pieces[1])
+            except ValueError:
+                pass
+
         if self.url_scheme == "https":
             return 443
         return 80


### PR DESCRIPTION
`str.isdigit` will return `True` for some non-decimal digit characters. This was used in a few places to check before calling `int()`, which meant the conversion could still raise. This would result in a 500 error instead of an empty value. However, `try int()/except ValueError` is more commonly used and results in an integer in the valid case. There were a few cases where checking the string still made sense; `str.isdecimal` is correct in those cases.