### PR TITLE
Fix multipart parsing when additional newlines are present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,20 +1,13 @@
 .. currentmodule:: werkzeug
 
-Version 2.3.8
--------------
-
-Unreleased
-
--   Fix parsing of multipart bodies. 
-    Adjust index of last newline in data start. :issue:`2761`
-
-
 Version 2.3.7
 -------------
 
 Unreleased
 
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
+-   Fix parsing of multipart bodies.
+    Adjust index of last newline in data start. :issue:`2761`
 
 
 Version 2.3.6

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 .. currentmodule:: werkzeug
 
+Version 2.3.8
+-------------
+
+Unreleased
+
+-   Fix parsing of multipart bodies. 
+    Adjust index of last newline in data start. :issue:`2761`
+
+
 Version 2.3.7
 -------------
 

--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -256,7 +256,8 @@ class MultipartDecoder:
             # a partial boundary at the end. As the boundary
             # starts with either a nl or cr find the earliest and
             # return up to that as data.
-            data_end = del_index = self.last_newline(data[data_start:])
+            last_newline_idx = self.last_newline(data[data_start:])
+            data_end = del_index = last_newline_idx + data_start  # Adjusted index
             more_data = True
         else:
             match = self.boundary_re.search(data)

--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -256,8 +256,7 @@ class MultipartDecoder:
             # a partial boundary at the end. As the boundary
             # starts with either a nl or cr find the earliest and
             # return up to that as data.
-            last_newline_idx = self.last_newline(data[data_start:])
-            data_end = del_index = last_newline_idx + data_start  # Adjusted index
+            data_end = del_index = self.last_newline(data[data_start:]) + data_start
             more_data = True
         else:
             match = self.boundary_re.search(data)
@@ -269,7 +268,7 @@ class MultipartDecoder:
                 data_end = match.start()
                 del_index = match.end()
             else:
-                data_end = del_index = self.last_newline(data[data_start:])
+                data_end = del_index = self.last_newline(data[data_start:]) + data_start
             more_data = match is None
 
         return bytes(data[data_start:data_end]), del_index, more_data

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -63,7 +63,7 @@ class _MutableMultiDictTests:
             d = create_instance()
             s = pickle.dumps(d, protocol)
             ud = pickle.loads(s)
-            assert type(ud) == type(d)
+            assert type(ud) == type(d)  # noqa: E721
             assert ud == d
             alternative = pickle.dumps(create_instance("werkzeug"), protocol)
             assert pickle.loads(alternative) == d

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -748,7 +748,7 @@ def test_uuid_converter():
     m = r.Map([r.Rule("/a/<uuid:a_uuid>", endpoint="a")])
     a = m.bind("example.org", "/")
     route, kwargs = a.match("/a/a8098c1a-f86e-11da-bd1a-00112444be1e")
-    assert type(kwargs["a_uuid"]) == uuid.UUID
+    assert type(kwargs["a_uuid"]) == uuid.UUID  # noqa: E721
 
 
 def test_converter_with_tuples():


### PR DESCRIPTION
Replaces #2762 and fixes #2761.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
