### PR TITLE
default `part_isolating=False` if regex has `/`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
 -   ``Request.get_json()`` will raise a ``415 Unsupported Media Type`` error if the
     ``Content-Type`` header is not ``application/json``, instead of a generic 400.
     :issue:`2550`
+-   A URL converter's ``part_isolating`` defaults to ``False`` if its ``regex`` contains
+    a ``/``. :issue:`2582`
 
 
 Version 2.2.3

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -42,16 +42,16 @@ class RulePart:
 _part_re = re.compile(
     r"""
     (?:
-        (?P<slash>\/)                                 # a slash
+        (?P<slash>/)                                 # a slash
       |
-        (?P<static>[^<\/]+)                           # static rule data
+        (?P<static>[^</]+)                           # static rule data
       |
         (?:
           <
             (?:
               (?P<converter>[a-zA-Z_][a-zA-Z0-9_]*)   # converter name
               (?:\((?P<arguments>.*?)\))?             # converter arguments
-              \:                                      # variable delimiter
+              :                                       # variable delimiter
             )?
             (?P<variable>[a-zA-Z_][a-zA-Z0-9_]*)      # variable name
            >

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -800,6 +800,20 @@ def test_any_converter_build_validates_value() -> None:
     assert str(exc.value) == "'invalid' is not one of 'patient', 'provider'"
 
 
+def test_part_isolating_default() -> None:
+    class TwoConverter(r.BaseConverter):
+        regex = r"\w+/\w+"
+
+        def to_python(self, value: str) -> t.Any:
+            return value.split("/")
+
+    m = r.Map(
+        [r.Rule("/<two:values>/", endpoint="two")], converters={"two": TwoConverter}
+    )
+    a = m.bind("localhost")
+    assert a.match("/a/b/") == ("two", {"values": ["a", "b"]})
+
+
 @pytest.mark.parametrize(
     ("endpoint", "value", "expect"),
     [


### PR DESCRIPTION
fixes #2582 

The default is only set if the new converter class sets `regex` and doesn't set `part_isolating`. This way, a converter can override `part_isolating` if it knows better, and can inherit `regex` and not change `part_isolating` if it was set manually in the parent.

Removed `part_isolating` from all the built-in converters, since it's detected correctly with this new behavior.

I also noticed that the base regex, which `UnicodeConverter` also uses, is `[^/]+` instead of `.+`. It's not clear if the "not slash" is needed, all tests still pass if I change it. I noticed this because "not slash" is the corner case that would make `part_isolating` false unnecessarily. @pgjones will look into whether it's necessary with the new router.