### PR TITLE
cookie sets `Path=/` everywhere by default again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.3.3
 
 Unreleased
 
+-   The cookie ``Path`` attribute is set to ``/`` by default again, to prevent clients
+    from falling back to RFC 6265's ``default-path`` behavior. :issue:`2672, 2679`
+
 
 Version 2.3.2
 -------------
@@ -14,8 +17,6 @@ Released 2023-04-28
 -   Parse the cookie ``Expires`` attribute correctly in the test client. :issue:`2669`
 -   ``max_content_length`` can only be enforced on streaming requests if the server
     sets ``wsgi.input_terminated``. :issue:`2668`
--   The cookie ``Path`` attribute is set to ``/`` by default again, to prevent clients
-    from falling back to RFC 6265's ``default-path`` behavior. :issue:`2672`
 
 
 Version 2.3.1

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -1388,7 +1388,7 @@ def dump_cookie(
 
     .. _`cookie`: http://browsercookielimits.squawky.net/
 
-    .. versionchanged:: 2.3.2
+    .. versionchanged:: 2.3.3
         The ``path`` parameter is ``/`` by default.
 
     .. versionchanged:: 2.3.1

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -225,7 +225,7 @@ class Response:
         value: str = "",
         max_age: timedelta | int | None = None,
         expires: str | datetime | int | float | None = None,
-        path: str | None = None,
+        path: str | None = "/",
         domain: str | None = None,
         secure: bool = False,
         httponly: bool = False,
@@ -276,7 +276,7 @@ class Response:
     def delete_cookie(
         self,
         key: str,
-        path: str | None = None,
+        path: str | None = "/",
         domain: str | None = None,
         secure: bool = False,
         httponly: bool = False,

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -117,6 +117,25 @@ def test_cookie_for_different_path():
     assert response.text == "test=test"
 
 
+def test_cookie_default_path() -> None:
+    """When no path is set for a cookie, the default uses everything up to but not
+    including the first slash.
+    """
+
+    @Request.application
+    def app(request: Request) -> Response:
+        r = Response()
+        r.set_cookie("k", "v", path=None)
+        return r
+
+    c = Client(app)
+    c.get("/nested/leaf")
+    assert c.get_cookie("k") is None
+    assert c.get_cookie("k", path="/nested") is not None
+    c.get("/nested/dir/")
+    assert c.get_cookie("k", path="/nested/dir") is not None
+
+
 def test_environ_builder_basics():
     b = EnvironBuilder()
     assert b.content_type is None

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -271,7 +271,7 @@ def test_base_response():
         ("Content-Type", "text/plain; charset=utf-8"),
         (
             "Set-Cookie",
-            "foo=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0",
+            "foo=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/",
         ),
     ]
 


### PR DESCRIPTION
Follow up to #2673 which missed most of the places this is set. :facepalm: Also adds the `default-path` behavior to the test client when storing cookies with no path.

fixes #2679 fixes #2672