### PR TITLE
remove test app and secret app binary data

### DIFF
--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -8,8 +8,6 @@ from datetime import datetime
 from datetime import timezone
 
 if t.TYPE_CHECKING:
-    from _typeshed.wsgi import StartResponse
-    from _typeshed.wsgi import WSGIApplication
     from _typeshed.wsgi import WSGIEnvironment
     from .wrappers.request import Request
 
@@ -311,91 +309,3 @@ def _decode_idna(domain: str) -> str:
             parts.append(part.decode("ascii"))
 
     return ".".join(parts)
-
-
-def _easteregg(app: WSGIApplication | None = None) -> WSGIApplication:
-    """Like the name says.  But who knows how it works?"""
-
-    def bzzzzzzz(gyver: bytes) -> str:
-        import base64
-        import zlib
-
-        return zlib.decompress(base64.b64decode(gyver)).decode("ascii")
-
-    gyver = "\n".join(
-        [
-            x + (77 - len(x)) * " "
-            for x in bzzzzzzz(
-                b"""
-eJyFlzuOJDkMRP06xRjymKgDJCDQStBYT8BCgK4gTwfQ2fcFs2a2FzvZk+hvlcRvRJD148efHt9m
-9Xz94dRY5hGt1nrYcXx7us9qlcP9HHNh28rz8dZj+q4rynVFFPdlY4zH873NKCexrDM6zxxRymzz
-4QIxzK4bth1PV7+uHn6WXZ5C4ka/+prFzx3zWLMHAVZb8RRUxtFXI5DTQ2n3Hi2sNI+HK43AOWSY
-jmEzE4naFp58PdzhPMdslLVWHTGUVpSxImw+pS/D+JhzLfdS1j7PzUMxij+mc2U0I9zcbZ/HcZxc
-q1QjvvcThMYFnp93agEx392ZdLJWXbi/Ca4Oivl4h/Y1ErEqP+lrg7Xa4qnUKu5UE9UUA4xeqLJ5
-jWlPKJvR2yhRI7xFPdzPuc6adXu6ovwXwRPXXnZHxlPtkSkqWHilsOrGrvcVWXgGP3daXomCj317
-8P2UOw/NnA0OOikZyFf3zZ76eN9QXNwYdD8f8/LdBRFg0BO3bB+Pe/+G8er8tDJv83XTkj7WeMBJ
-v/rnAfdO51d6sFglfi8U7zbnr0u9tyJHhFZNXYfH8Iafv2Oa+DT6l8u9UYlajV/hcEgk1x8E8L/r
-XJXl2SK+GJCxtnyhVKv6GFCEB1OO3f9YWAIEbwcRWv/6RPpsEzOkXURMN37J0PoCSYeBnJQd9Giu
-LxYQJNlYPSo/iTQwgaihbART7Fcyem2tTSCcwNCs85MOOpJtXhXDe0E7zgZJkcxWTar/zEjdIVCk
-iXy87FW6j5aGZhttDBoAZ3vnmlkx4q4mMmCdLtnHkBXFMCReqthSGkQ+MDXLLCpXwBs0t+sIhsDI
-tjBB8MwqYQpLygZ56rRHHpw+OAVyGgaGRHWy2QfXez+ZQQTTBkmRXdV/A9LwH6XGZpEAZU8rs4pE
-1R4FQ3Uwt8RKEtRc0/CrANUoes3EzM6WYcFyskGZ6UTHJWenBDS7h163Eo2bpzqxNE9aVgEM2CqI
-GAJe9Yra4P5qKmta27VjzYdR04Vc7KHeY4vs61C0nbywFmcSXYjzBHdiEjraS7PGG2jHHTpJUMxN
-Jlxr3pUuFvlBWLJGE3GcA1/1xxLcHmlO+LAXbhrXah1tD6Ze+uqFGdZa5FM+3eHcKNaEarutAQ0A
-QMAZHV+ve6LxAwWnXbbSXEG2DmCX5ijeLCKj5lhVFBrMm+ryOttCAeFpUdZyQLAQkA06RLs56rzG
-8MID55vqr/g64Qr/wqwlE0TVxgoiZhHrbY2h1iuuyUVg1nlkpDrQ7Vm1xIkI5XRKLedN9EjzVchu
-jQhXcVkjVdgP2O99QShpdvXWoSwkp5uMwyjt3jiWCqWGSiaaPAzohjPanXVLbM3x0dNskJsaCEyz
-DTKIs+7WKJD4ZcJGfMhLFBf6hlbnNkLEePF8Cx2o2kwmYF4+MzAxa6i+6xIQkswOqGO+3x9NaZX8
-MrZRaFZpLeVTYI9F/djY6DDVVs340nZGmwrDqTCiiqD5luj3OzwpmQCiQhdRYowUYEA3i1WWGwL4
-GCtSoO4XbIPFeKGU13XPkDf5IdimLpAvi2kVDVQbzOOa4KAXMFlpi/hV8F6IDe0Y2reg3PuNKT3i
-RYhZqtkQZqSB2Qm0SGtjAw7RDwaM1roESC8HWiPxkoOy0lLTRFG39kvbLZbU9gFKFRvixDZBJmpi
-Xyq3RE5lW00EJjaqwp/v3EByMSpVZYsEIJ4APaHmVtpGSieV5CALOtNUAzTBiw81GLgC0quyzf6c
-NlWknzJeCsJ5fup2R4d8CYGN77mu5vnO1UqbfElZ9E6cR6zbHjgsr9ly18fXjZoPeDjPuzlWbFwS
-pdvPkhntFvkc13qb9094LL5NrA3NIq3r9eNnop9DizWOqCEbyRBFJTHn6Tt3CG1o8a4HevYh0XiJ
-sR0AVVHuGuMOIfbuQ/OKBkGRC6NJ4u7sbPX8bG/n5sNIOQ6/Y/BX3IwRlTSabtZpYLB85lYtkkgm
-p1qXK3Du2mnr5INXmT/78KI12n11EFBkJHHp0wJyLe9MvPNUGYsf+170maayRoy2lURGHAIapSpQ
-krEDuNoJCHNlZYhKpvw4mspVWxqo415n8cD62N9+EfHrAvqQnINStetek7RY2Urv8nxsnGaZfRr/
-nhXbJ6m/yl1LzYqscDZA9QHLNbdaSTTr+kFg3bC0iYbX/eQy0Bv3h4B50/SGYzKAXkCeOLI3bcAt
-mj2Z/FM1vQWgDynsRwNvrWnJHlespkrp8+vO1jNaibm+PhqXPPv30YwDZ6jApe3wUjFQobghvW9p
-7f2zLkGNv8b191cD/3vs9Q833z8t"""
-            ).splitlines()
-        ]
-    )
-
-    def easteregged(
-        environ: WSGIEnvironment, start_response: StartResponse
-    ) -> t.Iterable[bytes]:
-        def injecting_start_response(
-            status: str, headers: list[tuple[str, str]], exc_info: t.Any = None
-        ) -> t.Callable[[bytes], t.Any]:
-            headers.append(("X-Powered-By", "Werkzeug"))
-            return start_response(status, headers, exc_info)
-
-        if app is not None and environ.get("QUERY_STRING") != "macgybarchakku":
-            return app(environ, injecting_start_response)
-        injecting_start_response("200 OK", [("Content-Type", "text/html")])
-        return [
-            f"""\
-<!doctype html>
-<html lang=en>
-<head>
-<title>About Werkzeug</title>
-<style type="text/css">
-  body {{ font: 15px Georgia, serif; text-align: center; }}
-  a {{ color: #333; text-decoration: none; }}
-  h1 {{ font-size: 30px; margin: 20px 0 10px 0; }}
-  p {{ margin: 0 0 30px 0; }}
-  pre {{ font: 11px 'Consolas', 'Monaco', monospace; line-height: 0.95; }}
-</style>
-</head>
-<body>
-<h1><a href="http://werkzeug.pocoo.org/">Werkzeug</a></h1>
-<p>the Swiss Army knife of Python web development.</p>
-<pre>{gyver}\n\n\n</pre>
-</body>
-</html>""".encode(
-                "latin1"
-            )
-        ]
-
-    return easteregged

