### PR TITLE
Replaced arrows with css styled underline

### DIFF
--- a/src/werkzeug/debug/shared/style.css
+++ b/src/werkzeug/debug/shared/style.css
@@ -35,6 +35,9 @@ div.traceback ul { list-style: none; margin: 0; padding: 0 0 0 1em; }
 div.traceback h4 { font-size: 13px; font-weight: normal; margin: 0.7em 0 0.1em 0; }
 div.traceback pre { margin: 0; padding: 5px 0 3px 15px;
                     background-color: #E8EFF0; border: 1px solid #D3E7E9; }
+div.traceback span.error { text-decoration: underline;
+                           text-decoration-style: wavy;
+                           text-decoration-color: red; }
 div.traceback .library .current { background: white; color: #555; }
 div.traceback .expanded .current { background: #E8EFF0; color: black; }
 div.traceback pre:hover { background-color: #DDECEE; color: black; cursor: pointer; }

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -396,6 +396,8 @@ class DebugFrameSummary(traceback.FrameSummary):
             # calculate offset with expanded tabs
             colno = len(original_line[:colno].expandtabs())
             end_colno = len(original_line[:end_colno].expandtabs())
+            if not line.strip():
+                line = line + ' ' # always render empty line
 
             highlight_error = False
             # split line to separatly escaped parts

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -9,7 +9,8 @@ import sysconfig
 import traceback
 import typing as t
 
-from markupsafe import escape, Markup
+from markupsafe import escape
+from markupsafe import Markup
 
 from ..utils import cached_property
 from .console import Console
@@ -397,7 +398,7 @@ class DebugFrameSummary(traceback.FrameSummary):
             colno = len(original_line[:colno].expandtabs())
             end_colno = len(original_line[:end_colno].expandtabs())
             if not line.strip():
-                line = line + ' ' # always render empty line
+                line = line + " "  # always render empty line
 
             highlight_error = False
             # split line to separatly escaped parts
@@ -410,7 +411,7 @@ class DebugFrameSummary(traceback.FrameSummary):
             previous_point = 0
             in_error = False
             in_ws = True
-            line_parts = ['', Markup('<span class="ws">')]
+            line_parts = ["", Markup('<span class="ws">')]
             for point in line_split_points:
                 line_parts.append(line[previous_point:point])
                 previous_point = point


### PR DESCRIPTION
This is more of a question than a finished patch.

I think that HTML underline is easier to visually recognize than arrows. In addition, traceback without additional lines is more compact.

This patch adds HTML markup ``<span class="error">``. It's pretty complicated because HTML tags needs to be closed and reopened if error column starts in whitespace section.

It would be good to include something like that. Of course I can change the style of errors, for example to white text on red background if the underline is inappropriate.

Comparison:

With underline
![werkzeug_underline](https://github.com/pallets/werkzeug/assets/33599/15552bea-bbda-4e40-9515-1c0ef7b13d70)

Arrows
![werkzeug_standard](https://github.com/pallets/werkzeug/assets/33599/753765a8-20ce-46a6-b906-64356b647a93)

