### PR TITLE
Bump pytest xprocess to latest version and fix issue with junk binary data to log streams

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -36,7 +36,7 @@ pytest==7.1.3
     #   pytest-xprocess
 pytest-timeout==2.1.0
     # via -r requirements/tests.in
-pytest-xprocess==0.20.0
+pytest-xprocess==0.22.2
     # via -r requirements/tests.in
 tomli==2.0.1
     # via pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,9 @@ class DevServerClient:
         self.log = None
 
     def tail_log(self, path):
-        self.log = open(path)
+        # surrogateescape allows for handling of file streams
+        # containing junk binary values as normal text streams
+        self.log = open(path, errors="surrogateescape")
         self.log.read()
 
     def connect(self, **kwargs):


### PR DESCRIPTION
Following discussion in https://github.com/pytest-dev/pytest-xprocess/issues/120