### PR TITLE
escape ASCII control characters in request log

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,8 @@ Unreleased
 -   Update type annotation for ``ProfilerMiddleware`` ``stream`` parameter.
     :issue:`2642`
 -   Use postponed evaluation of annotations. :pr:`2645`
+-   The development server escapes ASCII control characters in decoded URLs before
+    logging the request to the terminal. :pr:`2652`
 
 
 Version 2.2.3


### PR DESCRIPTION
The development server logs requested URLs to the terminal, and decodes percent escapes. If the value contains ASCII control characters, they can mess with the terminal. Copy the fix from Python's `http.server`: https://github.com/python/cpython/issues/100001

Reported by David Leadbeater, G-Research, @dgl