### PR TITLE
Update _reloader.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.0.3
 
 Unreleased
 
+-   Make reloader more robust when ``""`` is in ``sys.path``. :pr:`2823`
+
 
 Version 3.0.2
 -------------

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -157,7 +157,9 @@ def _find_common_roots(paths: t.Iterable[str]) -> t.Iterable[str]:
         for prefix, child in node.items():
             _walk(child, path + (prefix,))
 
-        if not node:
+        # If there are no more nodes, and a path has been accumulated, add it.
+        # Path may be empty if the "" entry is in sys.path.
+        if not node and path:
             rv.add(os.path.join(*path))
 
     _walk(root, ())


### PR DESCRIPTION
I've encountered a `TypeError` in the `_find_common_roots` function within the `_reloader.py` module, specifically triggered when `os.path.join(*path)` is called with an empty `path` tuple. 


\werkzeug\_reloader.py 161
root={}
path=()
os.path.join(*path)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
TypeError: join() missing 1 required positional argument: 'path'

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [ ] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
