### PR TITLE
development server discards header keys with underscores

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,8 @@ Unreleased
     request stream up to 10GB or 1000 reads. This allows clients to see a 413 error if
     ``max_content_length`` is exceeded, instead of a "connection reset" failure.
     :pr:`2620`
+-   The development server discards header keys that contain underscores ``_``, as they
+    are ambiguous with dashes ``-`` in WSGI. :pr:`2621`
 
 
 Version 2.2.3

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -202,6 +202,9 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
         }
 
         for key, value in self.headers.items():
+            if "_" in key:
+                continue
+
             key = key.upper().replace("-", "_")
             value = value.replace("\r\n", "")
             if key not in ("CONTENT_TYPE", "CONTENT_LENGTH"):


### PR DESCRIPTION
WSGI (from CGI) converts all header keys to uppercase with underscores. Headers typically have dashes instead of underscores. The development server will now discard headers with underscores, which would otherwise be indistinguishable from the same name with dashes.

Production WSGI and HTTP servers will already discard such headers, this makes the development server match that behavior for consistency. However, the development server still should not be used in production.