### PR TITLE
cookie sets `Path=/` by default again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Parse the cookie ``Expires`` attribute correctly in the test client. :issue:`2669`
 -   ``max_content_length`` can only be enforced on streaming requests if the server
     sets ``wsgi.input_terminated``. :issue:`2668`
+-   The cookie ``Path`` attribute is set to ``/`` by default again, to prevent clients
+    from falling back to RFC 6265's ``default-path`` behavior. :issue:`2672`
 
 
 Version 2.3.1

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -1341,7 +1341,7 @@ def dump_cookie(
     value: str = "",
     max_age: timedelta | int | None = None,
     expires: str | datetime | int | float | None = None,
-    path: str | None = None,
+    path: str | None = "/",
     domain: str | None = None,
     secure: bool = False,
     httponly: bool = False,
@@ -1387,6 +1387,9 @@ def dump_cookie(
         only be attached to requests if those requests are same-site.
 
     .. _`cookie`: http://browsercookielimits.squawky.net/
+
+    .. versionchanged:: 2.3.1
+        The ``path`` parameter is ``/`` by default.
 
     .. versionchanged:: 2.3
         ``localhost`` and other names without a dot are allowed for the domain. A


### PR DESCRIPTION
If the path parameter is not present, RFC 6265 has a rule for picking a `default-path` that's the parent of the current path. For some reason, Firefox and Chrome on my computer always pick `/` instead, which is why I thought it was ok to remove. This PR restores the previous behavior. Setting `Path=/` is also a requirement for the `__Host-` and `__Secure-` [cookie prefixes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#cookie_prefixes).

fixes #2672 