### PR TITLE
unix socket path can start with dot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,8 @@ Unreleased
     on Python >= 3.10. :issue:`2589`
 -   The Watchdog reloader ignores file opened events. Bump the minimum version of
     Watchdog to 2.3.0. :issue:`2603`
-
+-   When using a Unix socket for the development server, the path can start with a dot.
+    :issue:`2595`
 
 
 Version 2.2.3

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -620,7 +620,8 @@ def get_sockaddr(
     """Return a fully qualified socket address that can be passed to
     :func:`socket.bind`."""
     if family == af_unix:
-        return host.split("://", 1)[1]
+        # Absolute path avoids IDNA encoding error when path starts with dot.
+        return os.path.abspath(host.partition("://")[2])
     try:
         res = socket.getaddrinfo(
             host, port, family, socket.SOCK_STREAM, socket.IPPROTO_TCP


### PR DESCRIPTION
`socket.getfqdn` calls `host.encode("idna")` to allows users to enter Unicode host names directly. It doesn't make sense to call this on Unix socket paths, but there's no way to control that. If the path starts with a dot `.`, Python's IDNA encoder fails (it's not a valid domain). This makes the path absolute so that it never starts with a dot.

fixes #2595 