### PR TITLE
Update helpful error message about AirPlay collision on macOS

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -762,7 +762,7 @@ class BaseWSGIServer(HTTPServer):
                     if sys.platform == "darwin" and port == 5000:
                         print(
                             "On macOS, try disabling the 'AirPlay Receiver' service"
-                            " from System Preferences -> Sharing.",
+                            " from System Preferences -> General -> AirDrop & Handoff.",
                             file=sys.stderr,
                         )
 


### PR DESCRIPTION
Very small change to a log line that helps macOS users identify the likely source of collision on port 5000, to update in accordance with change to layout of macOS settings.

Apologies for not opening issue etc etc. Change is so small as to make an issue feel like spam :)