### PR TITLE
treat SSLEOFError as dropped connection

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
     quoted string values. :issue:`2907`
 -   Debugger pin auth is synchronized across threads/processes when tracking
     failed entries. :issue:`2916`
+-   Dev server handles unexpected `SSLEOFError` due to issue in Python < 3.13.
+    :issue:`2926`
 
 
 Version 3.0.3

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -37,6 +37,12 @@ from .urls import uri_to_iri
 
 try:
     import ssl
+
+    connection_dropped_errors: tuple[type[Exception], ...] = (
+        ConnectionError,
+        socket.timeout,
+        ssl.SSLEOFError,
+    )
 except ImportError:
 
     class _SslDummy:
@@ -47,6 +53,7 @@ except ImportError:
             )
 
     ssl = _SslDummy()  # type: ignore
+    connection_dropped_errors = (ConnectionError, socket.timeout)
 
 _log_add_style = True
 
@@ -361,7 +368,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
 
         try:
             execute(self.server.app)
-        except (ConnectionError, socket.timeout) as e:
+        except connection_dropped_errors as e:
             self.connection_dropped(e, environ)
         except Exception as e:
             if self.server.passthrough_errors:


### PR DESCRIPTION
Apparently on Python 3.10 - 3.12, a bug in `http.server` with TLS caused `SSLEOFError` to be handled incorrectly in some cases. https://github.com/python/cpython/issues/122254 Add that to the errors caught and handled as dropped connections.

fixes #2926