### PR TITLE
Update HTTP parse_options_headers method to avoid using regex for options matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 .. currentmodule:: werkzeug
 
+Version 3.0.4
+-------------
+
+Unreleased
+
+- Remove regex matching of options headers :issue:`2904` :pr:`#2907`
+
+
 Version 3.0.3
 -------------
 

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -496,7 +496,7 @@ def parse_options_header(value: str | None) -> tuple[str, dict[str, str]]:
         pk = pk.strip().lower()
         pv = pv.strip()
 
-        if not pk:
+        if not pk or not pv:
             # empty or invalid part
             continue
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -382,6 +382,20 @@ class TestHTTPUtility:
     def test_parse_options_header(self, value, expect) -> None:
         assert http.parse_options_header(value) == ("v", expect)
 
+    @pytest.mark.parametrize(
+        ("value",),
+        [
+            (
+                'v;!="\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+                "\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"
+                "\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",
+            ),
+        ],
+    )
+    @pytest.mark.timeout(1)
+    def test_parse_options_header_timeout(self, value) -> None:
+        assert http.parse_options_header(value)
+
     def test_parse_options_header_broken_values(self):
         # Issue #995
         assert http.parse_options_header(" ") == ("", {})


### PR DESCRIPTION
When parsing certain `Content-Type` headers http parser would take too much time because of exhaustive regex matching.

Instead of using regex matching for parsing options we're using FSM (similar to one used in Django, actually the main idea of it was taken from there), so the performance is much better and the exhaustive regex matching is avoided, this way we won't have performance issues when someone tries something like ReDoS on options headers.

fixes #2904 

Please take a look at the PR so we can fix the issue, thanks!

Also wanted to thank you for one of the best and most comprehensive test suites I've seen.
It eased the development a lot, so thank you once more!