### PR TITLE
add breakpoint middleware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
+        exclude: breakpoint\.py
       - id: fix-byte-order-marker
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@ Version 3.1.0
 
 Unreleased
 
--  Support Cookie CHIPS (Partitioned Cookies). :issue:`2797`
+-   Support Cookie CHIPS (Partitioned Cookies). :issue:`2797`
+-   Replace ``DebuggedApplication`` middleware with
+    ``BreakpointWSGIMiddleware``. This new middleware calls ``breakpoint()`` for
+    unhandled exceptions, which will run the user's local debugger of choice
+    rather than serving an interactive debugger UI to the browser.
+
 
 Version 3.0.3
 -------------

--- a/src/werkzeug/middleware/breakpoint.py
+++ b/src/werkzeug/middleware/breakpoint.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import collections.abc as c
+import traceback
+import typing as t
+
+from ..exceptions import InternalServerError
+
+if t.TYPE_CHECKING:
+    from _typeshed.wsgi import StartResponse
+    from _typeshed.wsgi import WSGIApplication
+    from _typeshed.wsgi import WSGIEnvironment
+
+
+class BreakpointWSGIMiddleware:
+    """Call Python's :func:`breakpoint` function to drop into a debugger on
+    unhandled exceptions. Python's default debugger is :mod:`pdb`, but there are
+    others available, such as in IDEs.
+
+    :param app: The WSGI application to wrap.
+    """
+
+    def __init__(self, app: WSGIApplication) -> None:
+        self.app = app
+
+    def __call__(
+        self, environ: WSGIEnvironment, start_response: StartResponse
+    ) -> c.Iterable[bytes]:
+        app_iter: c.Iterable[bytes] | None = None
+
+        try:
+            app_iter = self.app(environ, start_response)
+            yield from app_iter
+
+            if hasattr(app_iter, "close"):
+                app_iter.close()
+        except Exception:
+            if app_iter is not None and hasattr(app_iter, "close"):
+                app_iter.close()
+
+            app_iter = InternalServerError()(environ, start_response)
+
+            try:
+                yield from app_iter
+            except Exception:
+                # If a streaming response raised part way through the real
+                # app_iter, the headers were already sent and the 500 error
+                # can't be sent in its place.
+                pass
+
+            traceback.print_exc(file=environ["wsgi.errors"])
+            breakpoint()

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -33,6 +33,7 @@ from urllib.parse import urlsplit
 from ._internal import _log
 from ._internal import _wsgi_encoding_dance
 from .exceptions import InternalServerError
+from .middleware.breakpoint import BreakpointWSGIMiddleware
 from .urls import uri_to_iri
 
 try:
@@ -1066,9 +1067,7 @@ def run_simple(
         application = SharedDataMiddleware(application, static_files)
 
     if use_debugger:
-        from .debug import DebuggedApplication
-
-        application = DebuggedApplication(application, evalex=use_evalex)
+        application = BreakpointWSGIMiddleware(application)
 
     if not is_running_from_reloader():
         fd = None


### PR DESCRIPTION
The interactive debugger is a constant source of (usually invalid) security reports. Nowadays, there are a lot of nice Python debuggers besides the built-in `pdb`. Python has a built-in `breakpoint()` function which will start the user's preferred debugger. For example, pudb, ipdb, pdbpp, or IDE debuggers such as PyCharm and VSCode. This middleware catches unhandled exceptions, finishes the response, then calls `breakpoint()` to allow the user to inspect the stack. This provides exactly as much information as the interactive debugger, but without the huge complexity of storing frames, threads, contexts, etc or serving a remote Python interpreter UI.
