### PR TITLE
max_content_length only with wsgi.input_terminated

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 2.3.2
 Unreleased
 
 -   Parse the cookie ``Expires`` attribute correctly in the test client. :issue:`2669`
+-   ``max_content_length`` can only be enforced on streaming requests if the server
+    sets ``wsgi.input_terminated``. :issue:`2668`
 
 
 Version 2.3.1


### PR DESCRIPTION
`max_content_length` can only be enforced on streaming requests if the server sets `wsgi.input_terminated`. Otherwise, it is not safe to guess whether a request has no length because it has no data or because it's a stream. For example, the development server passes on the input stream without buffering or termination, which means attempting to read from a stream that's not sending data will hang. We also can't `select` on the input stream ourselves, since `wsgi.input` is not required to be backed by a file descriptor, only file-like. If the server does not support it, fall back to the old behavior of returning an empty stream for safety.

fixes #2668 