### PR TITLE
deprecate `make_line_iter` and `make_chunk_iter`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
     filenames in downloads. :issue:`2598`
 -   Deprecate the ``safe_conversion`` parameter of ``iri_to_uri``. The ``Location``
     header is converted to IRI using the same process as everywhere else. :issue:`2609`
+-   Deprecate ``werkzeug.wsgi.make_line_iter`` and ``make_chunk_iter``. :pr:`2613`
 -   Use modern packaging metadata with ``pyproject.toml`` instead of ``setup.cfg``.
     :pr:`2574`
 -   ``Request.get_json()`` will raise a ``415 Unsupported Media Type`` error if the

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -1135,7 +1135,9 @@ def url_decode_stream(
 
         cls = MultiDict
 
-    return cls(decoder)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "'make_chunk_iter", DeprecationWarning)
+        return cls(decoder)
 
 
 def _url_decode_impl(

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -1,6 +1,7 @@
 import io
 import re
 import typing as t
+import warnings
 from functools import partial
 from functools import update_wrapper
 from itertools import chain
@@ -403,6 +404,12 @@ def _make_chunk_iter(
     buffer_size: int,
 ) -> t.Iterator[bytes]:
     """Helper for the line and chunk iter functions."""
+    warnings.warn(
+        "'_make_chunk_iter' is deprecated and will be removed in Werkzeug 2.4.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     if isinstance(stream, (bytes, bytearray, str)):
         raise TypeError(
             "Passed a string or byte object instead of true iterator or stream."
@@ -441,14 +448,17 @@ def make_line_iter(
     If you need line-by-line processing it's strongly recommended to iterate
     over the input stream using this helper function.
 
-    .. versionchanged:: 0.8
-       This function now ensures that the limit was reached.
+    .. deprecated:: 2.3
+        Will be removed in Werkzeug 2.4.
+
+    .. versionadded:: 0.11
+       added support for the `cap_at_buffer` parameter.
 
     .. versionadded:: 0.9
        added support for iterators as input stream.
 
-    .. versionadded:: 0.11.10
-       added support for the `cap_at_buffer` parameter.
+    .. versionchanged:: 0.8
+       This function now ensures that the limit was reached.
 
     :param stream: the stream or iterate to iterate over.
     :param limit: the limit in bytes for the stream.  (Usually
@@ -460,9 +470,17 @@ def make_line_iter(
                           that the buffer size might be exhausted by a factor
                           of two however.
     """
+    warnings.warn(
+        "'make_line_iter' is deprecated and will be removed in Werkzeug 2.4.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _iter = _make_chunk_iter(stream, limit, buffer_size)
 
-    first_item = next(_iter, "")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "'_make_chunk_iter", DeprecationWarning)
+        first_item = next(_iter, "")
+
     if not first_item:
         return
 
@@ -527,13 +545,16 @@ def make_chunk_iter(
     you should use :func:`make_line_iter` instead as it
     supports arbitrary newline markers.
 
-    .. versionadded:: 0.8
+    .. deprecated:: 2.3
+        Will be removed in Werkzeug 2.4.
 
-    .. versionadded:: 0.9
+    .. versionchanged:: 0.11
+       added support for the `cap_at_buffer` parameter.
+
+    .. versionchanged:: 0.9
        added support for iterators as input stream.
 
-    .. versionadded:: 0.11.10
-       added support for the `cap_at_buffer` parameter.
+    .. versionadded:: 0.8
 
     :param stream: the stream or iterate to iterate over.
     :param separator: the separator that divides chunks.
@@ -546,9 +567,17 @@ def make_chunk_iter(
                           that the buffer size might be exhausted by a factor
                           of two however.
     """
+    warnings.warn(
+        "'make_chunk_iter' is deprecated and will be removed in Werkzeug 2.4.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     _iter = _make_chunk_iter(stream, limit, buffer_size)
 
-    first_item = next(_iter, b"")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "'_make_chunk_iter", DeprecationWarning)
+        first_item = next(_iter, b"")
+
     if not first_item:
         return
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -263,6 +263,7 @@ def test_get_current_url_invalid_utf8():
     assert rv == "http://localhost/?foo=bar&baz=blah&meh=%CF"
 
 
+@pytest.mark.filterwarnings("ignore:'make_line_iter:DeprecationWarning")
 def test_multi_part_line_breaks():
     data = "abcdef\r\nghijkl\r\nmnopqrstuvwxyz\r\nABCDEFGHIJK"
     test_stream = io.StringIO(data)
@@ -279,6 +280,7 @@ def test_multi_part_line_breaks():
     ]
 
 
+@pytest.mark.filterwarnings("ignore:'make_line_iter:DeprecationWarning")
 def test_multi_part_line_breaks_bytes():
     data = b"abcdef\r\nghijkl\r\nmnopqrstuvwxyz\r\nABCDEFGHIJK"
     test_stream = io.BytesIO(data)
@@ -300,6 +302,7 @@ def test_multi_part_line_breaks_bytes():
     ]
 
 
+@pytest.mark.filterwarnings("ignore:'make_line_iter:DeprecationWarning")
 def test_multi_part_line_breaks_problematic():
     data = "abc\rdef\r\nghi"
     for _ in range(1, 10):
@@ -308,12 +311,14 @@ def test_multi_part_line_breaks_problematic():
         assert lines == ["abc\r", "def\r\n", "ghi"]
 
 
+@pytest.mark.filterwarnings("ignore:'make_line_iter:DeprecationWarning")
 def test_iter_functions_support_iterators():
     data = ["abcdef\r\nghi", "jkl\r\nmnopqrstuvwxyz\r", "\nABCDEFGHIJK"]
     lines = list(wsgi.make_line_iter(data))
     assert lines == ["abcdef\r\n", "ghijkl\r\n", "mnopqrstuvwxyz\r\n", "ABCDEFGHIJK"]
 
 
+@pytest.mark.filterwarnings("ignore:'make_chunk_iter:DeprecationWarning")
 def test_make_chunk_iter():
     data = ["abcdefXghi", "jklXmnopqrstuvwxyzX", "ABCDEFGHIJK"]
     rv = list(wsgi.make_chunk_iter(data, "X"))
@@ -325,6 +330,7 @@ def test_make_chunk_iter():
     assert rv == ["abcdef", "ghijkl", "mnopqrstuvwxyz", "ABCDEFGHIJK"]
 
 
+@pytest.mark.filterwarnings("ignore:'make_chunk_iter:DeprecationWarning")
 def test_make_chunk_iter_bytes():
     data = [b"abcdefXghi", b"jklXmnopqrstuvwxyzX", b"ABCDEFGHIJK"]
     rv = list(wsgi.make_chunk_iter(data, "X"))
@@ -357,6 +363,7 @@ def test_make_chunk_iter_bytes():
     ]
 
 
+@pytest.mark.filterwarnings("ignore:'make_line_iter:DeprecationWarning")
 def test_lines_longer_buffer_size():
     data = "1234567890\n1234567890\n"
     for bufsize in range(1, 15):
@@ -366,6 +373,7 @@ def test_lines_longer_buffer_size():
         assert lines == ["1234567890\n", "1234567890\n"]
 
 
+@pytest.mark.filterwarnings("ignore:'make_line_iter:DeprecationWarning")
 def test_lines_longer_buffer_size_cap():
     data = "1234567890\n1234567890\n"
     for bufsize in range(1, 15):


### PR DESCRIPTION
Neither of these functions are used within Werkzeug (except for the deprecated `url_decode_stream`), and GitHub code search returned no uses (besides copies of Werkzeug) in other projects. They both rely on `_to_str` and `_to_bytes`, which we want to get rid of in #2602. The underlying `_make_chunk_iter` was inlined with more specialized versions in the two places it was used in the form parser.

It seems like the motivation for adding them was to support WSGI 1.0 (Python 2), where `input.readline(size)` was not part of the API. WSGI 1.1 (Python 3) makes it a "should", but in practice all modern WSGI servers either support it or are already limiting the input stream and including a `wsgi.limited_stream` marker.