### PR TITLE
update form parser API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,9 @@ Unreleased
 -   Use postponed evaluation of annotations. :pr:`2645`
 -   The development server escapes ASCII control characters in decoded URLs before
     logging the request to the terminal. :pr:`2652`
+-   The ``FormDataParser`` ``parse_functions`` attribute and ``get_parse_func`` method,
+    and the invalid ``application/x-url-encoded`` content type, are deprecated.
+    :pr:`2653`
 
 
 Version 2.2.3

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -244,14 +244,16 @@ class Request(_SansIORequest):
 
         .. versionadded:: 0.8
         """
+        charset = self._charset if self._charset != "utf-8" else None
+        errors = self._encoding_errors if self._encoding_errors != "replace" else None
         return self.form_data_parser_class(
-            self._get_file_stream,
-            self._charset,
-            self._encoding_errors,
-            self.max_form_memory_size,
-            self.max_content_length,
-            self.parameter_storage_class,
+            stream_factory=self._get_file_stream,
+            charset=charset,
+            errors=errors,
+            max_form_memory_size=self.max_form_memory_size,
+            max_content_length=self.max_content_length,
             max_form_parts=self.max_form_parts,
+            cls=self.parameter_storage_class,
         )
 
     def _load_form_data(self) -> None:


### PR DESCRIPTION
Update the `parse_form_data` function to accept `max_form_parts` from 2.2.3. Pass keyword arguments in more places. Deprecate `FormDataParser.parse_functions` and `get_parse_func` in favor of subclassing and overriding `parse`. Deprecate the invalid `application/x-url-encoded` content type. Deprecate `charset` and `errors` as part of #2602.