### PR TITLE
add specific supported python versions to classifiers metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 2.3.0
 
 Unreleased
 
+-   Add missing ``Programming Language :: Python`` versions and
+    implementations to report supported languages in published package
+    metadata.
+
 
 Version 2.2.2
 -------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,12 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Python :: Implementation :: PyPy
     Topic :: Internet :: WWW/HTTP :: Dynamic Content
     Topic :: Internet :: WWW/HTTP :: WSGI
     Topic :: Internet :: WWW/HTTP :: WSGI :: Application


### PR DESCRIPTION
I would like to propose this simple metadata update. 

Multiple tools like https://pyup.io, https://requires.io, etc. parse this package metadata to indicate whether they support specific versions and environments. Because [werkzeug](https://github.com/pallets/werkzeug) does not indicate them explicitly, they are flagged as incompatible for Python 3, although the docs and other configurations report that `python_requires = >= 3.7`.


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
