### PR TITLE
Remove: unreachable code from get_json.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Unreleased
     where the length is invalid, instead of raising an ``AssertionError``. :issue:`2531`
 -   Address remaining ``ResourceWarning`` related to the socket used by ``run_simple``.
     Remove ``prepare_socket``, which now happens when creating the server. :issue:`2421`
+-   Refactor ``get_json`` method, unreachable code removed.
 
 
 Version 2.2.2

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -597,10 +597,6 @@ class Request(_SansIORequest):
                     self._cached_json = (normal_rv, rv)
             else:
                 rv = self.on_json_loading_failed(e)
-
-                if cache:
-                    _, silent_rv = self._cached_json
-                    self._cached_json = (rv, silent_rv)
         else:
             if cache:
                 self._cached_json = (rv, rv)


### PR DESCRIPTION
Any code after `on_json_loading_failed()`  invocation is unreachable, because this function always raise an exception. 


<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
