### PR TITLE
Fix qvalue parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
     enforcement. :issue:`2734`
 -   Fix empty file streaming when testing. :issue:`2740`
 -   Clearer error message when URL rule does not start with slash. :pr:`2750`
+-   ``Accept`` ``q`` value can be a float without a decimal part. :issue:`2751`
 
 
 Version 2.3.6

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -313,7 +313,6 @@ def _decode_idna(domain: str) -> str:
 
 
 _plain_int_re = re.compile(r"-?\d+", re.ASCII)
-_plain_float_re = re.compile(r"-?\d+\.\d+", re.ASCII)
 
 
 def _plain_int(value: str) -> int:
@@ -329,19 +328,3 @@ def _plain_int(value: str) -> int:
         raise ValueError
 
     return int(value)
-
-
-def _plain_float(value: str) -> float:
-    """Parse a float only if it is only ASCII digits and ``-``, and contains digits
-    before and after the ``.``.
-
-    This disallows ``+``, ``_``, non-ASCII digits, and ``.123``, which are accepted by
-    ``float`` but are not allowed in HTTP header values.
-
-    Any leading or trailing whitespace is stripped
-    """
-    value = value.strip()
-    if _plain_float_re.fullmatch(value) is None:
-        raise ValueError
-
-    return float(value)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -776,6 +776,12 @@ def test_accept_invalid_float(value):
     assert list(a.values()) == ["en"]
 
 
+def test_accept_valid_int_one_zero():
+    assert http.parse_accept_header("en;q=1") == http.parse_accept_header("en;q=1.0")
+    assert http.parse_accept_header("en;q=0") == http.parse_accept_header("en;q=0.0")
+    assert http.parse_accept_header("en;q=5") == http.parse_accept_header("en;q=5.0")
+
+
 @pytest.mark.parametrize("value", ["🯱🯲🯳", "+1-", "1-1_23"])
 def test_range_invalid_int(value):
     assert http.parse_range_header(value) is None


### PR DESCRIPTION
Fixes #2751. Introduce proper regex for quality values as specified by [RFC9110](https://httpwg.org/specs/rfc9110.html#quality.values) 

- fixes #2751 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
