### PR TITLE
Strip leading/trailing whitespace from header values before checking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
 -   Fix parsing of multipart bodies.
     Adjust index of last newline in data start. :issue:`2761`
+-   ``_plain_int`` and ``_plain_float`` strip whitespace before type
+    enforcement. :issue:`2734`
 
 
 Version 2.3.6

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -321,7 +321,10 @@ def _plain_int(value: str) -> int:
 
     This disallows ``+``, ``_``, and non-ASCII digits, which are accepted by ``int`` but
     are not allowed in HTTP header values.
+
+    Any leading or trailing whitespace is stripped
     """
+    value = value.strip()
     if _plain_int_re.fullmatch(value) is None:
         raise ValueError
 
@@ -334,7 +337,10 @@ def _plain_float(value: str) -> float:
 
     This disallows ``+``, ``_``, non-ASCII digits, and ``.123``, which are accepted by
     ``float`` but are not allowed in HTTP header values.
+
+    Any leading or trailing whitespace is stripped
     """
+    value = value.strip()
     if _plain_float_re.fullmatch(value) is None:
         raise ValueError
 

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 import pytest

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -2,6 +2,7 @@ import typing as t
 
 import pytest
 
+from werkzeug.sansio.utils import get_content_length
 from werkzeug.sansio.utils import get_host
 
 
@@ -30,3 +31,23 @@ def test_get_host(
     expected: str,
 ) -> None:
     assert get_host(scheme, host_header, server) == expected
+
+
+@pytest.mark.parametrize(
+    ("http_content_length", "http_transfer_encoding", "expected"),
+    [
+        ("2", None, 2),
+        (" 2", None, 2),
+        ("2 ", None, 2),
+        (None, None, None),
+        (None, "chunked", None),
+        ("a", None, 0),
+        ("-2", None, 0),
+    ],
+)
+def test_get_content_length(
+    http_content_length: str | None,
+    http_transfer_encoding: str | None,
+    expected: int | None,
+) -> None:
+    assert get_content_length(http_content_length, http_transfer_encoding) == expected


### PR DESCRIPTION
Replaces #2738 (targets correct branch). Fixes https://github.com/pallets/werkzeug/issues/2734

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