--- a/src/werkzeug/testapp.py
+++ b/src/werkzeug/testapp.py
@@ -3,7 +3,6 @@ it for WSGI compliance.
 """
 from __future__ import annotations
 
-import base64
 import os
 import sys
 import typing as t
@@ -15,53 +14,6 @@ from . import __version__ as _werkzeug_version
 from .wrappers.request import Request
 from .wrappers.response import Response
 
-if t.TYPE_CHECKING:
-    from _typeshed.wsgi import StartResponse
-    from _typeshed.wsgi import WSGIEnvironment
-
-
-logo = Response(
-    base64.b64decode(
-        """
-R0lGODlhoACgAOMIAAEDACwpAEpCAGdgAJaKAM28AOnVAP3rAP/////////
-//////////////////////yH5BAEKAAgALAAAAACgAKAAAAT+EMlJq704680R+F0ojmRpnuj0rWnrv
-nB8rbRs33gu0bzu/0AObxgsGn3D5HHJbCUFyqZ0ukkSDlAidctNFg7gbI9LZlrBaHGtzAae0eloe25
-7w9EDOX2fst/xenyCIn5/gFqDiVVDV4aGeYiKkhSFjnCQY5OTlZaXgZp8nJ2ekaB0SQOjqphrpnOiq
-ncEn65UsLGytLVmQ6m4sQazpbtLqL/HwpnER8bHyLrLOc3Oz8PRONPU1crXN9na263dMt/g4SzjMeX
-m5yDpLqgG7OzJ4u8lT/P69ej3JPn69kHzN2OIAHkB9RUYSFCFQYQJFTIkCDBiwoXWGnowaLEjRm7+G
-p9A7Hhx4rUkAUaSLJlxHMqVMD/aSycSZkyTplCqtGnRAM5NQ1Ly5OmzZc6gO4d6DGAUKA+hSocWYAo
-SlM6oUWX2O/o0KdaVU5vuSQLAa0ADwQgMEMB2AIECZhVSnTno6spgbtXmHcBUrQACcc2FrTrWS8wAf
-78cMFBgwIBgbN+qvTt3ayikRBk7BoyGAGABAdYyfdzRQGV3l4coxrqQ84GpUBmrdR3xNIDUPAKDBSA
-ADIGDhhqTZIWaDcrVX8EsbNzbkvCOxG8bN5w8ly9H8jyTJHC6DFndQydbguh2e/ctZJFXRxMAqqPVA
-tQH5E64SPr1f0zz7sQYjAHg0In+JQ11+N2B0XXBeeYZgBZFx4tqBToiTCPv0YBgQv8JqA6BEf6RhXx
-w1ENhRBnWV8ctEX4Ul2zc3aVGcQNC2KElyTDYyYUWvShdjDyMOGMuFjqnII45aogPhz/CodUHFwaDx
-lTgsaOjNyhGWJQd+lFoAGk8ObghI0kawg+EV5blH3dr+digkYuAGSaQZFHFz2P/cTaLmhF52QeSb45
-Jwxd+uSVGHlqOZpOeJpCFZ5J+rkAkFjQ0N1tah7JJSZUFNsrkeJUJMIBi8jyaEKIhKPomnC91Uo+NB
-yyaJ5umnnpInIFh4t6ZSpGaAVmizqjpByDegYl8tPE0phCYrhcMWSv+uAqHfgH88ak5UXZmlKLVJhd
-dj78s1Fxnzo6yUCrV6rrDOkluG+QzCAUTbCwf9SrmMLzK6p+OPHx7DF+bsfMRq7Ec61Av9i6GLw23r
-idnZ+/OO0a99pbIrJkproCQMA17OPG6suq3cca5ruDfXCCDoS7BEdvmJn5otdqscn+uogRHHXs8cbh
-EIfYaDY1AkrC0cqwcZpnM6ludx72x0p7Fo/hZAcpJDjax0UdHavMKAbiKltMWCF3xxh9k25N/Viud8
-ba78iCvUkt+V6BpwMlErmcgc502x+u1nSxJSJP9Mi52awD1V4yB/QHONsnU3L+A/zR4VL/indx/y64
-gqcj+qgTeweM86f0Qy1QVbvmWH1D9h+alqg254QD8HJXHvjQaGOqEqC22M54PcftZVKVSQG9jhkv7C
-JyTyDoAJfPdu8v7DRZAxsP/ky9MJ3OL36DJfCFPASC3/aXlfLOOON9vGZZHydGf8LnxYJuuVIbl83y
-Az5n/RPz07E+9+zw2A2ahz4HxHo9Kt79HTMx1Q7ma7zAzHgHqYH0SoZWyTuOLMiHwSfZDAQTn0ajk9
-YQqodnUYjByQZhZak9Wu4gYQsMyEpIOAOQKze8CmEF45KuAHTvIDOfHJNipwoHMuGHBnJElUoDmAyX
-c2Qm/R8Ah/iILCCJOEokGowdhDYc/yoL+vpRGwyVSCWFYZNljkhEirGXsalWcAgOdeAdoXcktF2udb
-qbUhjWyMQxYO01o6KYKOr6iK3fE4MaS+DsvBsGOBaMb0Y6IxADaJhFICaOLmiWTlDAnY1KzDG4ambL
-cWBA8mUzjJsN2KjSaSXGqMCVXYpYkj33mcIApyhQf6YqgeNAmNvuC0t4CsDbSshZJkCS1eNisKqlyG
-cF8G2JeiDX6tO6Mv0SmjCa3MFb0bJaGPMU0X7c8XcpvMaOQmCajwSeY9G0WqbBmKv34DsMIEztU6Y2
-KiDlFdt6jnCSqx7Dmt6XnqSKaFFHNO5+FmODxMCWBEaco77lNDGXBM0ECYB/+s7nKFdwSF5hgXumQe
-EZ7amRg39RHy3zIjyRCykQh8Zo2iviRKyTDn/zx6EefptJj2Cw+Ep2FSc01U5ry4KLPYsTyWnVGnvb
-UpyGlhjBUljyjHhWpf8OFaXwhp9O4T1gU9UeyPPa8A2l0p1kNqPXEVRm1AOs1oAGZU596t6SOR2mcB
-Oco1srWtkaVrMUzIErrKri85keKqRQYX9VX0/eAUK1hrSu6HMEX3Qh2sCh0q0D2CtnUqS4hj62sE/z
-aDs2Sg7MBS6xnQeooc2R2tC9YrKpEi9pLXfYXp20tDCpSP8rKlrD4axprb9u1Df5hSbz9QU0cRpfgn
-kiIzwKucd0wsEHlLpe5yHXuc6FrNelOl7pY2+11kTWx7VpRu97dXA3DO1vbkhcb4zyvERYajQgAADs
-="""
-    ),
-    mimetype="image/png",
-)
-
-
 TEMPLATE = """\
 <!doctype html>
 <html lang=en>
