### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -65,8 +65,8 @@ jobs:
       # Try uploading to Test PyPI first, in case something fails.
       - uses: pypa/gh-action-pypi-publish@29930c9cf57955dc1b98162d0d8bc3ec80d9e75c
         with:
-          repository_url: https://test.pypi.org/legacy/
-          packages_dir: artifact/
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: artifact/
       - uses: pypa/gh-action-pypi-publish@29930c9cf57955dc1b98162d0d8bc3ec80d9e75c
         with:
-          packages_dir: artifact/
+          packages-dir: artifact/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,11 +40,6 @@ jobs:
           python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: 'requirements/*.txt'
-      - name: update pip
-        run: |
-          pip install -U wheel
-          pip install -U setuptools
-          python -m pip install -U pip
       - name: cache mypy
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:


### PR DESCRIPTION
* Update `pypa/gh-action-pypi-publish` parameter names.
* Remove "update pip, setuptools, wheel" step, it's not really doing anything since we use tox+virtualenv.

`setup-python` has some nice features for managing multiple versions and prereleases now, but I couldn't quite figure out how to use it for us. Maybe in the future.