### PR TITLE
Prevent Addition of Extra Newline in Binary File Uploads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Version 2.3.8
 
 Unreleased
 
--   Fix parsing of multipart bodies. 
+-   Fix parsing of multipart bodies.
     Adjust index of last newline in data start. :issue:`2761`
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: werkzeug
 
+Version 2.3.8
+-------------
+
+Unreleased
+
+-   Fix parsing of multipart bodies. 
+    Adjust index of last newline in data start. :issue:`2761`
+
+
 Version 2.3.7
 -------------
 

--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -256,7 +256,8 @@ class MultipartDecoder:
             # a partial boundary at the end. As the boundary
             # starts with either a nl or cr find the earliest and
             # return up to that as data.
-            data_end = del_index = self.last_newline(data[data_start:])
+            last_newline_idx = self.last_newline(data[data_start:])
+            data_end = del_index = last_newline_idx + data_start  # Adjusted index
             more_data = True
         else:
             match = self.boundary_re.search(data)


### PR DESCRIPTION
The change in this PR addresses the problem of wrong parsing of multipart request body. Specifically using a wrong index of the last newline in the file data in the `MultipartDecoder`.

The problem is passing index shifted data to `last_newline` method and using the index returned by this method directly on the original non-index-shifted data.

- fixes #2761

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
