### PR TITLE
Ignore SIGTTOU while enabling echo mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Unreleased
     client. :issue:`2549`
 -   Fix handling of header extended parameters such that they are no longer quoted.
     :issue:`2529`
+-   Allow the development server to run as a background process with the reloader enabled
+    by ignoring SIGTTOU while setting the terminal to echo mode. :issue:`2571`
 
 Version 2.2.2
 -------------

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -115,29 +115,6 @@ def test_reloader_sys_path(tmp_path, dev_server, reloader_type):
     assert client.request().status == 200
 
 
-@pytest.mark.parametrize("reloader_type", ["stat", "watchdog"])
-@pytest.mark.timeout(10)
-@pytest.mark.dev_server
-def test_reloader_no_echo_mode(dev_server, reloader_type):
-    """Test that the server runs when the reloader is enabled and the terminal's echo
-    mode is disabled. This can happen when, for example, the server is run as a
-    background processs. If the server doesn't run, the test will time out.
-    """
-    import termios
-
-    # Disable the terminal's echo mode.
-    original_attributes = termios.tcgetattr(sys.stdin)
-    new_attributes = termios.tcgetattr(sys.stdin)
-    new_attributes[3] = new_attributes[3] & ~termios.ECHO
-    try:
-        termios.tcsetattr(sys.stdin, termios.TCSANOW, new_attributes)
-        # Make sure the server still runs with echo mode disabled.
-        dev_server("reloader", reloader_type=reloader_type)
-    finally:
-        # Always restore the terminal's attributes.
-        termios.tcsetattr(sys.stdin, termios.TCSANOW, original_attributes)
-
-
 def test_windows_get_args_for_reloading(monkeypatch, tmp_path):
     argv = [str(tmp_path / "test.exe"), "run"]
     monkeypatch.setattr("sys.executable", str(tmp_path / "python.exe"))


### PR DESCRIPTION
This PR modifies `werkzeug._reloader.ensure_echo_mode` such that `SIGTTOU` is ignored when calling `termios.tcsetattr`. The `tcsetattr` system call otherwise triggers `SIGTTOU` and stops the process when running the development server with reloading enabled as a background process.

- fixes #2571 

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [X] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
