### PR TITLE
update version to remove deprecations to 3.0

### DIFF
--- a/src/werkzeug/datastructures/auth.py
+++ b/src/werkzeug/datastructures/auth.py
@@ -150,10 +150,10 @@ def auth_property(name: str, doc: str | None = None) -> property:
             special_realm = auth_property('special_realm')
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4.
+        Will be removed in Werkzeug 3.0.
     """
     warnings.warn(
-        "'auth_property' is deprecated and will be removed in Werkzeug 2.4.",
+        "'auth_property' is deprecated and will be removed in Werkzeug 3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -202,7 +202,7 @@ class WWWAuthenticate:
         if auth_type is None:
             warnings.warn(
                 "An auth type must be given as the first parameter. Assuming 'basic' is"
-                " deprecated and will be removed in Werkzeug 2.4.",
+                " deprecated and will be removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -264,10 +264,10 @@ class WWWAuthenticate:
         """Clear any existing data and set a ``Basic`` challenge.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. Create and assign an instance instead.
+            Will be removed in Werkzeug 3.0. Create and assign an instance instead.
         """
         warnings.warn(
-            "The 'set_basic' method is deprecated and will be removed in Werkzeug 2.4."
+            "The 'set_basic' method is deprecated and will be removed in Werkzeug 3.0."
             " Create and assign an instance instead."
         )
         self._type = "basic"
@@ -291,10 +291,10 @@ class WWWAuthenticate:
         """Clear any existing data and set a ``Digest`` challenge.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. Create and assign an instance instead.
+            Will be removed in Werkzeug 3.0. Create and assign an instance instead.
         """
         warnings.warn(
-            "The 'set_digest' method is deprecated and will be removed in Werkzeug 2.4."
+            "The 'set_digest' method is deprecated and will be removed in Werkzeug 3.0."
             " Create and assign an instance instead."
         )
         self._type = "digest"
@@ -415,11 +415,11 @@ class WWWAuthenticate:
         """The ``qop`` parameter as a set.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. It will become the same as other
+            Will be removed in Werkzeug 3.0. It will become the same as other
             parameters, returning a string.
         """
         warnings.warn(
-            "The 'qop' property is deprecated and will be removed in Werkzeug 2.4."
+            "The 'qop' property is deprecated and will be removed in Werkzeug 3.0."
             " It will become the same as other parameters, returning a string.",
             DeprecationWarning,
             stacklevel=2,
@@ -441,11 +441,11 @@ class WWWAuthenticate:
         """The ``stale`` parameter as a boolean.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. It will become the same as other
