### PR TITLE
Fix empty stream file uploads when testing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,11 @@ Version 2.3.7
 Unreleased
 
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
--   Fix parsing of multipart bodies.
+-   Fix parsing of multipart bodies. :issue:`2734`
     Adjust index of last newline in data start. :issue:`2761`
 -   ``_plain_int`` and ``_plain_float`` strip whitespace before type
     enforcement. :issue:`2734`
+-   Fix empty file streaming when testing. :issue:`2740`
 
 
 Version 2.3.6

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -136,6 +136,7 @@ def stream_encode_multipart(
                 chunk = reader(16384)
 
                 if not chunk:
+                    write_binary(encoder.send_event(Data(data=chunk, more_data=False)))
                     break
 
                 write_binary(encoder.send_event(Data(data=chunk, more_data=True)))

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -357,6 +357,23 @@ def test_environ_builder_unicode_file_mix():
         files["f"].close()
 
 
+def test_environ_builder_empty_file():
+    f = FileStorage(BytesIO(rb""), "empty.txt")
+    d = MultiDict(dict(f=f, s=""))
+    stream, length, boundary = stream_encode_multipart(d)
+    _, form, files = parse_form_data(
+        {
+            "wsgi.input": stream,
+            "CONTENT_LENGTH": str(length),
+            "CONTENT_TYPE": f'multipart/form-data; boundary="{boundary}"',
+        }
+    )
+    assert form["s"] == ""
+    assert files["f"].read() == rb""
+    stream.close()
+    files["f"].close()
+
+
 def test_create_environ():
     env = create_environ("/foo?bar=baz", "http://example.org/")
     expected = {
@@ -409,7 +426,7 @@ def test_file_closing():
 
     class SpecialInput:
         def read(self, size):
-            return ""
+            return b""
 
         def close(self):
             closed.append(self)


### PR DESCRIPTION
There should be a Data event with more_data=False, sent to the encoder as is now the case. This was ok for files that weren't empty as a Data event with more_data=True was sent thereby updating the state and working past this issue.

This includes a test from @pandabear.

The other test fix is required as the file should be bytes.

Replaces #2742. Fixes #https://github.com/pallets/werkzeug/issues/2740

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