@@ -72,7 +24,6 @@ TEMPLATE = """\
   body       { font-family: 'Lucida Grande', 'Lucida Sans Unicode', 'Geneva',
                'Verdana', sans-serif; background-color: white; color: #000;
                font-size: 15px; text-align: center; }
-  #logo      { float: right; padding: 0 0 10px 10px; }
   div.box    { text-align: left; width: 45em; margin: auto; padding: 50px 0;
                background-color: white; }
   h1, h2     { font-family: 'Ubuntu', 'Lucida Grande', 'Lucida Sans Unicode',
@@ -94,7 +45,6 @@ TEMPLATE = """\
   li.exp     { background: white; }
 </style>
 <div class="box">
-  <img src="?resource=logo" id="logo" alt="[The Werkzeug Logo]" />
   <h1>WSGI Information</h1>
   <p>
     This page displays all available information about the WSGI server and
@@ -161,7 +111,21 @@ def iter_sys_path() -> t.Iterator[tuple[str, bool, bool]]:
         yield strip(os.path.normpath(path)), not os.path.isdir(path), path != item
 
 
-def render_testapp(req: Request) -> bytes:
+@Request.application
+def test_app(req: Request) -> Response:
+    """Simple test application that dumps the environment.  You can use
+    it to check if Werkzeug is working properly:
+
+    .. sourcecode:: pycon
+
+        >>> from werkzeug.serving import run_simple
+        >>> from werkzeug.testapp import test_app
+        >>> run_simple('localhost', 3000, test_app)
+         * Running on http://localhost:3000/
+
+    The application displays important information from the WSGI environment,
+    the Python interpreter and the installed libraries.
+    """
     try:
         import pkg_resources
     except ImportError:
