### PR TITLE
`FileStorage.content_length` does not fail if no length was provided

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 2.3.6
 
 Unreleased
 
+-   ``FileStorage.content_length`` does not fail if the form data did not provide a
+    value. :issue:`2726`
+
 
 Version 2.3.5
 -------------

--- a/src/werkzeug/datastructures/file_storage.py
+++ b/src/werkzeug/datastructures/file_storage.py
@@ -67,10 +67,13 @@ class FileStorage:
     @property
     def content_length(self):
         """The content-length sent in the header.  Usually not available"""
-        try:
-            return _plain_int(self.headers.get("content-length") or 0)
-        except ValueError:
-            return 0
+        if "content-length" in self.headers:
+            try:
+                return _plain_int(self.headers["content-length"])
+            except ValueError:
+                pass
+
+        return 0
 
     @property
     def mimetype(self):


### PR DESCRIPTION
fixes #2726 