### PR TITLE
`Map.bind` ignores port for IDNA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Python 3.12 compatibility. :issue:`2704`
 -   Fix handling of invalid base64 values in ``Authorization.from_header``. :issue:`2717`
 -   The debugger escapes the exception message in the page title. :pr:`2719`
+-   When binding ``routing.Map``, a long IDNA ``server_name`` with a port does not fail
+    encoding. :issue:`2700`
 
 
 Version 2.3.4

--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -251,6 +251,9 @@ class Map:
         if path_info is None:
             path_info = "/"
 
+        # Port isn't part of IDNA, and might push a name over the 63 octet limit.
+        server_name, port_sep, port = server_name.partition(":")
+
         try:
             server_name = server_name.encode("idna").decode("ascii")
         except UnicodeError as e:
@@ -258,7 +261,7 @@ class Map:
 
         return MapAdapter(
             self,
-            server_name,
+            f"{server_name}{port_sep}{port}",
             script_name,
             subdomain,
             url_scheme,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1045,6 +1045,14 @@ def test_external_building_with_port_bind_to_environ_wrong_servername():
     assert adapter.subdomain == "<invalid>"
 
 
+def test_bind_long_idna_name_with_port():
+    map = r.Map([r.Rule("/", endpoint="index")])
+    adapter = map.bind("🐍" + "a" * 52 + ":8443")
+    name, _, port = adapter.server_name.partition(":")
+    assert len(name) == 63
+    assert port == "8443"
+
+
 def test_converter_parser():
     args, kwargs = r.parse_converter_args("test, a=1, b=3.0")
 


### PR DESCRIPTION
When calling `Map.bind`, the `server_name` will be IDNA-encoded (for convenience when binding to a developer-provided value, rather than the `Host` header). However, the value can contain a port, which should not be counted towards the length of the name when passing through IDNA.