### PR TITLE
Correctly implement multipart parsing for empty fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,7 @@ Unreleased
 -   ``secure_filename`` looks for more Windows reserved file names. :pr:`2622`
 -   Update type annotation for ``best_match`` to make ``default`` parameter clearer.
     :issue:`2625`
+-   Multipart parser handles empty fields correctly. :issue:`2632`
 
 
 Version 2.2.3


### PR DESCRIPTION
According to RFC2046

    body-part := MIME-part-headers [CRLF *OCTET]

Meaning there should only be a blank line if there is are body octets, hence if the field is empty it should not be present. The previous implementation assumed the blacnk line would always be present.

This fixes both the decoder and encoder to ensure that empty fields are correctly decoded and encoded.

Closes #2632

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
