### PR TITLE
Fix test failure with Pytest 8.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,12 @@
 .. currentmodule:: werkzeug
 
+Version 3.0.2
+-------------
+
+Unreleased
+
+-   Fix test failure with Pytest 8.0. :issue:`2845` :pr:`2846`
+
 Version 3.0.1
 -------------
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -8,6 +8,7 @@ from werkzeug import exceptions
 from werkzeug.datastructures import Headers
 from werkzeug.datastructures import WWWAuthenticate
 from werkzeug.exceptions import HTTPException
+from werkzeug.routing import RequestRedirect
 from werkzeug.wrappers import Response
 
 
@@ -163,7 +164,10 @@ def test_description_none():
     ),
 )
 def test_response_body(cls):
-    exc = cls()
+    if cls == RequestRedirect:
+        exc = cls("https://example.com")
+    else:
+        exc = cls()
     response_body = exc.get_body()
     assert response_body.startswith("<!doctype html>\n<html lang=en>\n")
     assert f"{exc.code} {escape(exc.name)}" in response_body


### PR DESCRIPTION
Not sure why this didn't fail before the pytest update, but oh well.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. Follow the steps in CONTRIBUTING.rst.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes https://github.com/pallets/werkzeug/issues/2845

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change. (N/A)
- [ ] Add or update relevant docs, in the docs folder and in code. (N/A)
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [ ] Add `.. versionchanged::` entries in any relevant code docs. (N/A)
- [ ] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
