### PR TITLE
reloader uses `sys.orig_argv`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Unreleased
     :issue:`2550`
 -   A URL converter's ``part_isolating`` defaults to ``False`` if its ``regex`` contains
     a ``/``. :issue:`2582`
+-   The reloader can pick up arguments to ``python`` like ``-X dev``, and does not
+    require heuristics to determine how to reload the command. Only available
+    on Python >= 3.10. :issue:`2589`
 
 
 Version 2.2.3

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -166,6 +166,11 @@ def _get_args_for_reloading() -> t.List[str]:
     """Determine how the script was executed, and return the args needed
     to execute it again in a new process.
     """
+    if sys.version_info >= (3, 10):
+        # sys.orig_argv, added in Python 3.10, contains the exact args used to invoke
+        # Python. Still replace argv[0] with sys.executable for accuracy.
+        return [sys.executable, *sys.orig_argv[1:]]
+
     rv = [sys.executable]
     py_script = sys.argv[0]
     args = sys.argv[1:]

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -115,6 +115,7 @@ def test_reloader_sys_path(tmp_path, dev_server, reloader_type):
     assert client.request().status == 200
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 10), reason="not needed on >= 3.10")
 def test_windows_get_args_for_reloading(monkeypatch, tmp_path):
     argv = [str(tmp_path / "test.exe"), "run"]
     monkeypatch.setattr("sys.executable", str(tmp_path / "python.exe"))


### PR DESCRIPTION
fixes #2589 
fixes #2588 