### PR TITLE
check length validity before calling ds.ContentRange

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 
 -   Type signature for ``get_json`` specifies that return type is not optional when
     ``silent=False``. :issue:`2508`
+-   ``parse_content_range_header`` returns ``None`` for a value like ``bytes */-1``
+    where the length is invalid, instead of raising an ``AssertionError``. :issue:`2531`
 
 
 Version 2.2.2

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -818,6 +818,9 @@ def parse_content_range_header(
             return None
 
     if rng == "*":
+        if not is_byte_range_valid(None, None, length):
+            return None
+
         return ds.ContentRange(units, None, None, length, on_update=on_update)
     elif "-" not in rng:
         return None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -619,6 +619,9 @@ class TestRange:
         rv = http.parse_content_range_header("bytes 0-98/*asdfsa")
         assert rv is None
 
+        rv = http.parse_content_range_header("bytes */-1")
+        assert rv is None
+
         rv = http.parse_content_range_header("bytes 0-99/100")
         assert rv.to_header() == "bytes 0-99/100"
         rv.start = None


### PR DESCRIPTION
Check if the length of ContentRange is valid before creating the object to avoid the AssertionError generated otherwise.

- fixes https://github.com/pallets/werkzeug/issues/2531

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [-] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
