### PR TITLE
Backport: Preserve query string on test client

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 0.15.3.1
+--------------
+
+Released 2022-11-08
+
+-   The test client includes the query string in ``REQUEST_URI`` and
+    ``RAW_URI``. :issue:`1781`
+
 Version 0.15.3
 --------------
 

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -309,7 +309,7 @@ class EnvironBuilder(object):
     :param environ_overrides: an optional dict of environment overrides.
     :param charset: the charset used to encode unicode data.
 
-    .. versionchanged:: 2.0.0
+    .. versionchanged:: 0.15.3.1
         ``REQUEST_URI`` and ``RAW_URI`` is the full raw URI including
         the query string, not only the path.
 


### PR DESCRIPTION
Backport the fix from upstream and tag new version `0.15.3.1`
https://github.com/pallets/werkzeug/pull/1853