### PR TITLE
handle unclosed socket resource warning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
 -   ``LocalProxy.__wrapped__`` is always set to the wrapped object when
     the proxy is unbound, fixing an issue in doctest that would cause it
     to fail. :issue:`2485`
+-   Address one ``ResourceWarning`` related to the socket used by
+    ``run_simple``. :issue:`2421`
 
 
 Version 2.2.1

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -1061,6 +1061,9 @@ def run_simple(
     if not is_running_from_reloader():
         s = prepare_socket(hostname, port)
         fd = s.fileno()
+        # Silence a ResourceWarning about an unclosed socket. This object is no longer
+        # used, the server will create another with fromfd.
+        s.detach()
         os.environ["WERKZEUG_SERVER_FD"] = str(fd)
     else:
         fd = int(os.environ["WERKZEUG_SERVER_FD"])


### PR DESCRIPTION
Call `socket.detach` on the socket prepared by `run_simple`. That object is not used, the server opens another with `socket.fromfd`. `fromfd` causes another `ResourceWarning`, but it's not clear that it's possible to address that one.

closes #2421 