### PR TITLE
Adjust handling of (unquoted) extended parameters in headers

### DIFF
--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -190,6 +190,15 @@ class COOP(Enum):
     SAME_ORIGIN = "same-origin"
 
 
+def _is_extended_parameter(key: str) -> bool:
+    """Per RFC 5987/8187, "extended" values may *not* be quoted.
+    This is in keeping with browser implementations. So we test
+    using this function to see if the key indicates this parameter
+    follows the `ext-parameter` syntax (using a trailing '*').
+    """
+    return key.strip().endswith("*")
+
+
 def quote_header_value(
     value: t.Union[str, int], extra_chars: str = "", allow_token: bool = True
 ) -> str:
@@ -254,6 +263,8 @@ def dump_options_header(
     for key, value in options.items():
         if value is None:
             segments.append(key)
+        elif _is_extended_parameter(key):
+            segments.append(f"{key}={value}")
         else:
             segments.append(f"{key}={quote_header_value(value)}")
     return "; ".join(segments)
@@ -282,6 +293,8 @@ def dump_header(
         for key, value in iterable.items():
             if value is None:
                 items.append(key)
+            elif _is_extended_parameter(key):
+                items.append(f"{key}=value")
             else:
                 items.append(
                     f"{key}={quote_header_value(value, allow_token=allow_token)}"

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -294,7 +294,7 @@ def dump_header(
             if value is None:
                 items.append(key)
             elif _is_extended_parameter(key):
-                items.append(f"{key}=value")
+                items.append(f"{key}={value}")
             else:
                 items.append(
                     f"{key}={quote_header_value(value, allow_token=allow_token)}"

--- a/src/werkzeug/local.py
+++ b/src/werkzeug/local.py
@@ -561,9 +561,9 @@ class LocalProxy(t.Generic[T]):
     # __weakref__ (__getattr__)
     # __init_subclass__ (proxying metaclass not supported)
     # __prepare__ (metaclass)
-    __class__ = _ProxyLookup(
+    __class__ = _ProxyLookup(  # type: ignore
         fallback=lambda self: type(self), is_attr=True
-    )  # type: ignore
+    )
     __instancecheck__ = _ProxyLookup(lambda self, other: isinstance(other, self))
     __subclasscheck__ = _ProxyLookup(lambda self, other: issubclass(other, self))
     # __class_getitem__ triggered through __getitem__

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -354,6 +354,7 @@ class TestHTTPUtility:
         assert http.dump_header([1, 2, 3], allow_token=False) == '"1", "2", "3"'
         assert http.dump_header({"foo": "bar"}, allow_token=False) == 'foo="bar"'
         assert http.dump_header({"foo": "bar"}) == "foo=bar"
+        assert http.dump_header({"foo*": "UTF-8''bar"}) == "foo*=UTF-8''bar"
 
     def test_is_resource_modified(self):
         env = create_environ()

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -118,11 +118,10 @@ def test_non_ascii_name(name, ascii, utf8):
     content_disposition = rv.headers["Content-Disposition"]
     assert f"filename={ascii}" in content_disposition
 
-    """Per RFC 5987/8187, "extended" values may *not* be quoted.
-    This is in keeping with browser implementations.
-    """
     if utf8:
         assert f"filename*=UTF-8''{utf8}" in content_disposition
+    else:
+        assert f"filename*=UTF-8''" not in content_disposition
 
 
 def test_no_cache_conditional_default():

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -107,6 +107,9 @@ def test_object_attachment_requires_name():
         ("Vögel.txt", "Vogel.txt", "V%C3%B6gel.txt"),
         # ":/" are not safe in filename* value
         ("те:/ст", '":/"', "%D1%82%D0%B5%3A%2F%D1%81%D1%82"),
+        # general test of extended parameter (non-quoted)
+        ("(тест.txt", '"(.txt"', "(%D1%82%D0%B5%D1%81%D1%82.txt"),
+        ("(test.txt", '"(test.txt"', None),
     ),
 )
 def test_non_ascii_name(name, ascii, utf8):
@@ -115,10 +118,11 @@ def test_non_ascii_name(name, ascii, utf8):
     content_disposition = rv.headers["Content-Disposition"]
     assert f"filename={ascii}" in content_disposition
 
+    """Per RFC 5987/8187, "extended" values may *not* be quoted.
+    This is in keeping with browser implementations.
+    """
     if utf8:
         assert f"filename*=UTF-8''{utf8}" in content_disposition
-    else:
-        assert "filename*=UTF-8''" not in content_disposition
 
 
 def test_no_cache_conditional_default():

--- a/tests/test_send_file.py
+++ b/tests/test_send_file.py
@@ -121,7 +121,7 @@ def test_non_ascii_name(name, ascii, utf8):
     if utf8:
         assert f"filename*=UTF-8''{utf8}" in content_disposition
     else:
-        assert f"filename*=UTF-8''" not in content_disposition
+        assert "filename*=UTF-8''" not in content_disposition
 
 
 def test_no_cache_conditional_default():


### PR DESCRIPTION
Adjust handling of (unquoted) extended parameters in headers to conform with RFCs and browser implementations.

Addresses #2529 by matching these implementations, namely **not** quoting extended parameter values with charset/language syntax (see RFC [8187](https://datatracker.ietf.org/doc/html/rfc8187)/[5987](https://datatracker.ietf.org/doc/html/rfc5987#section-3.2.1) -- also [Chromium's handling of extended parameter values](https://source.chromium.org/chromium/chromium/src/+/main:net/http/http_content_disposition.cc;drc=327a3573ed3d1ee29d433ee215e50947f1b94170;l=314)).

Also moves mypy comment (`type: ignore`) so as to no longer be unused.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2529
<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
