### PR TITLE
docs: update urlparse import

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -123,7 +123,7 @@ if they are not used right away, to keep it from being confusing::
 
     import os
     import redis
-    from werkzeug.urls import url_parse
+    from urllib.parse import urlparse
     from werkzeug.wrappers import Request, Response
     from werkzeug.routing import Map, Rule
     from werkzeug.exceptions import HTTPException, NotFound
@@ -308,7 +308,7 @@ we need to write a function and a helper method.  For URL validation this
 is good enough::
 
     def is_valid_url(url):
-        parts = url_parse(url)
+        parts = urlparse(url)
         return parts.scheme in ('http', 'https')
 
 For inserting the URL, all we need is this little method on our class::


### PR DESCRIPTION
Following the deprecation of the copy of `urllib.parse` https://github.com/pallets/werkzeug/pull/2768, the documentation should be updated here https://github.com/pallets/werkzeug/blob/d3dd65a27388fbd39d146caacf2563639ba622f0/docs/tutorial.rst?plain=1#L126 to `from urllib.parse import urlparse`

- fixes #2829
