### PR TITLE
remove iri_to_uri redirect workaround

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Unreleased
 
 -   Make reloader more robust when ``""`` is in ``sys.path``. :pr:`2823`
 -   Better TLS cert format with ``adhoc`` dev certs. :pr:`2891`
+-   Inform Python < 3.12 how to handle ``itms-services`` URIs correctly, rather
+    than using an overly-broad workaround in Werkzeug that caused some redirect
+    URIs to be passed on without encoding. :issue:`2828`
 
 
 Version 3.0.2

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -14,7 +14,6 @@ from ..http import parse_etags
 from ..http import parse_range_header
 from ..http import remove_entity_headers
 from ..sansio.response import Response as _SansIOResponse
-from ..urls import _invalid_iri_to_uri
 from ..urls import iri_to_uri
 from ..utils import cached_property
 from ..wsgi import _RangeWrapper
@@ -479,7 +478,7 @@ class Response(_SansIOResponse):
                 content_length = value
 
         if location is not None:
-            location = _invalid_iri_to_uri(location)
+            location = iri_to_uri(location)
 
             if self.autocorrect_location_header:
                 # Make the location header an absolute URL.

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -98,3 +98,9 @@ def test_iri_to_uri_dont_quote_valid_code_points():
     # [] are not valid URL code points according to WhatWG URL Standard
     # https://url.spec.whatwg.org/#url-code-points
     assert urls.iri_to_uri("/path[bracket]?(paren)") == "/path%5Bbracket%5D?(paren)"
+
+
+# Python < 3.12
+def test_itms_services() -> None:
+    url = "itms-services://?action=download-manifest&url=https://test.example/path"
+    assert urls.iri_to_uri(url) == url

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1154,6 +1154,7 @@ def test_disabled_auto_content_length():
     ("auto", "location", "expect"),
     (
         (False, "/test", "/test"),
+        (False, "/\\\\test.example?q", "/%5C%5Ctest.example?q"),
         (True, "/test", "http://localhost/test"),
         (True, "test", "http://localhost/a/b/test"),
         (True, "./test", "http://localhost/a/b/test"),


### PR DESCRIPTION
Tell Python < 3.12 to handle the `itms-services` scheme correctly, rather than using a workaround in Werkzeug. The workaround was too broad and would pass through other ASCII URIs that should have been percent encoded. See https://github.com/python/cpython/issues/104139#issuecomment-1539176043 for how to add other schemes. If you find a scheme that needs special handling, please report it to Python.

fixes #2828
