### PR TITLE
make cn field a valid single hostname, and use wildcard in SANs field.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 3.0.3
 Unreleased
 
 -   Make reloader more robust when ``""`` is in ``sys.path``. :pr:`2823`
+-   Better TLS cert format with ``adhoc`` dev certs. :pr:`2891`
 
 
 Version 3.0.2

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -532,7 +532,10 @@ def generate_adhoc_ssl_pair(
         .not_valid_before(dt.now(timezone.utc))
         .not_valid_after(dt.now(timezone.utc) + timedelta(days=365))
         .add_extension(x509.ExtendedKeyUsage([x509.OID_SERVER_AUTH]), critical=False)
-        .add_extension(x509.SubjectAlternativeName([x509.DNSName(cn)]), critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(cn), x509.DNSName(f"*.{cn}")]),
+            critical=False,
+        )
         .sign(pkey, hashes.SHA256(), backend)
     )
     return cert, pkey
@@ -560,7 +563,7 @@ def make_ssl_devcert(
     """
 
     if host is not None:
-        cn = f"*.{host}/CN={host}"
+        cn = host
     cert, pkey = generate_adhoc_ssl_pair(cn=cn)
 
     from cryptography.hazmat.primitives import serialization


### PR DESCRIPTION
fix: name and wildcard in the cn field doesn't validate for many TLS clients.

This resolves an issue with TLS validation from local clients by changing the cn name format so that clients like wget, and python requests accept it, while hopefully maintaining the same behaviour.

old:
```
        Subject: O=Dummy Certificate, CN=*.localhost/CN=localhost
            X509v3 Subject Alternative Name:
                DNS:*.localhost/CN=localhost
```

new:
```
        Subject: O=Dummy Certificate, CN=localhost
            X509v3 Subject Alternative Name:
                DNS:localhost, DNS:*.localhost
```

fixes #2891
