### PR TITLE
Make the exception tests more robust

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,7 +7,7 @@ from markupsafe import Markup
 from werkzeug import exceptions
 from werkzeug.datastructures import Headers
 from werkzeug.datastructures import WWWAuthenticate
-from werkzeug.exceptions import HTTPException
+from werkzeug.exceptions import default_exceptions, HTTPException
 from werkzeug.wrappers import Response
 
 
@@ -138,7 +138,7 @@ def test_retry_after_mixin(cls, value, expect):
 @pytest.mark.parametrize(
     "cls",
     sorted(
-        (e for e in HTTPException.__subclasses__() if e.code and e.code >= 400),
+        (e for e in default_exceptions.values() if e.code and e.code >= 400),
         key=lambda e: e.code,  # type: ignore
     ),
 )
@@ -158,7 +158,7 @@ def test_description_none():
 @pytest.mark.parametrize(
     "cls",
     sorted(
-        (e for e in HTTPException.__subclasses__() if e.code),
+        (e for e in default_exceptions.values() if e.code),
         key=lambda e: e.code,  # type: ignore
     ),
 )


### PR DESCRIPTION
This should ensure that the tests work with Pytest 8 onwards. The issue appears to be that __subclasses__ "returns a list of all those references still alive." which could include the RequestRedirect. If it does include RequestRedirect the tests will fail as it requires an argument to be constructed. Note this test is not meant for RequestRedirect.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
