### PR TITLE
include missing pyi files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Percent-encode plus (+) when building URLs and in test requests. :issue:`2657`
 -   Cookie values don't quote characters defined in RFC 6265. :issue:`2659`
+-   Include ``pyi`` files for ``datastructures`` type annotations. :issue:`2660`
 
 
 Version 2.3.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,6 @@ prune docs/_build
 graft examples
 graft tests
 include src/werkzeug/py.typed
-include src/werkzeug/*.pyi
+recursive-include src/werkzeug *.pyi
 graft src/werkzeug/debug/shared
 global-exclude *.pyc


### PR DESCRIPTION
When `datastructures` became a package, we forgot to update `MANIFEST.in`. Use `recursive-include` to make sure any `pyi` files are included (although the goal is to eventually remove the need for them).

fixes #2660 