### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 2.3.5
 
 Unreleased
 
+-   Python 3.12 compatibility. :issue:`2704`
+
 
 Version 2.3.4
 -------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ version = {attr = "werkzeug.__version__"}
 testpaths = ["tests"]
 filterwarnings = [
     "error",
-    # change in Python 3.12 alpha causes warning from inside pytest
-    "ignore:onerror argument:DeprecationWarning",
+    # change in Python 3.12 beta causes warning from inside pytest
+    "ignore:ast:DeprecationWarning",
 ]
 markers = ["dev_server: tests that start the dev server"]
 

--- a/src/werkzeug/datastructures/auth.py
+++ b/src/werkzeug/datastructures/auth.py
@@ -393,7 +393,7 @@ class WWWAuthenticate:
             items = []
 
             for key, value in self.parameters.items():
-                if key in {"realm", "domain", "nonce", "opaque", "realm", "qop"}:
+                if key in {"realm", "domain", "nonce", "opaque", "qop"}:
                     value = quote_header_value(value, allow_token=False)
                 else:
                     value = quote_header_value(value)

--- a/src/werkzeug/middleware/shared_data.py
+++ b/src/werkzeug/middleware/shared_data.py
@@ -10,9 +10,9 @@ Serve Shared Static Files
 """
 from __future__ import annotations
 
+import importlib.util
 import mimetypes
 import os
-import pkgutil
 import posixpath
 import typing as t
 from datetime import datetime
@@ -158,8 +158,8 @@ class SharedDataMiddleware:
 
     def get_package_loader(self, package: str, package_path: str) -> _TLoader:
         load_time = datetime.now(timezone.utc)
-        provider = pkgutil.get_loader(package)
-        reader = provider.get_resource_reader(package)  # type: ignore
+        spec = importlib.util.find_spec(package)
+        reader = spec.loader.get_resource_reader(package)  # type: ignore[union-attr]
 
         def loader(
             path: str | None,

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -754,15 +754,15 @@ class Rule(RuleFactory):
 
         def _parts(ops: list[tuple[bool, str]]) -> list[ast.AST]:
             parts = [
-                _convert(elem) if is_dynamic else ast.Str(s=elem)
+                _convert(elem) if is_dynamic else ast.Constant(elem)
                 for is_dynamic, elem in ops
             ]
-            parts = parts or [ast.Str("")]
+            parts = parts or [ast.Constant("")]
             # constant fold
             ret = [parts[0]]
             for p in parts[1:]:
-                if isinstance(p, ast.Str) and isinstance(ret[-1], ast.Str):
-                    ret[-1] = ast.Str(ret[-1].s + p.s)
+                if isinstance(p, ast.Constant) and isinstance(ret[-1], ast.Constant):
+                    ret[-1] = ast.Constant(ret[-1].value + p.value)
                 else:
                     ret.append(p)
             return ret
@@ -798,7 +798,7 @@ class Rule(RuleFactory):
             func_ast.args.args.append(ast.arg(arg, None))
         func_ast.args.kwarg = ast.arg(".kwargs", None)
         for _ in kargs:
-            func_ast.args.defaults.append(ast.Str(""))
+            func_ast.args.defaults.append(ast.Constant(""))
         func_ast.body = body
 
         # Use `ast.parse` instead of `ast.Module` for better portability, since the

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -586,7 +586,8 @@ def test_server_name_interpolation():
 
     with pytest.warns(UserWarning):
         adapter = map.bind_to_environ(env, server_name="foo")
-        assert adapter.subdomain == "<invalid>"
+
+    assert adapter.subdomain == "<invalid>"
 
 
 def test_rule_emptying():
@@ -959,8 +960,7 @@ def test_build_drop_none():
     adapter = map.bind("", "/")
     params = {"flub": None, "flop": None}
     with pytest.raises(r.BuildError):
-        x = adapter.build("endp", params)
-        assert not x
+        adapter.build("endp", params)
     params = {"flub": "x", "flop": None}
     url = adapter.build("endp", params)
     assert "flop" not in url
@@ -1041,7 +1041,8 @@ def test_external_building_with_port_bind_to_environ_wrong_servername():
 
     with pytest.warns(UserWarning):
         adapter = map.bind_to_environ(environ, server_name="example.org")
-        assert adapter.subdomain == "<invalid>"
+
+    assert adapter.subdomain == "<invalid>"
 
 
 def test_converter_parser():
@@ -1495,8 +1496,7 @@ def test_strict_slashes_false():
 
 def test_invalid_rule():
     with pytest.raises(ValueError):
-        map_ = r.Map([r.Rule("/<int()>", endpoint="test")])
-        map_.bind("localhost")
+        r.Map([r.Rule("/<int()>", endpoint="test")])
 
 
 def test_multiple_converters_per_part():


### PR DESCRIPTION
* `ast.Constant` should be used instead of `ast.Str`. pytest raises some of these warnings in its internals, ignore that.
* An AST node's `value` attributes should be used instead of `s`.
* `importlib.util.find_spec().loader` should be used instead of `pkgutil.find_loader`.

fixes #2704 