### PR TITLE
watchdog ignore closed_no_write

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,11 @@
 .. currentmodule:: werkzeug
 
+Unreleased
+
+-   The Watchdog reloader ignores file closed_no_write events. Bump the minimum
+    version of Watchdog to 5.0.3. :issue:`2945`
+
+
 Version 3.0.4
 -------------
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -191,7 +191,7 @@ virtualenv==20.26.3
     # via
     #   pre-commit
     #   tox
-watchdog==4.0.2
+watchdog==5.0.3
     # via
     #   -r tests.txt
     #   -r typing.txt

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -31,5 +31,5 @@ pytest-timeout==2.3.1
     # via -r tests.in
 pytest-xprocess==0.23.0
     # via -r tests.in
-watchdog==4.0.2
+watchdog==5.0.3
     # via -r tests.in

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -28,5 +28,5 @@ types-setuptools==73.0.0.20240822
     # via -r typing.in
 typing-extensions==4.12.2
     # via mypy
-watchdog==4.0.2
+watchdog==5.0.3
     # via -r typing.in

--- a/src/werkzeug/_reloader.py
+++ b/src/werkzeug/_reloader.py
@@ -312,6 +312,7 @@ class StatReloaderLoop(ReloaderLoop):
 
 class WatchdogReloaderLoop(ReloaderLoop):
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        from watchdog.events import EVENT_TYPE_CLOSED_NO_WRITE
         from watchdog.events import EVENT_TYPE_OPENED
         from watchdog.events import FileModifiedEvent
         from watchdog.events import PatternMatchingEventHandler
@@ -322,7 +323,7 @@ class WatchdogReloaderLoop(ReloaderLoop):
 
         class EventHandler(PatternMatchingEventHandler):
             def on_any_event(self, event: FileModifiedEvent):  # type: ignore
-                if event.event_type == EVENT_TYPE_OPENED:
+                if event.event_type in [EVENT_TYPE_OPENED, EVENT_TYPE_CLOSED_NO_WRITE]:
                     return
 
                 trigger_reload(event.src_path)


### PR DESCRIPTION
Ignore file closed_no_write events in the Watchdog Reloader.

fixes https://github.com/pallets/werkzeug/issues/2945
