### PR TITLE
`secure_filename` looks for more Windows reserved file names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,7 @@ Unreleased
     :pr:`2620`
 -   The development server discards header keys that contain underscores ``_``, as they
     are ambiguous with dashes ``-`` in WSGI. :pr:`2621`
+-   ``secure_filename`` looks for more Windows reserved file names. :pr:`2622`
 
 
 Version 2.2.3

--- a/src/werkzeug/utils.py
+++ b/src/werkzeug/utils.py
@@ -31,19 +31,14 @@ _T = t.TypeVar("_T")
 
 _entity_re = re.compile(r"&([^;]+);")
 _filename_ascii_strip_re = re.compile(r"[^A-Za-z0-9_.-]")
-_windows_device_files = (
+_windows_device_files = {
     "CON",
-    "AUX",
-    "COM1",
-    "COM2",
-    "COM3",
-    "COM4",
-    "LPT1",
-    "LPT2",
-    "LPT3",
     "PRN",
+    "AUX",
     "NUL",
-)
+    *(f"COM{i}" for i in range(10)),
+    *(f"LPT{i}" for i in range(10)),
+}
 
 
 class cached_property(property, t.Generic[_T]):


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file calls out COM0-9 and LPT0-9, not only 1-4.