### PR TITLE
Allow empty stream file upload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 2.3.7
 Unreleased
 
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Fix ``stream_encode_multipart`` from raising ValueError exception when handling
+    empty binary file. :issue:`2740`
 
 
 Version 2.3.6

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -38,6 +38,7 @@ from .sansio.multipart import Field
 from .sansio.multipart import File
 from .sansio.multipart import MultipartEncoder
 from .sansio.multipart import Preamble
+from .sansio.multipart import State
 from .urls import _urlencode
 from .urls import iri_to_uri
 from .utils import cached_property
@@ -135,7 +136,7 @@ def stream_encode_multipart(
             while True:
                 chunk = reader(16384)
 
-                if not chunk:
+                if not chunk and encoder.state != State.DATA_START:
                     break
 
                 write_binary(encoder.send_event(Data(data=chunk, more_data=True)))

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -357,6 +357,23 @@ def test_environ_builder_unicode_file_mix():
         files["f"].close()
 
 
+def test_environ_builder_empty_file():
+    f = FileStorage(BytesIO(rb""), "empty.txt")
+    d = MultiDict(dict(f=f, s=""))
+    stream, length, boundary = stream_encode_multipart(d)
+    _, form, files = parse_form_data(
+        {
+            "wsgi.input": stream,
+            "CONTENT_LENGTH": str(length),
+            "CONTENT_TYPE": f'multipart/form-data; boundary="{boundary}"',
+        }
+    )
+    assert form["s"] == ""
+    assert files["f"].read() == rb""
+    stream.close()
+    files["f"].close()
+
+
 def test_create_environ():
     env = create_environ("/foo?bar=baz", "http://example.org/")
     expected = {

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -426,7 +426,7 @@ def test_file_closing():
 
     class SpecialInput:
         def read(self, size):
-            return ""
+            return b""
 
         def close(self):
             closed.append(self)


### PR DESCRIPTION
<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

This PR fixes `stream_encode_multipart` from raising `ValueError`-exception when processing an empty content binary file.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #2740

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
