### PR TITLE
Expand variables button scrolls to page header

### DIFF
--- a/src/werkzeug/debug/shared/debugger.js
+++ b/src/werkzeug/debug/shared/debugger.js
@@ -305,7 +305,8 @@ function handleConsoleSubmit(e, command, frameID) {
           wrapperSpan.append(spanToWrap);
           spanToWrap.hidden = true;
 
-          expansionButton.addEventListener("click", () => {
+          expansionButton.addEventListener("click", (event) => {
+            event.preventDefault();
             spanToWrap.hidden = !spanToWrap.hidden;
             expansionButton.classList.toggle("open");
             return false;


### PR DESCRIPTION
Expansion button is rendered as `<a href="#"`, which scrolls to page header.

To prevent scroll, `event.preventDefault` should be called or expansion should be changed something else (e.g. `button`).
