### PR TITLE
updating pre-existing headers in multipart/form-data for pytest envir…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ Unreleased
     where the length is invalid, instead of raising an ``AssertionError``. :issue:`2531`
 -   Address remaining ``ResourceWarning`` related to the socket used by ``run_simple``.
     Remove ``prepare_socket``, which now happens when creating the server. :issue:`2421`
-
+-   Update pre-existing headers for multipart/form-data requests in pytest environment
+    instead of overwriting them. :issue:`2549`
 
 Version 2.2.2
 -------------

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -107,7 +107,8 @@ def stream_encode_multipart(
                     and mimetypes.guess_type(filename)[0]
                     or "application/octet-stream"
                 )
-            headers = Headers([("Content-Type", content_type)])
+            headers = value.headers
+            headers.update([("Content-Type", content_type)])
             if filename is None:
                 write_binary(encoder.send_event(Field(name=key, headers=headers)))
             else:


### PR DESCRIPTION
Update pre-existing headers for multipart/form-data requests in pytest environment instead of overwriting them. 


- fixes #2549 


Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. **--> Lines already covered in tests**
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
