### PR TITLE
debugger escapes title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   Python 3.12 compatibility. :issue:`2704`
 -   Fix handling of invalid base64 values in ``Authorization.from_header``. :issue:`2717`
+-   The debugger escapes the exception message in the page title. :pr:`2719`
 
 
 Version 2.3.4

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -327,7 +327,7 @@ class DebugTraceback:
             "evalex": "true" if evalex else "false",
             "evalex_trusted": "true" if evalex_trusted else "false",
             "console": "false",
-            "title": exc_lines[0],
+            "title": escape(exc_lines[0]),
             "exception": escape("".join(exc_lines)),
             "exception_type": escape(self._te.exc_type.__name__),
             "summary": self.render_traceback_html(include_title=False),


### PR DESCRIPTION
The debugger will render the exception's error message as the page title. This should be escaped so HTML characters in the message don't interfere. Note that the development server and debugger are never intended for production.