### PR TITLE
Allow the router to cope with nested groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,11 +21,14 @@ Unreleased
     :issue:`2550`
 -   A URL converter's ``part_isolating`` defaults to ``False`` if its ``regex`` contains
     a ``/``. :issue:`2582`
+-   A custom converter's regex can have capturing groups without breaking the router.
+    :pr:`2596`
 -   The reloader can pick up arguments to ``python`` like ``-X dev``, and does not
     require heuristics to determine how to reload the command. Only available
     on Python >= 3.10. :issue:`2589`
 -   The Watchdog reloader ignores file opened events. Bump the minimum version of
     Watchdog to 2.3.0. :issue:`2603`
+
 
 
 Version 2.2.3

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -127,13 +127,21 @@ class StateMachineMatcher:
                     remaining = []
                 match = re.compile(test_part.content).match(target)
                 if match is not None:
-                    groups = list(match.groups())
                     if test_part.suffixed:
                         # If a part_isolating=False part has a slash suffix, remove the
                         # suffix from the match and check for the slash redirect next.
-                        suffix = groups.pop()
+                        suffix = match.groups()[-1]
                         if suffix == "/":
                             remaining = [""]
+
+                    converter_groups = sorted(
+                        match.groupdict().items(), key=lambda entry: entry[0]
+                    )
+                    groups = [
+                        value
+                        for key, value in converter_groups
+                        if key[:11] == "__werkzeug_"
+                    ]
                     rv = _match(new_state, remaining, values + groups)
                     if rv is not None:
                         return rv

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -588,6 +588,7 @@ class Rule(RuleFactory):
         argument_weights = []
         static_weights: t.List[t.Tuple[int, int]] = []
         final = False
+        convertor_number = 0
 
         pos = 0
         while pos < len(rule):
@@ -614,7 +615,8 @@ class Rule(RuleFactory):
                 self.arguments.add(data["variable"])
                 if not convobj.part_isolating:
                     final = True
-                content += f"({convobj.regex})"
+                content += f"(?P<__werkzeug_{convertor_number}>{convobj.regex})"
+                convertor_number += 1
                 argument_weights.append(convobj.weight)
                 self._trace.append((True, data["variable"]))
 
@@ -643,6 +645,7 @@ class Rule(RuleFactory):
                     argument_weights = []
                     static_weights = []
                     final = False
+                    convertor_number = 0
 
             pos = match.end()
 


### PR DESCRIPTION
The previous, regex table, version of the router wrapped each converter's regex in a named capturing group which was then extracted from the match and passed to the converter as the value with the name matching the rule variable name. This meant that any nested groups within that named group were ignored.

The new, state machine, version of the router couldn't use this approach as the variable names are likely unique and hence the same rule with different variable names would have seperate states, rather than the same. Therefore the state machine version simply took the groups in order and passed them to the converters in order.

The requirement that the groups be in order means that nested groups cannot be used, as the nested groups are not ignored and in fact result in more group matches than there are converters.

As Werkzeug/Flask did support nested groups (although not directly as they aren't used in Werkzeug/Flask) it makes sense to restore this support. To do so I've used the previous approach with a generic name `__werkzeug_#` that is unlikely to conflict with any user defined name. Then only matching only the named groups (with the `__werkzeug_#` prefix) are passed to the converters in the order given by the name i.e. `__werkzeug_0` for the first converter in the part, `__werkzeug_1` for the second etc... This numbering is required as the match groupdict() order is not guaranteed anywhere.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2590

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
