### PR TITLE
refactor parse and dump header functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,8 +35,17 @@ Unreleased
 -   ``parse_options_header`` is 2-3 times faster. It conforms to :rfc:`9110`, some
     invalid parts that were previously accepted are now ignored. :issue:`1628`
 -   The ``is_filename`` parameter to ``unquote_header_value`` is deprecated. :pr:`2614`
+-   Deprecate the ``extra_chars`` parameter and passing bytes to ``quote_header_value``,
+    the ``allow_token`` parameter to ``dump_header``, and the ``cls`` parameter and
+    passing bytes to ``parse_dict_header``. :pr:`2618`
 -   Improve ``parse_accept_header`` implementation. Parse according to :rfc:`9110`.
     Discard items with invalid ``q`` values. :issue:`1623`
+-   ``quote_header_value`` quotes the empty string. :pr:`2618`
+-   ``dump_options_header`` skips ``None`` values rather than using a bare key.
+    :pr:`2618`
+-   ``dump_header`` and ``dump_options_header`` will not quote a value if the key ends
+    with an asterisk ``*``.
+-   ``parse_dict_header`` will decode values with charsets. :pr:`2618`
 
 
 Version 2.2.3

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -351,15 +351,10 @@ class TestHTTPUtility:
 
     def test_dump_options_header(self):
         assert http.dump_options_header("foo", {"bar": 42}) == "foo; bar=42"
-        assert http.dump_options_header("foo", {"bar": 42, "fizz": None}) in (
-            "foo; bar=42; fizz",
-            "foo; fizz; bar=42",
-        )
+        assert "fizz" not in http.dump_options_header("foo", {"bar": 42, "fizz": None})
 
     def test_dump_header(self):
         assert http.dump_header([1, 2, 3]) == "1, 2, 3"
-        assert http.dump_header([1, 2, 3], allow_token=False) == '"1", "2", "3"'
-        assert http.dump_header({"foo": "bar"}, allow_token=False) == 'foo="bar"'
         assert http.dump_header({"foo": "bar"}) == "foo=bar"
         assert http.dump_header({"foo*": "UTF-8''bar"}) == "foo*=UTF-8''bar"
 


### PR DESCRIPTION
* `parse_list_header` uses `urllib.request.parse_http_list`, which already unquotes and removes slash escapes. `parse_dict_header` and a few other places can remove inner `key="value"` quotes inline, without having to call `unquote_header_value`.
* ``quote_header_value`` quotes the empty string, since an empty value isn't a valid token on its own.
* `quote_header_value` `extra_chars` parameter is deprecated, it wasn't used anywhere and doesn't seem necessary for any HTTP header.
* As part of #2602, passing bytes to `quote_header_value` and `parse_dict_header` is deprecated.
* `dump_options_header` skips `None` values instead of writing a bare `key;`. While bare keys are useful for headers that use `dump_header`, they're not valid in `value; key=value` parameters.
* Inline the helper function that just did `if value[-1] == "*"` in `dump_header` and `dump_options_header`.
* `dump_header` `allow_token` parameter is deprecated. `quote_header_value` still has the parameter, mainly for the `Digest` auth scheme.
* `parse_dict_header` supports `key*=UTF-8''value` items the same way `parse_options_header` does.