### PR TITLE
check `max_content_length` consistently

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,14 @@ Unreleased
         multiple header values. However, accessing the property only returns the first
         instance.
 
+-   If ``request.max_content_length`` is set, it is checked immediately when accessing
+    the stream, and while reading from the stream in general, rather than only during
+    form parsing. :issue:`1513`
+-   The development server, which must not be used in production, will exhaust the
+    request stream up to 10GB or 1000 reads. This allows clients to see a 413 error if
+    ``max_content_length`` is exceeded, instead of a "connection reset" failure.
+    :pr:`2620`
+
 
 Version 2.2.3
 -------------

--- a/docs/request_data.rst
+++ b/docs/request_data.rst
@@ -94,6 +94,11 @@ and HTTPS servers should set their own limits on size and timeouts. The operatin
 or container manager should set limits on memory and processing time for server
 processes.
 
+If a 413 Content Too Large error is returned before the entire request is read, clients
+may show a "connection reset" failure instead of the 413 error. This is based on how the
+WSGI/HTTP server and client handle connections, it's not something the WSGI application
+(Werkzeug) has control over.
+
 
 How to extend Parsing?
 ----------------------

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -30,6 +30,7 @@ from ..user_agent import UserAgent
 from ..utils import cached_property
 from ..utils import header_property
 from .http import parse_cookie
+from .utils import get_content_length
 from .utils import get_current_url
 from .utils import get_host
 
@@ -274,17 +275,10 @@ class Request:
         the entity-body that would have been sent had the request been a
         GET.
         """
-        if self.headers.get("Transfer-Encoding", "") == "chunked":
-            return None
-
-        content_length = self.headers.get("Content-Length")
-        if content_length is not None:
-            try:
-                return max(0, int(content_length))
-            except (ValueError, TypeError):
-                pass
-
-        return None
+        return get_content_length(
+            http_content_length=self.headers.get("Content-Length"),
+            http_transfer_encoding=self.headers.get("Transfer-Encoding"),
+        )
 
     content_encoding = header_property[str](
         "Content-Encoding",

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -146,22 +146,21 @@ def get_current_url(
 
 def get_content_length(
     http_content_length: t.Union[str, None] = None,
-    http_transfer_encoding: t.Union[str, None] = "",
+    http_transfer_encoding: t.Union[str, None] = None,
 ) -> t.Optional[int]:
-    """Returns the content length as an integer or ``None`` if
-    unavailable or chunked transfer encoding is used.
+    """Return the ``Content-Length`` header value as an int. If the header is not given
+    or the ``Transfer-Encoding`` header is ``chunked``, ``None`` is returned to indicate
+    a streaming request. If the value is not an integer, or negative, 0 is returned.
 
     :param http_content_length: The Content-Length HTTP header.
     :param http_transfer_encoding: The Transfer-Encoding HTTP header.
 
     .. versionadded:: 2.2
     """
-    if http_transfer_encoding == "chunked":
+    if http_transfer_encoding == "chunked" or http_content_length is None:
         return None
 
-    if http_content_length is not None:
-        try:
-            return max(0, int(http_content_length))
-        except (ValueError, TypeError):
-            pass
-    return None
+    try:
+        return max(0, int(http_content_length))
+    except ValueError:
+        return 0

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -9,6 +9,8 @@ from itertools import chain
 from ._internal import _make_encode_wrapper
 from ._internal import _to_bytes
 from ._internal import _to_str
+from .exceptions import ClientDisconnected
+from .exceptions import RequestEntityTooLarge
 from .sansio import utils as _sansio_utils
 from .sansio.utils import host_is_trusted  # noqa: F401 # Imported as part of API
 
