### PR TITLE
improve parse_options_header performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 -   Restore behavior where parsing `multipart/x-www-form-urlencoded` data with
     invalid UTF-8 bytes in the body results in no form data parsed rather than a
     413 error. :issue:`2930`
+-   Improve ``parse_options_header`` performance when parsing unterminated
+    quoted string values. :issue:`2907`
 
 
 Version 3.0.3

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -361,8 +361,8 @@ class TestHTTPUtility:
             ('v;a="b\\"c";d=e', {"a": 'b"c', "d": "e"}),
             # HTTP headers use \\ for internal \
             ('v;a="c:\\\\"', {"a": "c:\\"}),
-            # Invalid trailing slash in quoted part is left as-is.
-            ('v;a="c:\\"', {"a": "c:\\"}),
+            # Part with invalid trailing slash is discarded.
+            ('v;a="c:\\"', {}),
             ('v;a="b\\\\\\"c"', {"a": 'b\\"c'}),
             # multipart form data uses %22 for internal "
             ('v;a="b%22c"', {"a": 'b"c'}),
@@ -377,6 +377,8 @@ class TestHTTPUtility:
             ("v;a*0=b;a*1=c;d=e", {"a": "bc", "d": "e"}),
             ("v;a*0*=b", {"a": "b"}),
             ("v;a*0*=UTF-8''b;a*1=c;a*2*=%C2%B5", {"a": "bcµ"}),
+            # Long invalid quoted string with trailing slashes does not freeze.
+            ('v;a="' + "\\" * 400, {}),
         ],
     )
     def test_parse_options_header(self, value, expect) -> None:


### PR DESCRIPTION
Improve `parse_options_header` performance when parsing long unterminated quoted value. fixes #2904

In #2614, I split up the giant regex that was previously used into a few smaller parts. However, the `"(?:\\\\|\\"|.)*?"` regex I came up with to parse quoted values was still susceptible to backtracking performance issues with strings like `'"' + "\\" * 100`.

This reduces the complexity of the regex even further. A regex is used to match token keys and values. If the value starts with a quote, a loop is used to scan characters, skipping escaped slashes and quotes, until a closing quote is found.

Previously, we were matching the invalid value `a="c:\\"` as `c:\`. I couldn't figure out a good reason for this, it seems like it was discussed in #1628 as a behavior in some old browsers which didn't happen anymore. Perhaps it just happened to work with the first refactor, and I left it in? If it does come up, the loop can be modified to handle it if there's still a good reason to.