### PR TITLE
Pass status code to the exception created in Aborter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 3.0.1
+-------------
+
+Unreleased
+
+-   Set status code in the exception raised in ``Aborter`` when
+    handling a ``Response``. :issue:`2793`
+
 Version 3.0.0
 -------------
 

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -853,7 +853,9 @@ class Aborter:
         from .sansio.response import Response
 
         if isinstance(code, Response):
-            raise HTTPException(response=code)
+            exception = HTTPException(response=code)
+            exception.code = code.status_code
+            raise exception
 
         if code not in self.mapping:
             raise LookupError(f"no exception for {code!r}")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -12,10 +12,11 @@ from werkzeug.wrappers import Response
 
 
 def test_proxy_exception():
-    orig_resp = Response("Hello World")
+    orig_resp = Response("Hello World", status=200)
     with pytest.raises(exceptions.HTTPException) as excinfo:
         exceptions.abort(orig_resp)
     resp = excinfo.value.get_response({})
+    assert excinfo.value.code == 200
     assert resp is orig_resp
     assert resp.get_data() == b"Hello World"
 


### PR DESCRIPTION
This PR sets the `code` attribute in the `HTTPException` raised by `Aborter`, in the `Response` handling case. This `code` attribute was missing.


- fixes #2793

Please do correct me on the CHANGES.rst change as there is no "unreleased version" entry and I didn't know where to put that.

Checklist:

- [X] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [X] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [X] Run `pytest` and `tox`, no tests failed.
