### PR TITLE
encode plus in urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 2.3.1
 
 Unreleased
 
+-   Percent-encode plus (+) when building URLs and in test requests. :issue:`2657`
+
 
 Version 2.3.0
 -------------

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -1367,4 +1367,4 @@ def _urlencode(
 ) -> str:
     items = [x for x in iter_multi_items(query) if x[1] is not None]
     # safe = https://url.spec.whatwg.org/#percent-encoded-bytes
-    return urlencode(items, safe="!$'()*+,/:;?@", encoding=encoding)
+    return urlencode(items, safe="!$'()*,/:;?@", encoding=encoding)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -922,6 +922,7 @@ def test_build_values_multidict(endpoint, value, expect):
         ([1, 2], "?v=1&v=2"),
         ([1, None, 2], "?v=1&v=2"),
         ([1, "", 2], "?v=1&v=&v=2"),
+        ("1+2", "?v=1%2B2"),
     ],
 )
 def test_build_append_unknown_dict(value, expect):


### PR DESCRIPTION
The `urlencode` helper used when building URLs in the router and test client treated `+` as safe, but it has special meaning in query strings and should be percent-encoded.

fixes #2657 