### PR TITLE
 watchdog: Prevent reload if a file gets closed without any changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 -   ``CacheControl.no_transform`` is a boolean when present. ``min_fresh`` is
     ``None`` when not present. Added the ``must_understand`` attribute. Fixed
     some typing issues on cache control. :issue:`2881`
+-   The Watchdog reloader ignores file closed no write events. Bump version of
+    Watchdog used in tests etc. to 5.0.2. :issue:`2945`
 
 
 Version 3.0.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -191,7 +191,7 @@ virtualenv==20.26.3
     # via
     #   pre-commit
     #   tox
-watchdog==4.0.2
+watchdog==5.0.2
     # via
     #   -r tests.txt
     #   -r typing.txt

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -31,5 +31,5 @@ pytest-timeout==2.3.1
     # via -r tests.in
 pytest-xprocess==0.23.0
     # via -r tests.in
-watchdog==4.0.2
+watchdog==5.0.2
     # via -r tests.in

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -28,5 +28,5 @@ types-setuptools==73.0.0.20240822
     # via -r typing.in
 typing-extensions==4.12.2
     # via mypy
-watchdog==4.0.2
+watchdog==5.0.2
     # via -r typing.in

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -314,10 +314,12 @@ class StatReloaderLoop(ReloaderLoop):
 class WatchdogReloaderLoop(ReloaderLoop):
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
         from watchdog.events import EVENT_TYPE_OPENED
+
         ignored_events = [EVENT_TYPE_OPENED]
         # event introduced in watchdog 5.0
         with contextlib.suppress(ImportError):
             from watchdog.events import EVENT_TYPE_CLOSED_NO_WRITE
+
             ignored_events.append(EVENT_TYPE_CLOSED_NO_WRITE)
         from watchdog.events import FileModifiedEvent
         from watchdog.events import PatternMatchingEventHandler


### PR DESCRIPTION
Ignores the new `closed_no_write` event type fired by watchdog 5.x that is causing unnecessary reloads.

fixes https://github.com/pallets/werkzeug/issues/2945

- Test case added
- Requirements updated
- Changelog added