### PR TITLE
Raise an error if the converter arguments cannot be parsed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 -   Fix response_wrapper type check in test client. :issue:`2831`
 -   Make the return type of ``MultiPartParser.parse`` more
     precise. :issue:`2840`
+-   Raise an error if converter arguments cannot be
+    parsed. :issue:`2822`
 
 Version 3.0.1
 -------------

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -67,6 +67,7 @@ _part_re = re.compile(
 _simple_rule_re = re.compile(r"<([^>]+)>")
 _converter_args_re = re.compile(
     r"""
+    \s*
     ((?P<name>\w+)\s*=\s*)?
     (?P<value>
         True|False|
@@ -112,8 +113,14 @@ def parse_converter_args(argstr: str) -> tuple[tuple[t.Any, ...], dict[str, t.An
     argstr += ","
     args = []
     kwargs = {}
+    position = 0
 
     for item in _converter_args_re.finditer(argstr):
+        if item.start() != position:
+            raise ValueError(
+                f"Cannot parse converter argument '{argstr[position:item.start()]}'"
+            )
+
         value = item.group("stringval")
         if value is None:
             value = item.group("value")
@@ -123,6 +130,7 @@ def parse_converter_args(argstr: str) -> tuple[tuple[t.Any, ...], dict[str, t.An
         else:
             name = item.group("name")
             kwargs[name] = value
+        position = item.end()
 
     return tuple(args), kwargs
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1076,6 +1076,9 @@ def test_converter_parser():
     args, kwargs = r.parse_converter_args('"foo", "bar"')
     assert args == ("foo", "bar")
 
+    with pytest.raises(ValueError):
+        r.parse_converter_args("min=0;max=500")
+
 
 def test_alias_redirects():
     m = r.Map(


### PR DESCRIPTION
This could happen for example with `min=0;max=500` as the `;` is not a word character everything before it is ignored in the regex during the finditer call. This then lefts the user confused as the `min=0;` was silently ignored.

fixes #2822 

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
