### PR TITLE
test client parses set-cookie more accurately

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 2.3.2
 
 Unreleased
 
+-   Parse the cookie ``Expires`` attribute correctly in the test client. :issue:`2669`
+
 
 Version 2.3.1
 -------------


### PR DESCRIPTION
The test client was using a shortcut to parse cookies, replacing `;` with `,` and calling `parse_dict_header`. However, the cookie spec doesn't actually conform to `parse_dict_header`, it allows unquoted spaces and simply expects `;` separators. The `Expires` parameter has spaces in the date string, and so was not being parsed.

fixes #2669 