### PR TITLE
Default the PathConverter (and descendants) to be non part isolating

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
 -   Add the ``"werkzeug.profiler"`` item to the  WSGI ``environ`` dictionary
     passed to `ProfilerMiddleware`'s `filename_format` function. It contains
     the ``elapsed`` and ``time`` values for the profiled request. :issue:`2775`
+-   Explicitly marked the PathConverter as non path isolating. :pr:`2784`
 
 
 Version 2.3.8

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -119,6 +119,7 @@ class PathConverter(BaseConverter):
     :param map: the :class:`Map`.
     """
 
+    part_isolating = False
     regex = "[^/].*?"
     weight = 200
 


### PR DESCRIPTION
This is likely to be the expected for anything that is or extends the PathConverter and by adding it explicitly I hope it will cause less confusion, as seen in a recent issue 2783.

Note the PathConverter was already non part isolating due to the BaseConverter check.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
