### PR TITLE
test with python 3.13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - {python: '3.13'}
           - {python: '3.12'}
           - {name: Windows, python: '3.12', os: windows-latest}
           - {name: Mac, python: '3.12', os: macos-latest}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ strict = true
 module = [
     "colorama.*",
     "cryptography.*",
-    "eventlet.*",
-    "gevent.*",
-    "greenlet.*",
     "watchdog.*",
     "xprocess.*",
 ]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ certifi==2024.2.2
     # via
     #   -r docs.txt
     #   requests
-cffi==1.16.0
+cffi @ https://github.com/python-cffi/cffi/archive/d7f750b1b1c5ea4da5aa537b9baba0e01b0ce843.zip
     # via
     #   -r tests.txt
     #   cryptography
@@ -46,8 +46,6 @@ filelock==3.13.3
     # via
     #   tox
     #   virtualenv
-greenlet==3.0.3
-    # via -r tests.txt
 identify==2.5.35
     # via pre-commit
 idna==3.6

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -3,6 +3,7 @@ pytest-timeout
 # pinned for python 3.8 support
 pytest-xprocess<1
 cryptography
-greenlet
 watchdog
 ephemeral-port-reserve
+# pin current commit on main for python 3.13 support
+https://github.com/python-cffi/cffi/archive/d7f750b1b1c5ea4da5aa537b9baba0e01b0ce843.zip

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile tests.in
 #
-cffi==1.16.0
-    # via cryptography
+cffi @ https://github.com/python-cffi/cffi/archive/d7f750b1b1c5ea4da5aa537b9baba0e01b0ce843.zip
+    # via
+    #   -r tests.in
+    #   cryptography
 cryptography==42.0.5
     # via -r tests.in
 ephemeral-port-reserve==1.1.4
-    # via -r tests.in
-greenlet==3.0.3
     # via -r tests.in
 iniconfig==2.0.0
     # via pytest

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -296,7 +296,12 @@ class DebugTraceback:
 
                 rows.append("\n".join(row_parts))
 
-        is_syntax_error = issubclass(self._te.exc_type, SyntaxError)
+        if sys.version_info < (3, 13):
+            exc_type_str = self._te.exc_type.__name__
+        else:
+            exc_type_str = self._te.exc_type_str
+
+        is_syntax_error = exc_type_str == "SyntaxError"
 
         if include_title:
             if is_syntax_error:
@@ -325,13 +330,19 @@ class DebugTraceback:
     ) -> str:
         exc_lines = list(self._te.format_exception_only())
         plaintext = "".join(self._te.format())
+
+        if sys.version_info < (3, 13):
+            exc_type_str = self._te.exc_type.__name__
+        else:
+            exc_type_str = self._te.exc_type_str
+
         return PAGE_HTML % {
             "evalex": "true" if evalex else "false",
             "evalex_trusted": "true" if evalex_trusted else "false",
             "console": "false",
             "title": escape(exc_lines[0]),
             "exception": escape("".join(exc_lines)),
-            "exception_type": escape(self._te.exc_type.__name__),
+            "exception_type": escape(exc_type_str),
             "summary": self.render_traceback_html(include_title=False),
             "plaintext": escape(plaintext),
             "plaintext_cs": re.sub("-{2,}", "-", plaintext),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3{12,11,10,9,8}
+    py3{13,12,11,10,9,8}
     pypy310
     style
     typing


### PR DESCRIPTION
Tests pass on Python 3.13 beta 1. Add test env for 3.13 to tox and CI.

- Remove greenlet from test dependencies. It was a leftover from before the switch to `contextvars` was complete.
- Pin cffi to the current commit on main. Waiting for a new release to support 3.13, see https://github.com/python-cffi/cffi/issues/71 and https://github.com/python-cffi/cffi/pull/72.
- `TracebackException` deprecated the `exc_type` attribute, which was a strong reference to the actual class. It's replaced by `exc_type_str`, the string representation of the class. For our purposes, this should be fine. See https://github.com/python/cpython/pull/112333.
