### PR TITLE
restore invalid bytes behavior for form parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Version 3.0.4
 
 Unreleased
 
+-   Restore behavior where parsing `multipart/x-www-form-urlencoded` data with
+    invalid UTF-8 bytes in the body results in no form data parsed rather than a
+    413 error. :issue:`2930`
+
 
 Version 3.0.3
 -------------

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -281,15 +281,11 @@ class FormDataParser:
         ):
             raise RequestEntityTooLarge()
 
-        try:
-            items = parse_qsl(
-                stream.read().decode(),
-                keep_blank_values=True,
-                errors="werkzeug.url_quote",
-            )
-        except ValueError as e:
-            raise RequestEntityTooLarge() from e
-
+        items = parse_qsl(
+            stream.read().decode(),
+            keep_blank_values=True,
+            errors="werkzeug.url_quote",
+        )
         return stream, self.cls(items), self.cls()
 
 

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -122,12 +122,20 @@ class TestFormParser:
         req.max_form_parts = 1
         pytest.raises(RequestEntityTooLarge, lambda: req.form["foo"])
 
-    def test_x_www_urlencoded_max_form_parts(self):
+    def test_urlencoded_no_max(self) -> None:
         r = Request.from_values(method="POST", data={"a": 1, "b": 2})
         r.max_form_parts = 1
 
         assert r.form["a"] == "1"
         assert r.form["b"] == "2"
+
+    def test_urlencoded_silent_decode(self) -> None:
+        r = Request.from_values(
+            data=b"\x80",
+            content_type="application/x-www-form-urlencoded",
+            method="POST",
+        )
+        assert not r.form
 
     def test_missing_multipart_boundary(self):
         data = (


### PR DESCRIPTION
#2694 removed max part limit from `application/x-www-form-urlencoded` parsing, previously added in #2620. However, it left the `except ValueError: raise RequestEntityTooLarge`. If `body.decode()` raised a `UnicodeError`, it resulted in a 413 error rather than being silently ignored. This restores that previous behavior.

fixes #2930