### PR TITLE
Handle TypeError in TypeConversionDict.get()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.0.2
 
 Unreleased
 
+-   Fix handling of TypeError in TypeConversionDict.get() to match
+    ValueErrors. :issue:`2843`
 -   Fix response_wrapper type check in test client. :issue:`2831`
 -   Make the return type of ``MultiPartParser.parse`` more
     precise. :issue:`2840`

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -70,8 +70,12 @@ class TypeConversionDict(dict):
                         be looked up.  If not further specified `None` is
                         returned.
         :param type: A callable that is used to cast the value in the
-                     :class:`MultiDict`.  If a :exc:`ValueError` is raised
-                     by this callable the default value is returned.
+                     :class:`MultiDict`.  If a :exc:`ValueError` or a
+                     :exc:`TypeError` is raised by this callable the default
+                     value is returned.
+
+        .. versionchanged:: 3.0.2
+           Returns the default value on :exc:`TypeError`, too.
         """
         try:
             rv = self[key]
@@ -80,7 +84,7 @@ class TypeConversionDict(dict):
         if type is not None:
             try:
                 rv = type(rv)
-            except ValueError:
+            except (ValueError, TypeError):
                 rv = default
         return rv
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -550,8 +550,9 @@ class TestTypeConversionDict:
         assert d.get("foo", type=int) == 1
 
     def test_return_default_when_conversion_is_not_possible(self):
-        d = self.storage_class(foo="bar")
+        d = self.storage_class(foo="bar", baz=None)
         assert d.get("foo", default=-1, type=int) == -1
+        assert d.get("baz", default=-1, type=int) == -1
 
     def test_propagate_exceptions_in_conversion(self):
         d = self.storage_class(foo="bar")


### PR DESCRIPTION
`TypeConversionDict.get()` did not handle `TypeError`. Since this is probably unexpected by the user this PR changes this to return the default value on `TypeError` instead.

- fixes #2842

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