@@ -197,44 +161,18 @@ def render_testapp(req: Request) -> bytes:
         class_ = f' class="{" ".join(class_)}"' if class_ else ""
         sys_path.append(f"<li{class_}>{escape(item)}")
 
-    return (
-        TEMPLATE
-        % {
-            "python_version": "<br>".join(escape(sys.version).splitlines()),
-            "platform": escape(sys.platform),
-            "os": escape(os.name),
-            "api_version": sys.api_version,
-            "byteorder": sys.byteorder,
-            "werkzeug_version": _werkzeug_version,
-            "python_eggs": "\n".join(python_eggs),
-            "wsgi_env": "\n".join(wsgi_env),
-            "sys_path": "\n".join(sys_path),
-        }
-    ).encode("utf-8")
-
-
-def test_app(
-    environ: WSGIEnvironment, start_response: StartResponse
-) -> t.Iterable[bytes]:
-    """Simple test application that dumps the environment.  You can use
-    it to check if Werkzeug is working properly:
-
-    .. sourcecode:: pycon
-
-        >>> from werkzeug.serving import run_simple
-        >>> from werkzeug.testapp import test_app
-        >>> run_simple('localhost', 3000, test_app)
-         * Running on http://localhost:3000/
-
-    The application displays important information from the WSGI environment,
-    the Python interpreter and the installed libraries.
-    """
-    req = Request(environ, populate_request=False)
-    if req.args.get("resource") == "logo":
-        response = logo
-    else:
-        response = Response(render_testapp(req), mimetype="text/html")
-    return response(environ, start_response)
+    context = {
+        "python_version": "<br>".join(escape(sys.version).splitlines()),
+        "platform": escape(sys.platform),
+        "os": escape(os.name),
+        "api_version": sys.api_version,
+        "byteorder": sys.byteorder,
+        "werkzeug_version": _werkzeug_version,
+        "python_eggs": "\n".join(python_eggs),
+        "wsgi_env": "\n".join(wsgi_env),
+        "sys_path": "\n".join(sys_path),
+    }
+    return Response(TEMPLATE % context, mimetype="text/html")
 
 
 if __name__ == "__main__":

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,14 +1,6 @@
-from werkzeug import _internal as internal
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
-
-
-def test_easteregg():
-    req = Request.from_values("/?macgybarchakku")
-    resp = Response.force_type(internal._easteregg(None), req)
-    assert b"About Werkzeug" in resp.get_data()
-    assert b"the Swiss Army knife of Python web development" in resp.get_data()
 
 
 def test_wrapper_internals():


### PR DESCRIPTION
The test app included a base64-encoded PNG of the Werkzeug logo. A secret app included a zlib+base64 encoded ASCII art. These are both part of the code and so were included in all wheel builds. Given the number of downloads we get, removing these saves PyPI about 500 GB per month in bandwidth.

We should probably get rid of the test app completely, it's not particularly useful compared to `wsgiref.simple_server.demo_app`. The most interesting addition it has is showing installed packages, but it uses pkg_resources to do it, which I'm not interested in upgrading, and you can just do `pip list` now.

<details><summary>For posterity, here's what the secret app did</summary>

```
from werkzeug import run_simple
from werkzeug._internal import _easteregg

run_simple("127.0.0.1", 5000, _easteregg())
```

![ASCII art of MacGyver](https://user-images.githubusercontent.com/1242887/233212243-696b5ced-df0d-4824-8541-ed6977818ce0.png)

It's ASCII art of MacGyver, a character from the TV show of the same name, who gets out of tricky situations using only the few items he can find nearby. Fitting for Werkzeug, which is the small parts used to build bigger WSGI applications.

</details>