### PR TITLE
change type annotation for SharedDataMiddleware to handle common scenarios

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 -   The Watchdog reloader ignores file closed no write events. :issue:`2945`
 -   Logging works with client addresses containing an IPv6 scope :issue:`2952`
 -   Ignore invalid authorization parameters. :issue:`2955`
+-   Improve type annotation fore ``SharedDataMiddleware``. :issue:`2958`
 
 
 Version 3.0.4

--- a/src/werkzeug/middleware/shared_data.py
+++ b/src/werkzeug/middleware/shared_data.py
@@ -11,6 +11,7 @@ Serve Shared Static Files
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import importlib.util
 import mimetypes
 import os
@@ -103,7 +104,7 @@ class SharedDataMiddleware:
         self,
         app: WSGIApplication,
         exports: (
-            dict[str, str | tuple[str, str]]
+            cabc.Mapping[str, str | tuple[str, str]]
             | t.Iterable[tuple[str, str | tuple[str, str]]]
         ),
         disallow: None = None,
@@ -116,7 +117,7 @@ class SharedDataMiddleware:
         self.cache = cache
         self.cache_timeout = cache_timeout
 
-        if isinstance(exports, dict):
+        if isinstance(exports, cabc.Mapping):
             exports = exports.items()
 
         for key, value in exports:


### PR DESCRIPTION
fixes #2958 