@@ -114,55 +116,77 @@ def get_host(
 
 
 def get_content_length(environ: "WSGIEnvironment") -> t.Optional[int]:
-    """Returns the content length from the WSGI environment as
-    integer. If it's not available or chunked transfer encoding is used,
-    ``None`` is returned.
+    """Return the ``Content-Length`` header value as an int. If the header is not given
+    or the ``Transfer-Encoding`` header is ``chunked``, ``None`` is returned to indicate
+    a streaming request. If the value is not an integer, or negative, 0 is returned.
+
+    :param environ: The WSGI environ to get the content length from.
 
     .. versionadded:: 0.9
-
-    :param environ: the WSGI environ to fetch the content length from.
     """
     return _sansio_utils.get_content_length(
         http_content_length=environ.get("CONTENT_LENGTH"),
-        http_transfer_encoding=environ.get("HTTP_TRANSFER_ENCODING", ""),
+        http_transfer_encoding=environ.get("HTTP_TRANSFER_ENCODING"),
     )
 
 
 def get_input_stream(
-    environ: "WSGIEnvironment", safe_fallback: bool = True
+    environ: "WSGIEnvironment",
+    safe_fallback: bool = True,
+    max_content_length: t.Optional[int] = None,
 ) -> t.IO[bytes]:
-    """Returns the input stream from the WSGI environment and wraps it
-    in the most sensible way possible. The stream returned is not the
-    raw WSGI stream in most cases but one that is safe to read from
-    without taking into account the content length.
+    """Return the WSGI input stream, wrapped so that it may be read safely without going
+    past the ``Content-Length`` header value or ``max_content_length``.
 
-    If content length is not set, the stream will be empty for safety reasons.
-    If the WSGI server supports chunked or infinite streams, it should set
-    the ``wsgi.input_terminated`` value in the WSGI environ to indicate that.
+    If ``Content-Length`` exceeds ``max_content_length``, a
+    :exc:`RequestEntityTooLarge`` ``413 Content Too Large`` error is raised.
+
+    If the WSGI server sets ``environ["wsgi.input_terminated"]``, it indicates that the
+    server handles terminating the stream, so it is safe to read directly. For example,
+    a server that knows how to handle chunked requests safely would set this.
+
+    If ``max_content_length`` is set, that limit is used even if ``Content-Length`` or
+    ``wsgi.input_terminated`` are set. If none of these are set, then an empty stream is
+    returned unless the user explicitly disables this safe fallback.
+
+    If the limit is reached before the underlying stream is exhausted (such as a file
+    that is too large, or an infinite stream), the remaining contents of the stream
+    cannot be read safely. Depending on how the server handles this, clients may show a
+    "connection reset" failure instead of seeing the 413 response.
+
+    :param environ: The WSGI environ containing the stream.
+    :param safe_fallback: Return an empty stream when ``Content-Length`` is not set.
+        Disabling this allows infinite streams, which can be a denial-of-service risk.
+    :param max_content_length: The maximum length that content-length or streaming
+        requests may not exceed.
+
+    .. versionchanged:: 2.3
+        Check ``max_content_length`` and raise an error if it is exceeded.
 
     .. versionadded:: 0.9
-
-    :param environ: the WSGI environ to fetch the stream from.
-    :param safe_fallback: use an empty stream as a safe fallback when the
-        content length is not set. Disabling this allows infinite streams,
-        which can be a denial-of-service risk.
     """
     stream = t.cast(t.IO[bytes], environ["wsgi.input"])
     content_length = get_content_length(environ)
 
-    # A wsgi extension that tells us if the input is terminated.  In
-    # that case we return the stream unchanged as we know we can safely
-    # read it until the end.
-    if environ.get("wsgi.input_terminated"):
+    if content_length is not None and max_content_length is not None:
+        if content_length > max_content_length:
+            raise RequestEntityTooLarge()
+    elif max_content_length is not None:
+        return t.cast(
+            t.IO[bytes], LimitedStream(stream, max_content_length, is_max=True)
+        )
+
+    # A WSGI server can set this to indicate that it terminates the input stream. In
+    # that case the stream is safe without wrapping.
+    if "wsgi.input_terminated" in environ:
         return stream
 
-    # If the request doesn't specify a content length, returning the stream is
-    # potentially dangerous because it could be infinite, malicious or not. If
-    # safe_fallback is true, return an empty stream instead for safety.
+    # No limit given, return an empty stream unless the user explicitly allows the
+    # potentially infinite stream. An infinite stream is dangerous if it's not expected,
+    # as it can tie up a worker indefinitely.
     if content_length is None:
         return io.BytesIO() if safe_fallback else stream
 
-    # Otherwise limit the stream to the content length
     return t.cast(t.IO[bytes], LimitedStream(stream, content_length))
 
 
@@ -621,198 +645,174 @@ def make_chunk_iter(
         yield _join(buffer)
 
 
-class LimitedStream(io.IOBase):
-    """Wraps a stream so that it doesn't read more than n bytes.  If the
-    stream is exhausted and the caller tries to get more bytes from it
-    :func:`on_exhausted` is called which by default returns an empty
-    string.  The return value of that function is forwarded
-    to the reader function.  So if it returns an empty string
-    :meth:`read` will return an empty string as well.
+class LimitedStream(io.RawIOBase):
+    """Wrap a stream so that it doesn't read more than a given limit. This is used to
+    limit ``wsgi.input`` to the ``Content-Length`` header value or
+    :attr:`.Request.max_content_length`.
 
-    The limit however must never be higher than what the stream can
-    output.  Otherwise :meth:`readlines` will try to read past the
-    limit.
+    When attempting to read after the limit has been reached, :meth:`on_exhausted` is
+    called. When the limit is a maximum, this raises :exc:`.RequestEntityTooLarge`.
 
-    .. admonition:: Note on WSGI compliance
+    If reading from the stream returns zero bytes or raises an error,
+    :meth:`on_disconnect` is called, which raises :exc:`.ClientDisconnected`. When the
+    limit is a maximum and zero bytes were read, no error is raised, since it may be the
+    end of the stream.
 
-       calls to :meth:`readline` and :meth:`readlines` are not
-       WSGI compliant because it passes a size argument to the
-       readline methods.  Unfortunately the WSGI PEP is not safely
-       implementable without a size argument to :meth:`readline`
-       because there is no EOF marker in the stream.  As a result
-       of that the use of :meth:`readline` is discouraged.
+    If the limit is reached before the underlying stream is exhausted (such as a file
+    that is too large, or an infinite stream), the remaining contents of the stream
+    cannot be read safely. Depending on how the server handles this, clients may show a
+    "connection reset" failure instead of seeing the 413 response.
 
-       For the same reason iterating over the :class:`LimitedStream`
-       is not portable.  It internally calls :meth:`readline`.
+    :param stream: The stream to read from. Must be a readable binary IO object.
+    :param limit: The limit in bytes to not read past. Should be either the
+        ``Content-Length`` header value or ``request.max_content_length``.
+    :param is_max: Whether the given ``limit`` is ``request.max_content_length`` instead
+        of the ``Content-Length`` header value. This changes how exhausted and
+        disconnect events are handled.
 
-       We strongly suggest using :meth:`read` only or using the
-       :func:`make_line_iter` which safely iterates line-based
-       over a WSGI input stream.
+    .. versionchanged:: 2.3
+        Handle ``max_content_length`` differently than ``Content-Length``.
 
-    :param stream: the stream to wrap.
-    :param limit: the limit for the stream, must not be longer than
-                  what the string can provide if the stream does not
-                  end with `EOF` (like `wsgi.input`)
+    .. versionchanged:: 2.3
+        Implements ``io.RawIOBase`` rather than ``io.IOBase``.
     """
 
-    def __init__(self, stream: t.IO[bytes], limit: int) -> None:
-        self._read = stream.read
-        self._readline = stream.readline
+    def __init__(self, stream: t.IO[bytes], limit: int, is_max: bool = False) -> None:
+        self._stream = stream
         self._pos = 0
         self.limit = limit
-
-    def __iter__(self) -> "LimitedStream":
-        return self
+        self._limit_is_max = is_max
 
     @property
     def is_exhausted(self) -> bool:
-        """If the stream is exhausted this attribute is `True`."""
+        """Whether the current stream position has reached the limit."""
         return self._pos >= self.limit
 
-    def on_exhausted(self) -> bytes:
-        """This is called when the stream tries to read past the limit.
-        The return value of this function is returned from the reading
-        function.
+    def on_exhausted(self) -> None:
+        """Called when attempting to read after the limit has been reached.
+
+        The default behavior is to do nothing, unless the limit is a maximum, in which
+        case it raises :exc:`.RequestEntityTooLarge`.
+
+        .. versionchanged:: 2.3
+            Raises ``RequestEntityTooLarge`` if the limit is a maximum.
+
+        .. versionchanged:: 2.3
+            Any return value is ignored.
         """
-        # Read null bytes from the stream so that we get the
-        # correct end of stream marker.
-        return self._read(0)
+        if self._limit_is_max:
+            raise RequestEntityTooLarge()
 
-    def on_disconnect(self) -> bytes:
-        """What should happen if a disconnect is detected?  The return
-        value of this function is returned from read functions in case
-        the client went away.  By default a
-        :exc:`~werkzeug.exceptions.ClientDisconnected` exception is raised.
+    def on_disconnect(self, error: t.Optional[Exception] = None) -> None:
+        """Called when an attempted read receives zero bytes before the limit was
+        reached. This indicates that the client disconnected before sending the full
+        request body.
+
+        The default behavior is to raise :exc:`.ClientDisconnected`, unless the limit is
+        a maximum and no error was raised.
+
+        .. versionchanged:: 2.3
+            Added the ``error`` parameter. Do nothing if the limit is a maximum and no
+            error was raised.
+
+        .. versionchanged:: 2.3
+            Any return value is ignored.
         """
-        from .exceptions import ClientDisconnected
+        if not self._limit_is_max or error is not None:
+            raise ClientDisconnected()
 
-        raise ClientDisconnected()
+        # If the limit is a maximum, then we may have read zero bytes because the
+        # streaming body is complete. There's no way to distinguish that from the
+        # client disconnecting early.
 
-    def _exhaust_chunks(self, chunk_size: int = 1024 * 64) -> t.Iterator[bytes]:
+    def exhaust(self) -> bytes:
         """Exhaust the stream by reading until the limit is reached or the client
-        disconnects, yielding each chunk.
+        disconnects, returning the remaining data.
 
-        :param chunk_size: How many bytes to read at a time.
-
-        :meta private:
-
-        .. versionadded:: 2.2.3
-        """
-        to_read = self.limit - self._pos
-
-        while to_read > 0:
-            chunk = self.read(min(to_read, chunk_size))
-            yield chunk
-            to_read -= len(chunk)
-
-    def exhaust(self, chunk_size: int = 1024 * 64) -> None:
-        """Exhaust the stream by reading until the limit is reached or the client
-        disconnects, discarding the data.
-
-        :param chunk_size: How many bytes to read at a time.
+        .. versionchanged:: 2.3
+            Return the remaining data.
 
         .. versionchanged:: 2.2.3
             Handle case where wrapped stream returns fewer bytes than requested.
         """
-        for _ in self._exhaust_chunks(chunk_size):
-            pass
+        if not self.is_exhausted:
+            return self.readall()
 
-    def read(self, size: t.Optional[int] = None) -> bytes:
-        """Read up to ``size`` bytes from the underlying stream. If size is not
-        provided, read until the limit.
+        return b""
 
-        If the limit is reached, :meth:`on_exhausted` is called, which returns empty
-        bytes.
+    def readinto(self, b: bytearray) -> t.Optional[int]:  # type: ignore[override]
+        size = len(b)
+        remaining = self.limit - self._pos
 
-        If no bytes are read and the limit is not reached, or if an error occurs during
-        the read, :meth:`on_disconnect` is called, which raises
-        :exc:`.ClientDisconnected`.
+        if remaining <= 0:
+            self.on_exhausted()
+            return 0
 
-        :param size: The number of bytes to read. ``None``, default, reads until the
-            limit is reached.
+        if hasattr(self._stream, "readinto"):
+            # Use stream.readinto if it's available.
+            if size <= remaining:
+                # The size fits in the remaining limit, use the buffer directly.
+                try:
+                    out_size: t.Optional[int] = self._stream.readinto(b)
+                except (OSError, ValueError) as e:
+                    self.on_disconnect(error=e)
+                    return 0
+            else:
+                # Use a temp buffer with the remaining limit as the size.
+                temp_b = bytearray(remaining)
 
-        .. versionchanged:: 2.2.3
-            Handle case where wrapped stream returns fewer bytes than requested.
-        """
-        if self._pos >= self.limit:
-            return self.on_exhausted()
+                try:
+                    out_size = self._stream.readinto(temp_b)
+                except (OSError, ValueError) as e:
+                    self.on_disconnect(error=e)
+                    return 0
 
-        if size is None or size == -1:  # -1 is for consistency with file
-            # Keep reading from the wrapped stream until the limit is reached. Can't
-            # rely on stream.read(size) because it's not guaranteed to return size.
-            buf = bytearray()
-
-            for chunk in self._exhaust_chunks():
-                buf.extend(chunk)
-
-            return bytes(buf)
-
-        to_read = min(self.limit - self._pos, size)
-
-        try:
-            read = self._read(to_read)
-        except (OSError, ValueError):
-            return self.on_disconnect()
-
-        if to_read and not len(read):
-            # If no data was read, treat it as a disconnect. As long as some data was
-            # read, a subsequent call can still return more before reaching the limit.
-            return self.on_disconnect()
-
-        self._pos += len(read)
-        return read
-
-    def readline(self, size: t.Optional[int] = None) -> bytes:
-        """Reads one line from the stream."""
-        if self._pos >= self.limit:
-            return self.on_exhausted()
-        if size is None:
-            size = self.limit - self._pos
+                if out_size:
+                    b[:out_size] = temp_b
         else:
-            size = min(size, self.limit - self._pos)
-        try:
-            line = self._readline(size)
-        except (ValueError, OSError):
-            return self.on_disconnect()
-        if size and not line:
-            return self.on_disconnect()
-        self._pos += len(line)
-        return line
+            # WSGI requires that stream.read is available.
+            try:
+                data = self._stream.read(min(size, remaining))
+            except (OSError, ValueError) as e:
+                self.on_disconnect(error=e)
+                return 0
 
-    def readlines(self, size: t.Optional[int] = None) -> t.List[bytes]:
-        """Reads a file into a list of strings.  It calls :meth:`readline`
-        until the file is read to the end.  It does support the optional
-        `size` argument if the underlying stream supports it for
-        `readline`.
-        """
-        last_pos = self._pos
-        result = []
-        if size is not None:
-            end = min(self.limit, last_pos + size)
-        else:
-            end = self.limit
-        while True:
-            if size is not None:
-                size -= last_pos - self._pos
-            if self._pos >= end:
+            out_size = len(data)
+            b[:out_size] = data
+
+        if not out_size:
+            # Read zero bytes from the stream.
+            self.on_disconnect()
+            return 0
+
+        self._pos += out_size
+        return out_size
+
+    def readall(self) -> bytes:
+        if self.is_exhausted:
+            self.on_exhausted()
+            return b""
+
+        out = bytearray()
+
+        # The parent implementation uses "while True", which results in an extra read.
+        while not self.is_exhausted:
+            data = self.read(1024 * 64)
+
+            # Stream may return empty before a max limit is reached.
+            if not data:
                 break
-            result.append(self.readline(size))
-            if size is not None:
-                last_pos = self._pos
-        return result
+
+            out.extend(data)
+
+        return bytes(out)
 
     def tell(self) -> int:
-        """Returns the position of the stream.
+        """Return the current stream position.
 
         .. versionadded:: 0.9
         """
         return self._pos
-
-    def __next__(self) -> bytes:
-        line = self.readline()
-        if not line:
-            raise StopIteration()
-        return line
 
     def readable(self) -> bool:
         return True


### PR DESCRIPTION
`max_content_length` is now checked consistently for anything that accesses `request.stream`, such as `request.data`, `request.form`, and `request.json`. The check is done in `get_input_stream`.

If `request.max_content_length` is set, it is checked immediately when accessing `request.stream`, and raises a 413 Content Too Large error (`RequestEntityTooLarge`). If `Content-Length` is not set (a streaming request), `max_content_length` is used in `LimitedStream` so that it may raise once the limit is met.

`LimitedStream` now implements `io.RawIOBase` instead of the even more basic `io.IOBase`. Only `readinto` needs to be implemented, `read`, `readline`, and `readlines` have default C implementations based on that. The default `readall` required an extra read to check for EOF, so that had to be implemented as well.

`LimitedStream` has a new `is_max` parameter to distinguish whether the limit is a client-reported `Content-Length` or an application-set `max_content_length`. If the limit is a maximum, reading from an exhausted stream raises a 413 error instead of returning empty. Reading empty does not raise a `ClientDisconnected` error, since there's no way to tell if the client stopped sending because the stream was done or because it really disconnected.

The `readlines` implementation handles the `size` parameter correctly now. It reads at least one line, but stops reading more lines if the size was reached while reading the last line. Therefore, more than `size` bytes may be read. It is still safe, since each read goes through `readinto`, so it will still be limited.

fixes #1513 
fixes #2620
fixes #690

---

It is not possible for the WSGI application to safely exhaust the input stream. It's up to the WSGI/HTTP server which handles the socket, or the client application which handles what happens when the server closes the input stream. Therefore it's expected that the client might show a "connection reset" failure rather than a 413 error message.

All "exhaust input" handling is removed from the application side of Werkzeug. It now always raises an error once `Content-Length` or `max_content_length` is reached, and will not read past that. However, the development server will now continue to read up to 10GB, 10MB at a time, up to 1000 reads, for 10 seconds. This allows the client to see the 413 error in all but extreme cases. The development server is already not appropriate for production, so adding this does not seem unreasonable.

The server is still not able to handle HTTP/1.1 keep-alive connections. It was too complicated to handle exhausting the input while not accidentally reading the next request line.

I really think we should take all these things we've been adding on top of `http.server` and push them back upstream, if anyone wants to work on that.