### PR TITLE
unpick two changelog entries for v2.3.7 that had become entwined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,8 +21,8 @@ Version 2.3.7
 Released 2023-08-14
 
 -   Use ``flit_core`` instead of ``setuptools`` as build backend.
--   Fix parsing of multipart bodies. :issue:`2734` Adjust index of last newline
-    in data start. :issue:`2761`
+-   Fix parsing of multipart bodies. :issue:`2734`
+-   Adjust index of last newline in data start. :issue:`2761`
 -   Parsing ints from header values strips spacing first. :issue:`2734`
 -   Fix empty file streaming when testing. :issue:`2740`
 -   Clearer error message when URL rule does not start with slash. :pr:`2750`


### PR DESCRIPTION
continues #2791 