### PR TITLE
Fix UnicodeDecodeError issue (#2930)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.0.4
 
 Unreleased
 
+- Return correct status code when unicode decode error occurred :issue:`2930`
+
 
 Version 3.0.3
 -------------

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -8,6 +8,7 @@ from ._internal import _plain_int
 from .datastructures import FileStorage
 from .datastructures import Headers
 from .datastructures import MultiDict
+from .exceptions import BadRequest
 from .exceptions import RequestEntityTooLarge
 from .http import parse_options_header
 from .sansio.multipart import Data
@@ -287,6 +288,8 @@ class FormDataParser:
                 keep_blank_values=True,
                 errors="werkzeug.url_quote",
             )
+        except UnicodeDecodeError as e:
+            raise BadRequest() from e
         except ValueError as e:
             raise RequestEntityTooLarge() from e
 

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -7,6 +7,7 @@ import pytest
 
 from werkzeug import formparser
 from werkzeug.datastructures import MultiDict
+from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import RequestEntityTooLarge
 from werkzeug.formparser import FormDataParser
 from werkzeug.formparser import parse_form_data
@@ -79,6 +80,14 @@ class TestFormParser:
         pytest.raises(RequestEntityTooLarge, lambda: req.form["foo"])
         # content-length was set, so request could exit early without reading anything
         assert input_stream.read() == b"foo=123456"
+
+        input_stream = io.BytesIO(b"\x80")
+        req = Request.from_values(
+            input_stream=input_stream,
+            content_type="application/x-www-form-urlencoded",
+            method="POST",
+        )
+        pytest.raises(BadRequest, lambda: req.form)
 
         data = (
             b"--foo\r\nContent-Disposition: form-field; name=foo\r\n\r\n"


### PR DESCRIPTION

Added handling of unicode-decode error and return correct HTTP status code when error occurred.
fixes #2930 

