### PR TITLE
Use Python 3 print() function in Werkzeug Quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -141,7 +141,7 @@ the quality, the best item being the first:
 'text/html'
 >>> 'application/xhtml+xml' in request.accept_mimetypes
 True
->>> print request.accept_mimetypes["application/json"]
+>>> print(request.accept_mimetypes["application/json"])
 0.8
 
 The same works for languages:


### PR DESCRIPTION
Fixes: #2861 

This is option 1 as discussed in #2861. This PR is an alternative to #2863.