### PR TITLE
Use more precise type for formparser.MultiPartParser.parse return

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 3.0.2
+-------------
+
+Unreleased
+
+-   Make the return type of ``MultiPartParser.parse`` more
+    precise. :issue:`2840`
+
 Version 3.0.1
 -------------
 

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -352,7 +352,7 @@ class MultiPartParser:
 
     def parse(
         self, stream: t.IO[bytes], boundary: bytes, content_length: int | None
-    ) -> tuple[MultiDict, MultiDict]:
+    ) -> tuple[MultiDict[str, str], MultiDict[str, FileStorage]]:
         current_part: Field | File
         container: t.IO[bytes] | list[bytes]
         _write: t.Callable[[bytes], t.Any]


### PR DESCRIPTION
Without this change, `pyright` with `typeCheckingMode` set to `strict` reports:

```
error: Type of "fields" is partially unknown
    Type of "fields" is "MultiDict[Unknown, Unknown]" (reportUnknownVariableType)
```

when I use this method.

- fixes #2840

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [X] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs.
- [X] Run `pre-commit` hooks and fix any issues.
- [ ] Run `pytest` and `tox`, no tests failed.
