### PR TITLE
fix `ProfilerMiddleware` stream param type hint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,8 @@ Unreleased
     use UTF-8. :issue:`2602`
 -   Header values that have charset information only allow ASCII, UTF-8, and ISO-8859-1.
     :pr:`2614, 2640`
+-   Update type annotation for ``ProfilerMiddleware`` ``stream`` parameter.
+    :issue:`2642`
 
 
 Version 2.2.3

--- a/src/werkzeug/middleware/profiler.py
+++ b/src/werkzeug/middleware/profiler.py
@@ -77,7 +77,7 @@ class ProfilerMiddleware:
     def __init__(
         self,
         app: "WSGIApplication",
-        stream: t.IO[str] = sys.stdout,
+        stream: t.Union[t.IO[str], None] = sys.stdout,
         sort_by: t.Iterable[str] = ("time", "calls"),
         restrictions: t.Iterable[t.Union[str, int, float]] = (),
         profile_dir: t.Optional[str] = None,


### PR DESCRIPTION
Make the ProfilerMiddleware initializer stream argument type hint conform to the documentation and implementation.

The documentation and implementation for the initialization argument `stream` of `ProfilerMiddleware` doesn't match the type hint. This fix intend to make all three compliant.

- fixes #2642 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.

**Does this warrant a change to CHANGES.rst?** If so I can add it .

**pytest fails with an unrelated error** `tests/test_serving.py` fails with:
```self = <conftest.UnixSocketHTTPConnection object at 0x1024e42e0>

    def connect(self):
        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
>       self.sock.connect(self.host)
E       OSError: AF_UNIX path too long

tests/conftest.py:21: OSError
```
Which seems to be unrelated but still a failure. Please advice.