+            Will be removed in Werkzeug 3.0. It will become the same as other
             parameters, returning a string.
         """
         warnings.warn(
-            "The 'stale' property is deprecated and will be removed in Werkzeug 2.4."
+            "The 'stale' property is deprecated and will be removed in Werkzeug 3.0."
             " It will become the same as other parameters, returning a string.",
             DeprecationWarning,
             stacklevel=2,
@@ -467,7 +467,7 @@ class WWWAuthenticate:
         if isinstance(value, bool):
             warnings.warn(
                 "Setting the 'stale' property to a boolean is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -483,7 +483,7 @@ def _deprecated_dict_method(f):  # type: ignore[no-untyped-def]
     def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
         warnings.warn(
             "Treating 'Authorization' and 'WWWAuthenticate' as a dict is deprecated and"
-            " will be removed in Werkzeug 2.4. Use the 'parameters' attribute instead.",
+            " will be removed in Werkzeug 3.0. Use the 'parameters' attribute instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/werkzeug/datastructures/headers.py
+++ b/src/werkzeug/datastructures/headers.py
@@ -103,7 +103,7 @@ class Headers:
 
         .. versionchanged:: 2.3
             The ``as_bytes`` parameter is deprecated and will be removed
-            in Werkzeug 2.4.
+            in Werkzeug 3.0.
 
         .. versionchanged:: 0.9
             The ``as_bytes`` parameter was added.
@@ -111,7 +111,7 @@ class Headers:
         if as_bytes is not None:
             warnings.warn(
                 "The 'as_bytes' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -143,7 +143,7 @@ class Headers:
 
         .. versionchanged:: 2.3
             The ``as_bytes`` parameter is deprecated and will be removed
-            in Werkzeug 2.4.
+            in Werkzeug 3.0.
 
         .. versionchanged:: 0.9
             The ``as_bytes`` parameter was added.
@@ -151,7 +151,7 @@ class Headers:
         if as_bytes is not None:
             warnings.warn(
                 "The 'as_bytes' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -480,7 +480,7 @@ def _str_header_key(key: t.Any) -> str:
     if not isinstance(key, str):
         warnings.warn(
             "Header keys must be strings. Passing other types is deprecated and will"
-            " not be supported in Werkzeug 2.4.",
+            " not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -500,7 +500,7 @@ def _str_header_value(value: t.Any) -> str:
     if isinstance(value, bytes):
         warnings.warn(
             "Passing bytes as a header value is deprecated and will not be supported in"
-            " Werkzeug 2.4.",
+            " Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -114,7 +114,7 @@ def parse_form_data(
 
     .. versionchanged:: 2.3
         The ``charset`` and ``errors`` parameters are deprecated and will be removed in
-        Werkzeug 2.4.
+        Werkzeug 3.0.
 
     .. versionadded:: 0.5.1
        Added the ``silent`` parameter.
@@ -162,11 +162,11 @@ class FormDataParser:
 
     .. versionchanged:: 2.3
         The ``charset`` and ``errors`` parameters are deprecated and will be removed in
-        Werkzeug 2.4.
+        Werkzeug 3.0.
 
     .. versionchanged:: 2.3
         The ``parse_functions`` attribute and ``get_parse_func`` methods are deprecated
-        and will be removed in Werkzeug 2.4.
+        and will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 2.2.3
         Added the ``max_form_parts`` parameter.
@@ -194,7 +194,7 @@ class FormDataParser:
         if charset is not None:
             warnings.warn(
                 "The 'charset' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -206,7 +206,7 @@ class FormDataParser:
         if errors is not None:
             warnings.warn(
                 "The 'errors' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -234,7 +234,7 @@ class FormDataParser:
     ):
         warnings.warn(
             "The 'get_parse_func' method is deprecated and will be"
-            " removed in Werkzeug 2.4.",
+            " removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -246,7 +246,7 @@ class FormDataParser:
         elif mimetype == "application/x-url-encoded":
             warnings.warn(
                 "The 'application/x-url-encoded' mimetype is invalid, and will not be"
-                " treated as 'application/x-www-form-urlencoded' in Werkzeug 2.4.",
+                " treated as 'application/x-www-form-urlencoded' in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -254,7 +254,7 @@ class FormDataParser:
         elif mimetype in self.parse_functions:
             warnings.warn(
                 "The 'parse_functions' attribute is deprecated and will be removed in"
-                " Werkzeug 2.4. Override 'parse' instead.",
+                " Werkzeug 3.0. Override 'parse' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -297,7 +297,7 @@ class FormDataParser:
 
         .. versionchanged:: 2.3
             The ``application/x-url-encoded`` content type is deprecated and will not be
-            treated as ``application/x-www-form-urlencoded`` in Werkzeug 2.4.
+            treated as ``application/x-www-form-urlencoded`` in Werkzeug 3.0.
         """
         if mimetype == "multipart/form-data":
             parse_func = self._parse_multipart
