### PR TITLE
Replace os.path.sep by os.sep

### DIFF
--- a/src/werkzeug/security.py
+++ b/src/werkzeug/security.py
@@ -12,7 +12,7 @@ SALT_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 DEFAULT_PBKDF2_ITERATIONS = 260000
 
 _os_alt_seps: t.List[str] = list(
-    sep for sep in [os.path.sep, os.path.altsep] if sep is not None and sep != "/"
+    sep for sep in [os.sep, os.path.altsep] if sep is not None and sep != "/"
 )
 
 

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -221,7 +221,7 @@ def secure_filename(filename: str) -> str:
     filename = unicodedata.normalize("NFKD", filename)
     filename = filename.encode("ascii", "ignore").decode("ascii")
 
-    for sep in os.path.sep, os.path.altsep:
+    for sep in os.sep, os.path.altsep:
         if sep:
             filename = filename.replace(sep, " ")
     filename = str(_filename_ascii_strip_re.sub("", "_".join(filename.split()))).strip(


### PR DESCRIPTION
The `os.path.sep` attribute is not available in all environments, as noted in https://github.com/stub42/pytz/issues/72 and https://github.com/pallets/jinja/issues/1697.

The Python documentation uses [`os.sep`](https://docs.python.org/3/library/os.html#os.sep) in most places.

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
