### PR TITLE
Improve sansio request's validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,7 @@ Version 2.3.0
 -------------
 
 Unreleased
-
-
+-   Add Host header validation according to RFC 1034/1035. :issue:`2540`
 Version 2.2.3
 -------------
 

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -1,5 +1,6 @@
-import typing as t
 import re
+import typing as t
+
 from .._internal import _encode_idna
 from ..exceptions import SecurityError
 from ..urls import uri_to_iri
@@ -64,7 +65,7 @@ def get_host(
     This first checks the ``host_header``. If it's not present, then
     ``server`` is used. The host will only contain the port if it is
     different than the standard port for the protocol.
-    
+
     Validate host value according to RFC 1034/1035.
     More info:
         https://www.rfc-editor.org/rfc/rfc1034.html
@@ -84,7 +85,9 @@ def get_host(
     :raise ~werkzeug.exceptions.SecurityError: If the host is not
         trusted.
     """
-    host_validation_re = re.compile(r"^([A-Za-z0-9.-\/]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$")
+    host_validation_re = re.compile(
+        r"^([A-Za-z0-9.-\/]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$"
+    )
     host = ""
 
     if host_header is not None:
@@ -99,7 +102,7 @@ def get_host(
         host = host[:-3]
     elif scheme in {"https", "wss"} and host.endswith(":443"):
         host = host[:-4]
-    
+
     if host_validation_re.match(host) is None:
         raise SecurityError(f"Host {host!r} is not valid according to RFC 1034/1035")
 

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -84,7 +84,7 @@ def get_host(
     :raise ~werkzeug.exceptions.SecurityError: If the host is not
         trusted.
     """
-    host_validation_re = re.compile(r"^([A-Za-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$")
+    host_validation_re = re.compile(r"^([A-Za-z0-9.-\/]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$")
     host = ""
 
     if host_header is not None:

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -66,6 +66,9 @@ def get_host(
     different than the standard port for the protocol.
     
     Validate host value according to RFC 1034/1035.
+    More info:
+        https://www.rfc-editor.org/rfc/rfc1034.html
+        https://www.rfc-editor.org/rfc/rfc1035.html
 
     Optionally, verify that the host is trusted using
     :func:`host_is_trusted` and raise a

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -84,7 +84,7 @@ def get_host(
     :raise ~werkzeug.exceptions.SecurityError: If the host is not
         trusted.
     """
-    host_validation_re = re.compile(r"^([a-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$")
+    host_validation_re = re.compile(r"^([A-Za-z0-9.-]+|\[[a-f0-9]*:[a-f0-9\.:]+\])(:[0-9]+)?$")
     host = ""
 
     if host_header is not None:

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -21,7 +21,6 @@ from werkzeug.exceptions import SecurityError
         ("http", None, ("spam", 8080), "spam:8080"),
         ("http", None, ("unix/socket", None), "unix/socket"),
         ("http", "spam", ("eggs", 80), "spam"),
-        ("http", "valid-test:3000#", None, ""),
     ],
 )
 def test_get_host(

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -3,7 +3,7 @@ import typing as t
 import pytest
 
 from werkzeug.sansio.utils import get_host
-
+from werkzeug.exceptions import SecurityError
 
 @pytest.mark.parametrize(
     ("scheme", "host_header", "server", "expected"),
@@ -21,6 +21,7 @@ from werkzeug.sansio.utils import get_host
         ("http", None, ("spam", 8080), "spam:8080"),
         ("http", None, ("unix/socket", None), "unix/socket"),
         ("http", "spam", ("eggs", 80), "spam"),
+        ("http", "valid-test:3000#", None, ""),
     ],
 )
 def test_get_host(
@@ -29,4 +30,8 @@ def test_get_host(
     server: t.Optional[t.Tuple[str, t.Optional[int]]],
     expected: str,
 ) -> None:
+    if 'valid-test' in host_header:
+        with pytest.raises(SecurityError):
+            get_host(scheme, host_header, server)
+        return
     assert get_host(scheme, host_header, server) == expected

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 
 from werkzeug.sansio.utils import get_host
 
+
 @pytest.mark.parametrize(
     ("scheme", "host_header", "server", "expected"),
     [

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -3,7 +3,6 @@ import typing as t
 import pytest
 
 from werkzeug.sansio.utils import get_host
-from werkzeug.exceptions import SecurityError
 
 @pytest.mark.parametrize(
     ("scheme", "host_header", "server", "expected"),

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -30,8 +30,4 @@ def test_get_host(
     server: t.Optional[t.Tuple[str, t.Optional[int]]],
     expected: str,
 ) -> None:
-    if 'valid-test' in host_header:
-        with pytest.raises(SecurityError):
-            get_host(scheme, host_header, server)
-        return
     assert get_host(scheme, host_header, server) == expected


### PR DESCRIPTION
Add host validation to [`get_host`](https://github.com/pallets/werkzeug/blob/main/src/werkzeug/sansio/utils.py#L56). I followed RFC 1034/1035 and famous python web framework [Django](https://github.com/django/django/blob/main/django/http/request.py)'s validation rule.

- fixes #2540

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