@@ -306,7 +306,7 @@ class FormDataParser:
         elif mimetype == "application/x-url-encoded":
             warnings.warn(
                 "The 'application/x-url-encoded' mimetype is invalid, and will not be"
-                " treated as 'application/x-www-form-urlencoded' in Werkzeug 2.4.",
+                " treated as 'application/x-www-form-urlencoded' in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -314,7 +314,7 @@ class FormDataParser:
         elif mimetype in self.parse_functions:
             warnings.warn(
                 "The 'parse_functions' attribute is deprecated and will be removed in"
-                " Werkzeug 2.4. Override 'parse' instead.",
+                " Werkzeug 3.0. Override 'parse' instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -407,7 +407,7 @@ class MultiPartParser:
         if charset is not None:
             warnings.warn(
                 "The 'charset' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -419,7 +419,7 @@ class MultiPartParser:
         if errors is not None:
             warnings.warn(
                 "The 'errors' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -153,16 +153,16 @@ def quote_header_value(
         The value is quoted if it is the empty string.
 
     .. versionchanged:: 2.3
-        Passing bytes is deprecated and will not be supported in Werkzeug 2.4.
+        Passing bytes is deprecated and will not be supported in Werkzeug 3.0.
 
     .. versionchanged:: 2.3
-        The ``extra_chars`` parameter is deprecated and will be removed in Werkzeug 2.4.
+        The ``extra_chars`` parameter is deprecated and will be removed in Werkzeug 3.0.
 
     .. versionadded:: 0.5
     """
     if isinstance(value, bytes):
         warnings.warn(
-            "Passing bytes is deprecated and will not be supported in Werkzeug 2.4.",
+            "Passing bytes is deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -171,7 +171,7 @@ def quote_header_value(
     if extra_chars is not None:
         warnings.warn(
             "The 'extra_chars' parameter is deprecated and will be"
-            " removed in Werkzeug 2.4.",
+            " removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -203,12 +203,12 @@ def unquote_header_value(value: str, is_filename: bool | None = None) -> str:
     :param value: The header value to unquote.
 
     .. versionchanged:: 2.3
-        The ``is_filename`` parameter is deprecated and will be removed in Werkzeug 2.4.
+        The ``is_filename`` parameter is deprecated and will be removed in Werkzeug 3.0.
     """
     if is_filename is not None:
         warnings.warn(
             "The 'is_filename' parameter is deprecated and will be"
-            " removed in Werkzeug 2.4.",
+            " removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -298,7 +298,7 @@ def dump_header(
     :param iterable: The items to create a header from.
 
     .. versionchanged:: 2.3
-        The ``allow_token`` parameter is deprecated and will be removed in Werkzeug 2.4.
+        The ``allow_token`` parameter is deprecated and will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 2.2.3
         If a key ends with ``*``, its value will not be quoted.
@@ -306,7 +306,7 @@ def dump_header(
     if allow_token is not None:
         warnings.warn(
             "'The 'allow_token' parameter is deprecated and will be"
-            " removed in Werkzeug 2.4.",
+            " removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -394,10 +394,10 @@ def parse_dict_header(value: str, cls: type[dict] | None = None) -> dict[str, st
         Added support for ``key*=charset''value`` encoded items.
 
     .. versionchanged:: 2.3
-        Passing bytes is deprecated, support will be removed in Werkzeug 2.4.
+        Passing bytes is deprecated, support will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 2.3
-        The ``cls`` argument is deprecated and will be removed in Werkzeug 2.4.
+        The ``cls`` argument is deprecated and will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 0.9
        The ``cls`` argument was added.
@@ -406,7 +406,7 @@ def parse_dict_header(value: str, cls: type[dict] | None = None) -> dict[str, st
         cls = dict
     else:
         warnings.warn(
-            "The 'cls' parameter is deprecated and will be removed in Werkzeug 2.4.",
+            "The 'cls' parameter is deprecated and will be removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -415,7 +415,7 @@ def parse_dict_header(value: str, cls: type[dict] | None = None) -> dict[str, st
 
     if isinstance(value, bytes):
         warnings.warn(
-            "Passing bytes is deprecated and will be removed in Werkzeug 2.4.",
+            "Passing bytes is deprecated and will be removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -823,7 +823,7 @@ def parse_authorization_header(
     :return: a :class:`~werkzeug.datastructures.Authorization` object or `None`.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use :meth:`.Authorization.from_header` instead.
+        Will be removed in Werkzeug 3.0. Use :meth:`.Authorization.from_header` instead.
     """
     from .datastructures import Authorization
 
@@ -850,7 +850,7 @@ def parse_www_authenticate_header(
     :return: a :class:`~werkzeug.datastructures.WWWAuthenticate` object.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use :meth:`.WWWAuthenticate.from_header`
+        Will be removed in Werkzeug 3.0. Use :meth:`.WWWAuthenticate.from_header`
         instead.
     """
     from .datastructures.auth import WWWAuthenticate
@@ -1298,7 +1298,7 @@ def parse_cookie(
 
     .. versionchanged:: 2.3
         Passing bytes, and the ``charset`` and ``errors`` parameters, are deprecated and
-        will be removed in Werkzeug 2.4.
+        will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 1.0
         Returns a :class:`MultiDict` instead of a ``TypeConversionDict``.
@@ -1311,7 +1311,7 @@ def parse_cookie(
         cookie = header.get("HTTP_COOKIE")
     elif isinstance(header, bytes):
         warnings.warn(
-            "Passing bytes is deprecated and will not be supported in Werkzeug 2.4.",
+            "Passing bytes is deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1403,7 +1403,7 @@ def dump_cookie(
 
     .. versionchanged:: 2.3
         Passing bytes, and the ``charset`` parameter, are deprecated and will be removed
-        in Werkzeug 2.4.
+        in Werkzeug 3.0.
 
     .. versionchanged:: 1.0.0
         The string ``'None'`` is accepted for ``samesite``.
@@ -1411,7 +1411,7 @@ def dump_cookie(
     if charset is not None:
         warnings.warn(
             "The 'charset' parameter is deprecated and will be removed"
-            " in Werkzeug 2.4.",
+            " in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1421,7 +1421,7 @@ def dump_cookie(
     if isinstance(key, bytes):
         warnings.warn(
             "The 'key' parameter must be a string. Bytes are deprecated"
-            " and will not be supported in Werkzeug 2.4.",
+            " and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1430,7 +1430,7 @@ def dump_cookie(
     if isinstance(value, bytes):
         warnings.warn(
             "The 'value' parameter must be a string. Bytes are"
-            " deprecated and will not be supported in Werkzeug 2.4.",
+            " deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -45,7 +45,7 @@ class BaseConverter:
         if isinstance(value, (bytes, bytearray)):
             warnings.warn(
                 "Passing bytes as a URL value is deprecated and will not be supported"
-                " in Werkzeug 2.4.",
+                " in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=7,
             )

--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -70,7 +70,7 @@ class Map:
 
     .. versionchanged:: 2.3
         The ``charset`` and ``encoding_errors`` parameters are deprecated and will be
-        removed in Werkzeug 2.4.
+        removed in Werkzeug 3.0.
 
     .. versionchanged:: 1.0
         If ``url_scheme`` is ``ws`` or ``wss``, only WebSocket rules will match.
@@ -117,7 +117,7 @@ class Map:
         if charset is not None:
             warnings.warn(
                 "The 'charset' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -129,7 +129,7 @@ class Map:
         if encoding_errors is not None:
             warnings.warn(
                 "The 'encoding_errors' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4.",
+                " removed in Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/werkzeug/sansio/http.py
+++ b/src/werkzeug/sansio/http.py
@@ -140,7 +140,7 @@ def parse_cookie(
 
     .. versionchanged:: 2.3
         Passing bytes, and the ``charset`` and ``errors`` parameters, are deprecated and
-        will be removed in Werkzeug 2.4.
+        will be removed in Werkzeug 3.0.
 
     .. versionadded:: 2.2
     """
@@ -150,7 +150,7 @@ def parse_cookie(
     if isinstance(cookie, bytes):
         warnings.warn(
             "The 'cookie' parameter must be a string. Passing bytes is deprecated and"
-            " will not be supported in Werkzeug 2.4.",
+            " will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -158,7 +158,7 @@ def parse_cookie(
 
     if charset is not None:
         warnings.warn(
-            "The 'charset' parameter is deprecated and will be removed in Werkzeug 2.4",
+            "The 'charset' parameter is deprecated and will be removed in Werkzeug 3.0",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -167,7 +167,7 @@ def parse_cookie(
 
     if errors is not None:
         warnings.warn(
-            "The 'errors' parameter is deprecated and will be removed in Werkzeug 2.4",
+            "The 'errors' parameter is deprecated and will be removed in Werkzeug 3.0",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -69,7 +69,7 @@ class Request:
         """The charset used to decode body, form, and cookie data. Defaults to UTF-8.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. Request data must always be UTF-8.
+            Will be removed in Werkzeug 3.0. Request data must always be UTF-8.
         """
         warnings.warn(
             "The 'charset' attribute is deprecated and will not be used in Werkzeug"
@@ -98,11 +98,11 @@ class Request:
         """How errors when decoding bytes are handled. Defaults to "replace".
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4.
+            Will be removed in Werkzeug 3.0.
         """
         warnings.warn(
             "The 'encoding_errors' attribute is deprecated and will not be used in"
-            " Werkzeug 2.4.",
+            " Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -112,7 +112,7 @@ class Request:
     def encoding_errors(self, value: str) -> None:
         warnings.warn(
             "The 'encoding_errors' attribute is deprecated and will not be used in"
-            " Werkzeug 2.4.",
+            " Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -126,13 +126,13 @@ class Request:
         Defaults to the value of :attr:`charset`, which defaults to UTF-8.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. Percent-encoded bytes must always be UTF-8.
+            Will be removed in Werkzeug 3.0. Percent-encoded bytes must always be UTF-8.
 
         .. versionadded:: 0.6
         """
         warnings.warn(
             "The 'url_charset' attribute is deprecated and will not be used in"
-            " Werkzeug 2.4. Percent-encoded bytes must always be UTF-8.",
+            " Werkzeug 3.0. Percent-encoded bytes must always be UTF-8.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -142,7 +142,7 @@ class Request:
     def url_charset(self, value: str) -> None:
         warnings.warn(
             "The 'url_charset' attribute is deprecated and will not be used in"
-            " Werkzeug 2.4. Percent-encoded bytes must always be UTF-8.",
+            " Werkzeug 3.0. Percent-encoded bytes must always be UTF-8.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -224,7 +224,7 @@ class Request:
         if not isinstance(type(self).encoding_errors, property):
             warnings.warn(
                 "The 'encoding_errors' attribute is deprecated and will not be used in"
-                " Werkzeug 2.4.",
+                " Werkzeug 3.0.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -235,7 +235,7 @@ class Request:
         if not isinstance(type(self).url_charset, property):
             warnings.warn(
                 "The 'url_charset' attribute is deprecated and will not be used in"
-                " Werkzeug 2.4. Percent-encoded bytes must always be UTF-8.",
+                " Werkzeug 3.0. Percent-encoded bytes must always be UTF-8.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -91,7 +91,7 @@ class Response:
         """The charset used to encode body and cookie data. Defaults to UTF-8.
 
         .. deprecated:: 2.3
-            Will be removed in Werkzeug 2.4. Response data must always be UTF-8.
+            Will be removed in Werkzeug 3.0. Response data must always be UTF-8.
         """
         warnings.warn(
             "The 'charset' attribute is deprecated and will not be used in Werkzeug"

--- a/src/werkzeug/security.py
+++ b/src/werkzeug/security.py
@@ -27,7 +27,7 @@ def _hash_internal(method: str, salt: str, password: str) -> tuple[str, str]:
     if method == "plain":
         warnings.warn(
             "The 'plain' password method is deprecated and will be removed in"
-            " Werkzeug 2.4. Migrate to the 'scrypt' method.",
+            " Werkzeug 3.0. Migrate to the 'scrypt' method.",
             stacklevel=3,
         )
         return password, method
@@ -74,7 +74,7 @@ def _hash_internal(method: str, salt: str, password: str) -> tuple[str, str]:
     else:
         warnings.warn(
             f"The '{method}' password method is deprecated and will be removed in"
-            " Werkzeug 2.4. Migrate to the 'scrypt' method.",
+            " Werkzeug 3.0. Migrate to the 'scrypt' method.",
             stacklevel=3,
         )
         return hmac.new(salt, password, method).hexdigest(), method
@@ -110,7 +110,7 @@ def generate_password_hash(
         The default iterations for pbkdf2 was increased to 600,000.
 
     .. versionchanged:: 2.3
-        All plain hashes are deprecated and will not be supported in Werkzeug 2.4.
+        All plain hashes are deprecated and will not be supported in Werkzeug 3.0.
     """
     salt = gen_salt(salt_length)
     h, actual_method = _hash_internal(method, salt, password)
@@ -129,7 +129,7 @@ def check_password_hash(pwhash: str, password: str) -> bool:
     :param password: The plaintext password.
 
     .. versionchanged:: 2.3
-        All plain hashes are deprecated and will not be supported in Werkzeug 2.4.
+        All plain hashes are deprecated and will not be supported in Werkzeug 3.0.
     """
     try:
         method, salt, hashval = pwhash.split("$", 2)

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -65,11 +65,11 @@ def stream_encode_multipart(
     in a file descriptor.
 
     .. versionchanged:: 2.3
-        The ``charset`` parameter is deprecated and will be removed in Werkzeug 2.4
+        The ``charset`` parameter is deprecated and will be removed in Werkzeug 3.0
     """
     if charset is not None:
         warnings.warn(
-            "The 'charset' parameter is deprecated and will be removed in Werkzeug 2.4",
+            "The 'charset' parameter is deprecated and will be removed in Werkzeug 3.0",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -163,7 +163,7 @@ def encode_multipart(
     (``boundary``, ``data``) where data is bytes.
 
     .. versionchanged:: 2.3
-        The ``charset`` parameter is deprecated and will be removed in Werkzeug 2.4
+        The ``charset`` parameter is deprecated and will be removed in Werkzeug 3.0
     """
     stream, length, boundary = stream_encode_multipart(
         values, use_tempfile=False, boundary=boundary, charset=charset
@@ -259,7 +259,7 @@ class EnvironBuilder:
         is a shortcut for ``Basic`` authorization.
 
     .. versionchanged:: 2.3
-        The ``charset`` parameter is deprecated and will be removed in Werkzeug 2.4
+        The ``charset`` parameter is deprecated and will be removed in Werkzeug 3.0
 
     .. versionchanged:: 2.1
         ``CONTENT_TYPE`` and ``CONTENT_LENGTH`` are not duplicated as
@@ -342,7 +342,7 @@ class EnvironBuilder:
         if charset is not None:
             warnings.warn(
                 "The 'charset' parameter is deprecated and will be"
-                " removed in Werkzeug 2.4",
+                " removed in Werkzeug 3.0",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -860,7 +860,7 @@ class Client:
     def cookie_jar(self) -> t.Iterable[Cookie] | None:
         warnings.warn(
             "The 'cookie_jar' attribute is a private API and will be removed in"
-            " Werkzeug 2.4. Use the 'get_cookie' method instead.",
+            " Werkzeug 3.0. Use the 'get_cookie' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -927,7 +927,7 @@ class Client:
 
         .. versionchanged:: 2.3
             The first parameter ``server_name`` is deprecated and will be removed in
-            Werkzeug 2.4. The first parameter is ``key``. Use the ``domain`` and
+            Werkzeug 3.0. The first parameter is ``key``. Use the ``domain`` and
             ``origin_only`` parameters instead.
         """
         if self._cookies is None:
@@ -938,7 +938,7 @@ class Client:
         if args:
             warnings.warn(
                 "The first parameter 'server_name' is no longer used, and will be"
-                " removed in Werkzeug 2.4. The positional parameters are 'key' and"
+                " removed in Werkzeug 3.0. The positional parameters are 'key' and"
                 " 'value'. Use the 'domain' and 'origin_only' parameters instead.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -977,7 +977,7 @@ class Client:
 
         .. versionchanged:: 2.3
             The first parameter ``server_name`` is deprecated and will be removed in
-            Werkzeug 2.4. The first parameter is ``key``. Use the ``domain`` parameter
+            Werkzeug 3.0. The first parameter is ``key``. Use the ``domain`` parameter
             instead.
 
         .. versionchanged:: 2.3

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -59,7 +59,7 @@ class BaseURL(_URLTuple):
     """Superclass of :py:class:`URL` and :py:class:`BytesURL`.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use the ``urllib.parse`` library instead.
+        Will be removed in Werkzeug 3.0. Use the ``urllib.parse`` library instead.
     """
 
     __slots__ = ()
@@ -71,7 +71,7 @@ class BaseURL(_URLTuple):
     def __new__(cls, *args: t.Any, **kwargs: t.Any) -> BaseURL:
         warnings.warn(
             f"'werkzeug.urls.{cls.__name__}' is deprecated and will be removed in"
-            " Werkzeug 2.4. Use the 'urllib.parse' library instead.",
+            " Werkzeug 3.0. Use the 'urllib.parse' library instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -358,7 +358,7 @@ class URL(BaseURL):
     URL.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use the ``urllib.parse`` library instead.
+        Will be removed in Werkzeug 3.0. Use the ``urllib.parse`` library instead.
     """
 
     __slots__ = ()
@@ -384,7 +384,7 @@ class BytesURL(BaseURL):
     """Represents a parsed URL in bytes.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use the ``urllib.parse`` library instead.
+        Will be removed in Werkzeug 3.0. Use the ``urllib.parse`` library instead.
     """
 
     __slots__ = ()
@@ -500,10 +500,10 @@ def url_parse(
                             from the URL.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.urlsplit`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.urlsplit`` instead.
     """
     warnings.warn(
-        "'werkzeug.urls.url_parse' is deprecated and will be removed in Werkzeug 2.4."
+        "'werkzeug.urls.url_parse' is deprecated and will be removed in Werkzeug 3.0."
         " Use 'urllib.parse.urlsplit' instead.",
         DeprecationWarning,
         stacklevel=2,
@@ -599,13 +599,13 @@ def url_quote(
     :param unsafe: an optional sequence of unsafe characters.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.quote`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.quote`` instead.
 
     .. versionadded:: 0.9.2
        The `unsafe` parameter was added.
     """
     warnings.warn(
-        "'werkzeug.urls.url_quote' is deprecated and will be removed in Werkzeug 2.4."
+        "'werkzeug.urls.url_quote' is deprecated and will be removed in Werkzeug 3.0."
         " Use 'urllib.parse.quote' instead.",
         DeprecationWarning,
         stacklevel=2,
@@ -640,7 +640,7 @@ def url_quote_plus(
     :param safe: An optional sequence of safe characters.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.quote_plus`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.quote_plus`` instead.
     """
     warnings.warn(
         "'werkzeug.urls.url_quote_plus' is deprecated and will be removed in Werkzeug"
@@ -660,10 +660,10 @@ def url_unparse(components: tuple[str, str, str, str, str]) -> str:
                        into a URL string.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.urlunsplit`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.urlunsplit`` instead.
     """
     warnings.warn(
-        "'werkzeug.urls.url_unparse' is deprecated and will be removed in Werkzeug 2.4."
+        "'werkzeug.urls.url_unparse' is deprecated and will be removed in Werkzeug 3.0."
         " Use 'urllib.parse.urlunsplit' instead.",
         DeprecationWarning,
         stacklevel=2,
@@ -708,10 +708,10 @@ def url_unquote(
     :param errors: the error handling for the charset decoding.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.unquote`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.unquote`` instead.
     """
     warnings.warn(
-        "'werkzeug.urls.url_unquote' is deprecated and will be removed in Werkzeug 2.4."
+        "'werkzeug.urls.url_unquote' is deprecated and will be removed in Werkzeug 3.0."
         " Use 'urllib.parse.unquote' instead.",
         DeprecationWarning,
         stacklevel=2,
@@ -737,7 +737,7 @@ def url_unquote_plus(
     :param errors: The error handling for the `charset` decoding.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.unquote_plus`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.unquote_plus`` instead.
     """
     warnings.warn(
         "'werkzeug.urls.url_unquote_plus' is deprecated and will be removed in Werkzeug"
@@ -768,10 +768,10 @@ def url_fix(s: str, charset: str = "utf-8") -> str:
         as a string.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4.
+        Will be removed in Werkzeug 3.0.
     """
     warnings.warn(
-        "'werkzeug.urls.url_fix' is deprecated and will be removed in Werkzeug 2.4.",
+        "'werkzeug.urls.url_fix' is deprecated and will be removed in Werkzeug 3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -856,7 +856,7 @@ def uri_to_iri(
 
     .. versionchanged:: 2.3
         Passing a tuple or bytes, and the ``charset`` and ``errors`` parameters, are
-        deprecated and will be removed in Werkzeug 2.4.
+        deprecated and will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 2.3
         Which characters remain quoted is specific to each part of the URL.
@@ -870,7 +870,7 @@ def uri_to_iri(
     """
     if isinstance(uri, tuple):
         warnings.warn(
-            "Passing a tuple is deprecated and will not be supported in Werkzeug 2.4.",
+            "Passing a tuple is deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -878,7 +878,7 @@ def uri_to_iri(
 
     if isinstance(uri, bytes):
         warnings.warn(
-            "Passing bytes is deprecated and will not be supported in Werkzeug 2.4.",
+            "Passing bytes is deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -887,7 +887,7 @@ def uri_to_iri(
     if charset is not None:
         warnings.warn(
             "The 'charset' parameter is deprecated and will be removed"
-            " in Werkzeug 2.4.",
+            " in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -896,7 +896,7 @@ def uri_to_iri(
 
     if errors is not None:
         warnings.warn(
-            "The 'errors' parameter is deprecated and will be removed in Werkzeug 2.4.",
+            "The 'errors' parameter is deprecated and will be removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -948,7 +948,7 @@ def iri_to_uri(
 
     .. versionchanged:: 2.3
         Passing a tuple or bytes, and the ``charset`` and ``errors`` parameters, are
-        deprecated and will be removed in Werkzeug 2.4.
+        deprecated and will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 2.3
         Which characters remain unquoted is specific to each part of the URL.
@@ -968,7 +968,7 @@ def iri_to_uri(
     """
     if isinstance(iri, tuple):
         warnings.warn(
-            "Passing a tuple is deprecated and will not be supported in Werkzeug 2.4.",
+            "Passing a tuple is deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -976,7 +976,7 @@ def iri_to_uri(
 
     if isinstance(iri, bytes):
         warnings.warn(
-            "Passing bytes is deprecated and will not be supported in Werkzeug 2.4.",
+            "Passing bytes is deprecated and will not be supported in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -985,7 +985,7 @@ def iri_to_uri(
     if charset is not None:
         warnings.warn(
             "The 'charset' parameter is deprecated and will be removed"
-            " in Werkzeug 2.4.",
+            " in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -994,7 +994,7 @@ def iri_to_uri(
 
     if errors is not None:
         warnings.warn(
-            "The 'errors' parameter is deprecated and will be removed in Werkzeug 2.4.",
+            "The 'errors' parameter is deprecated and will be removed in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1004,7 +1004,7 @@ def iri_to_uri(
     if safe_conversion is not None:
         warnings.warn(
             "The 'safe_conversion' parameter is deprecated and will be removed in"
-            " Werkzeug 2.4.",
+            " Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1058,7 +1058,7 @@ def _invalid_iri_to_uri(iri: str) -> str:
     not have a host component. There may be other invalid schemes as well. Currently,
     responses will always call ``iri_to_uri`` on the redirect ``Location`` header, which
     removes the ``//``. For now, if the IRI only contains ASCII and does not contain
-    spaces, pass it on as-is. In Werkzeug 2.4, this should become a
+    spaces, pass it on as-is. In Werkzeug 3.0, this should become a
     ``response.process_location`` flag.
 
     :meta private:
@@ -1093,7 +1093,7 @@ def url_decode(
     :param cls: Container to hold result instead of :class:`MultiDict`.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4. Use ``urllib.parse.parse_qs`` instead.
+        Will be removed in Werkzeug 3.0. Use ``urllib.parse.parse_qs`` instead.
 
     .. versionchanged:: 2.1
         The ``decode_keys`` parameter was removed.

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -211,14 +211,14 @@ def get_path_info(
 
     .. versionchanged:: 2.3
         The ``charset`` and ``errors`` parameters are deprecated and will be removed in
-        Werkzeug 2.4.
+        Werkzeug 3.0.
 
     .. versionadded:: 0.9
     """
     if charset is not ...:
         warnings.warn(
             "The 'charset' parameter is deprecated and will be removed"
-            " in Werkzeug 2.4.",
+            " in Werkzeug 3.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -230,7 +230,7 @@ def get_path_info(
 
     if errors is not None:
         warnings.warn(
-            "The 'errors' parameter is deprecated and will be removed in Werkzeug 2.4",
+            "The 'errors' parameter is deprecated and will be removed in Werkzeug 3.0",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -462,7 +462,7 @@ def _make_chunk_iter(
 ) -> t.Iterator[bytes]:
     """Helper for the line and chunk iter functions."""
     warnings.warn(
-        "'_make_chunk_iter' is deprecated and will be removed in Werkzeug 2.4.",
+        "'_make_chunk_iter' is deprecated and will be removed in Werkzeug 3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -506,7 +506,7 @@ def make_line_iter(
     over the input stream using this helper function.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4.
+        Will be removed in Werkzeug 3.0.
 
     .. versionadded:: 0.11
        added support for the `cap_at_buffer` parameter.
@@ -528,7 +528,7 @@ def make_line_iter(
                           of two however.
     """
     warnings.warn(
-        "'make_line_iter' is deprecated and will be removed in Werkzeug 2.4.",
+        "'make_line_iter' is deprecated and will be removed in Werkzeug 3.0.",
         DeprecationWarning,
         stacklevel=2,
     )
@@ -601,7 +601,7 @@ def make_chunk_iter(
     supports arbitrary newline markers.
 
     .. deprecated:: 2.3
-        Will be removed in Werkzeug 2.4.
+        Will be removed in Werkzeug 3.0.
 
     .. versionchanged:: 0.11
        added support for the `cap_at_buffer` parameter.
@@ -623,7 +623,7 @@ def make_chunk_iter(
                           of two however.
     """
     warnings.warn(
-        "'make_chunk_iter' is deprecated and will be removed in Werkzeug 2.4.",
+        "'make_chunk_iter' is deprecated and will be removed in Werkzeug 3.0.",
         DeprecationWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
Removing `urls`, bytes compat, and using UTF-8 only is a significant enough set of changes that a 3.0 milestone version feels appropriate. The next feature release will be 3.0 instead of 2.4.