### PR TITLE
refactor `parse_options_header`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Unreleased
 -   When using a Unix socket for the development server, the path can start with a dot.
     :issue:`2595`
 -   Increase default work factor for PBKDF2 to 600,000 iterations. :issue:`2611`
+-   ``parse_options_header`` is 2-3 times faster. It conforms to :rfc:`9110`, some
+    invalid parts that were previously accepted are now ignored. :issue:`1628`
+-   The ``is_filename`` parameter to ``unquote_header_value`` is deprecated. :pr:`2614`
 
 
 Version 2.2.3

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -13,7 +13,7 @@ from enum import Enum
 from hashlib import sha1
 from time import mktime
 from time import struct_time
-from urllib.parse import unquote_to_bytes as _unquote
+from urllib.parse import unquote
 from urllib.request import parse_http_list as _parse_list_header
 
 from ._internal import _cookie_quote
@@ -50,37 +50,6 @@ _token_chars = frozenset(
     "!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~"
 )
 _etag_re = re.compile(r'([Ww]/)?(?:"(.*?)"|(.*?))(?:\s*,\s*|$)')
-_option_header_piece_re = re.compile(
-    r"""
-    ;\s*,?\s*  # newlines were replaced with commas
-    (?P<key>
-        "[^"\\]*(?:\\.[^"\\]*)*"  # quoted string
-    |
-        [^\s;,=*]+  # token
-    )
-    (?:\*(?P<count>\d+))?  # *1, optional continuation index
-    \s*
-    (?:  # optionally followed by =value
-        (?:  # equals sign, possibly with encoding
-            \*\s*=\s*  # * indicates extended notation
-            (?:  # optional encoding
-                (?P<encoding>[^\s]+?)
-                '(?P<language>[^\s]*?)'
-            )?
-        |
-            =\s*  # basic notation
-        )
-        (?P<value>
-            "[^"\\]*(?:\\.[^"\\]*)*"  # quoted string
-        |
-            [^;,]+  # token
-        )?
-    )?
-    \s*
-    """,
-    flags=re.VERBOSE,
-)
-_option_header_start_mime_type = re.compile(r",\s*([^;,\s]+)([;,]\s*.+)?")
 _entity_headers = frozenset(
     [
         "allow",
@@ -222,30 +191,28 @@ def quote_header_value(
     return f'"{value}"'
 
 
-def unquote_header_value(value: str, is_filename: bool = False) -> str:
-    r"""Unquotes a header value.  (Reversal of :func:`quote_header_value`).
-    This does not use the real unquoting but what browsers are actually
-    using for quoting.
-
-    .. versionadded:: 0.5
+def unquote_header_value(value: str, is_filename: t.Optional[bool] = None) -> str:
+    """Unquote a header value. Reverse of :func:`quote_header_value`.
 
     :param value: the header value to unquote.
-    :param is_filename: The value represents a filename or path.
+
+    .. versionchanged:: 2.3
+        The ``is_filename`` parameter is deprecated and will be removed in Werkzeug 2.4.
     """
+    if is_filename is not None:
+        warnings.warn(
+            "The 'is_filename' parameter is deprecated and will be"
+            " removed in Werkzeug 2.4.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if value and value[0] == value[-1] == '"':
-        # this is not the real unquoting, but fixing this so that the
-        # RFC is met will result in bugs with internet explorer and
-        # probably some other browsers as well.  IE for example is
-        # uploading files with "C:\foo\bar.txt" as filename
         value = value[1:-1]
 
-        # if this is a filename and the starting characters look like
-        # a UNC path, then just return the value without quotes.  Using the
-        # replace sequence below on a UNC path has the effect of turning
-        # the leading double slash into a single slash and then
-        # _fix_ie_filename() doesn't work correctly.  See #458.
-        if not is_filename or value[:2] != "\\\\":
+        if not is_filename:
             return value.replace("\\\\", "\\").replace('\\"', '"')
+
     return value
 
 
@@ -387,17 +354,80 @@ def parse_dict_header(value: str, cls: t.Type[dict] = dict) -> t.Dict[str, str]:
     return result
 
 
+# https://httpwg.org/specs/rfc9110.html#parameter
+_parameter_re = re.compile(
+    r"""
+    # don't match multiple empty parts, that causes backtracking
+    \s*;\s*  # find the part delimiter
+    (?:
+        ([\w!#$%&'*+\-.^`|~]+)  # key, one or more token chars
+        =  # equals, with no space on either side
+        (  # value, token or quoted string
+            [\w!#$%&'*+\-.^`|~]+  # one or more token chars
+        |
+            "(?:\\\\|\\"|.)*?"  # quoted string, consuming slash escapes
+        )
+    )?  # optionally match key=value, to account for empty parts
+    """,
+    re.ASCII | re.VERBOSE,
+)
+# https://www.rfc-editor.org/rfc/rfc2231#section-4
+_charset_value_re = re.compile(
+    r"""
+    ([\w!#$%&*+\-.^`|~]*)'  # charset part, could be empty
+    [\w!#$%&*+\-.^`|~]*'  # don't care about language part, usually empty
+    ([\w!#$%&'*+\-.^`|~]+)  # one or more token chars with percent encoding
+    """,
+    re.ASCII | re.VERBOSE,
+)
+# https://www.rfc-editor.org/rfc/rfc2231#section-3
+_continuation_re = re.compile(r"\*(\d+)$", re.ASCII)
+
+
 def parse_options_header(value: t.Optional[str]) -> t.Tuple[str, t.Dict[str, str]]:
-    """Parse a ``Content-Type``-like header into a tuple with the
-    value and any options:
+    """Parse a header that consists of a value with ``key=value`` parameters separated
+    by semicolons ``;``. For example, the ``Content-Type`` header.
 
-    >>> parse_options_header('text/html; charset=utf8')
-    ('text/html', {'charset': 'utf8'})
+    .. code-block:: python
 
-    This should is not for ``Cache-Control``-like headers, which use a
-    different format. For those, use :func:`parse_dict_header`.
+        parse_options_header("text/html; charset=UTF-8")
+        ('text/html', {'charset': 'UTF-8'})
+
+        parse_options_header("")
+        ("", {})
+
+    This parses valid parameter parts as described in
+    `RFC 9110 <https://httpwg.org/specs/rfc9110.html#parameter>`__. Invalid parts are
+    skipped.
+
+    This handles continuations and charsets as described in
+    `RFC 2231 <https://www.rfc-editor.org/rfc/rfc2231#section-3>`__, although not as
+    strictly as the RFC. Only ASCII, UTF-8, and ISO-8859-1 charsets are accepted,
+    otherwise the value remains quoted. These features should not be sent by modern
+    clients.
+
+    Clients may not be consistent in how they handle a quote character within a quoted
+    value. The `HTML Standard <https://html.spec.whatwg.org/#multipart-form-data>`__
+    replaces it with ``%22`` in multipart form data.
+    `RFC 9110 <https://httpwg.org/specs/rfc9110.html#quoted.strings>`__ uses backslash
+    escapes in HTTP headers. Both are decoded to the ``"`` character.
+
+    Clients may not be consistent in how they handle non-ASCII characters. HTML
+    documents must declare ``<meta charset=UTF-8>``, otherwise browsers may replace with
+    HTML character references, which can be decoded using :func:`html.unescape`.
 
     :param value: The header value to parse.
+    :return: ``(value, options)``, where ``options`` is a dict
+
+    .. versionchanged:: 2.3
+        Invalid parts, such as keys with no value, quoted keys, and incorrectly quoted
+        values, are discarded instead of treating as ``None``.
+
+    .. versionchanged:: 2.3
+        Only ASCII, UTF-8, and ISO-8859-1 are accepted for charset values.
+
+    .. versionchanged:: 2.3
+        Escaped quotes in quoted values, like ``%22`` and ``\\"``, are handled.
 
     .. versionchanged:: 2.2
         Option names are always converted to lowercase.
@@ -410,59 +440,71 @@ def parse_options_header(value: t.Optional[str]) -> t.Tuple[str, t.Dict[str, str
 
     .. versionadded:: 0.5
     """
-    if not value:
+    if value is None:
         return "", {}
 
-    result: t.List[t.Any] = []
+    value, _, rest = value.partition(";")
+    value = value.strip()
+    rest = rest.strip()
 
-    value = "," + value.replace("\n", ",")
-    while value:
-        match = _option_header_start_mime_type.match(value)
-        if not match:
-            break
-        result.append(match.group(1))  # mimetype
-        options: t.Dict[str, str] = {}
-        # Parse options
-        rest = match.group(2)
-        encoding: t.Optional[str]
-        continued_encoding: t.Optional[str] = None
-        while rest:
-            optmatch = _option_header_piece_re.match(rest)
-            if not optmatch:
-                break
-            option, count, encoding, language, option_value = optmatch.groups()
-            # Continuations don't have to supply the encoding after the
-            # first line. If we're in a continuation, track the current
-            # encoding to use for subsequent lines. Reset it when the
-            # continuation ends.
-            if not count:
-                continued_encoding = None
-            else:
-                if not encoding:
-                    encoding = continued_encoding
+    if not value or not rest:
+        # empty (invalid) value, or value without options
+        return value, {}
+
+    rest = f";{rest}"
+    options: t.Dict[str, str] = {}
+    encoding: t.Optional[str] = None
+    continued_encoding: t.Optional[str] = None
+
+    for pk, pv in _parameter_re.findall(rest):
+        if not pk:
+            # empty or invalid part
+            continue
+
+        pk = pk.lower()
+
+        if pk[-1] == "*":
+            # key*=charset''value becomes key=value, where value is percent encoded
+            pk = pk[:-1]
+            match = _charset_value_re.match(pv)
+
+            if match:
+                # If there is a valid charset marker in the value, split it off.
+                encoding, pv = match.groups()
+                # This might be the empty string, handled next.
+                encoding = encoding.lower()
+
+            # No charset marker, or marker with empty charset value.
+            if not encoding:
+                encoding = continued_encoding
+
+            # A safe list of encodings. Modern clients should only send ASCII or UTF-8.
+            # This list will not be extended further. An invalid encoding will leave the
+            # value quoted.
+            if encoding in {"ascii", "us-ascii", "utf-8", "iso-8859-1"}:
+                # Continuation parts don't require their own charset marker. This is
+                # looser than the RFC, it will persist across different keys and allows
+                # changing the charset during a continuation. But this implementation is
+                # much simpler than tracking the full state.
                 continued_encoding = encoding
-            option = unquote_header_value(option).lower()
+                # invalid bytes are replaced during unquoting
+                pv = unquote(pv, encoding=encoding)
 
-            if option_value is not None:
-                option_value = unquote_header_value(option_value, option == "filename")
+        # Remove quotes. At this point the value cannot be empty or a single quote.
+        if pv[0] == pv[-1] == '"':
+            # HTTP headers use slash, multipart form data uses percent
+            pv = pv[1:-1].replace("\\\\", "\\").replace('\\"', '"').replace("%22", '"')
 
-                if encoding is not None:
-                    option_value = _unquote(option_value).decode(encoding)
+        match = _continuation_re.search(pk)
 
-            if count:
-                # Continuations append to the existing value. For
-                # simplicity, this ignores the possibility of
-                # out-of-order indices, which shouldn't happen anyway.
-                if option_value is not None:
-                    options[option] = options.get(option, "") + option_value
-            else:
-                options[option] = option_value  # type: ignore[assignment]
+        if match:
+            # key*0=a; key*1=b becomes key=ab
+            pk = pk[: match.start()]
+            options[pk] = options.get(pk, "") + pv
+        else:
+            options[pk] = pv
 
-            rest = rest[optmatch.end() :]
-        result.append(options)
-        return tuple(result)  # type: ignore[return-value]
-
-    return tuple(result) if result else ("", {})  # type: ignore[return-value]
+    return value, options
 
 
 _TAnyAccept = t.TypeVar("_TAnyAccept", bound="ds.Accept")


### PR DESCRIPTION
Based on the implementation @tronic shared in #1628, I've refactored `parse_options_header`. The new implementation is 2-3 times faster. The parser now does an initial pass for valid `; key=value` parts, then does two simpler checks for continuation and charset markers on each key.

This parses parameters that are valid according to RFC 9110. Some invalid values were previously accepted, such as `key`, `key=`, and `key = value` (spaces around equals). Invalid parts are ignored.

This updates the parsing of quoted strings to handle both `\"` escaping in HTTP headers and `%22` in multipart form data.

We already handled RFC 2231 continuation and charset markers, however I don't think either feature is sent by modern clients. Only UTF-8, ASCII, and ISO-8859-1 charsets are accepted, others are left quoted.

Removed the remnants of the `multiple=True` flag that was removed earlier.

fixes #1628 