### PR TITLE
Fix handling of custom response_wrapper in test.Client

### DIFF
--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -809,10 +809,12 @@ class Client:
 
         if response_wrapper in {None, Response}:
             response_wrapper = TestResponse
-        elif not isinstance(response_wrapper, TestResponse):
+        elif response_wrapper is not None and not issubclass(
+            response_wrapper, TestResponse
+        ):
             response_wrapper = type(
                 "WrapperTestResponse",
-                (TestResponse, response_wrapper),  # type: ignore
+                (TestResponse, response_wrapper),
                 {},
             )
 

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -16,6 +16,7 @@ from werkzeug.test import create_environ
 from werkzeug.test import EnvironBuilder
 from werkzeug.test import run_wsgi_app
 from werkzeug.test import stream_encode_multipart
+from werkzeug.test import TestResponse
 from werkzeug.utils import redirect
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
@@ -903,3 +904,24 @@ def test_no_content_type_header_addition():
     c = Client(no_response_headers_app)
     response = c.open()
     assert response.headers == Headers([("Content-Length", "8")])
+
+
+def test_client_response_wrapper():
+    class CustomResponse(Response):
+        pass
+
+    class CustomTestResponse(TestResponse, Response):
+        pass
+
+    c1 = Client(Response(), CustomResponse)
+    r1 = c1.open()
+
+    assert isinstance(r1, CustomResponse)
+    assert type(r1) is not CustomResponse  # Got subclassed
+    assert issubclass(type(r1), CustomResponse)
+
+    c2 = Client(Response(), CustomTestResponse)
+    r2 = c2.open()
+
+    assert isinstance(r2, CustomTestResponse)
+    assert type(r2) is CustomTestResponse  # Did not get subclassed


### PR DESCRIPTION
This patch replaces the incorrect `isinstance` check with `issubclass` in how `test.Client` processes the `response_wrapper` argument. Without this patch, supplying a subclass of `werkzeug.test.TestResponse` and `flask.wrappers.Response` will fail with `TypeError: Cannot create a consistent method resolution`.

- fixes #2831

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
