### PR TITLE
Ignore invalid authorization parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 
 -   The Watchdog reloader ignores file closed no write events. :issue:`2945`
 -   Logging works with client addresses containing an IPv6 scope :issue:`2952`
+-   Ignore invalid authorization parameters. :issue:`2955`
 
 
 Version 3.0.4

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -361,6 +361,10 @@ def parse_dict_header(value: str) -> dict[str, str | None]:
         key, has_value, value = item.partition("=")
         key = key.strip()
 
+        if not key:
+            # =value is not valid
+            continue
+
         if not has_value:
             result[key] = None
             continue


### PR DESCRIPTION
This change will gracefully handle invalid authorization parameters.

fixes #2955 

