### PR TITLE
`__wrapped__` is always set on unbound local proxy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Unreleased
 -   Parsing of some invalid header characters is more robust. :pr:`2494`
 -   When starting the development server, a warning not to use it in a
     production deployment is always shown. :issue:`2480`
+-   ``LocalProxy.__wrapped__`` is always set to the wrapped object when
+    the proxy is unbound, fixing an issue in doctest that would cause it
+    to fail. :issue:`2485`
 
 
 Version 2.2.1


### PR DESCRIPTION
Doctest calls `inspect.unwrap`, which does `getattr(obj, "__wrapped__")`, which would fail if the proxy was anything but a function. In Flask 2.2, the proxies no longer use functions, so users started reporting that their doctests were failing.

Now the proxy always records what it's wrapping, and returns that when accessing `__wrapped__` when unbound. When bound, the attribute access is always passed through to the real object, rather than always returning the proxy's value.

fixes #2485 