### PR TITLE
improve `parse_accept_header`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Unreleased
 -   ``parse_options_header`` is 2-3 times faster. It conforms to :rfc:`9110`, some
     invalid parts that were previously accepted are now ignored. :issue:`1628`
 -   The ``is_filename`` parameter to ``unquote_header_value`` is deprecated. :pr:`2614`
+-   Improve ``parse_accept_header`` implementation. Parse according to :rfc:`9110`.
+    Discard items with invalid ``q`` values. :issue:`1623`
 
 
 Version 2.2.3


### PR DESCRIPTION
Use `parse_list_header` and `parse_options_header` (improved in #2614) to parse accept headers instead of a custom regex. RFC 9110 dropped support for extra parameters after `q`, so this just treats any parameters besides `q` as part of the media query. Items with an invalid quality value are skipped.

Also, `parse_list_header` was calling `unquote_header_value`, but that's not needed. First it was doing the same check the function does, and second `urllib.request.parse_http_list` already handles slash escapes. Now it just removes the wrapping quotes from the value.

fixes #1623