### PR TITLE
replace pytest-xprocess

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ strict = true
 module = [
     "colorama.*",
     "cryptography.*",
+    "ephemeral_port_reserve",
     "watchdog.*",
     "xprocess.*",
 ]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -104,10 +104,6 @@ pluggy==1.5.0
     #   tox
 pre-commit==4.0.1
     # via -r dev.in
-psutil==6.1.0
-    # via
-    #   -r tests.txt
-    #   pytest-xprocess
 pycparser==2.22
     # via
     #   -r tests.txt
@@ -125,10 +121,7 @@ pytest==8.3.3
     #   -r tests.txt
     #   -r typing.txt
     #   pytest-timeout
-    #   pytest-xprocess
 pytest-timeout==2.3.1
-    # via -r tests.txt
-pytest-xprocess==0.23.0
     # via -r tests.txt
 pyyaml==6.0.2
     # via pre-commit

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -1,6 +1,5 @@
 pytest
 pytest-timeout
-pytest-xprocess<1
 cryptography
 watchdog
 ephemeral-port-reserve

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -18,18 +18,13 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-psutil==6.1.0
-    # via pytest-xprocess
 pycparser==2.22
     # via cffi
 pytest==8.3.3
     # via
     #   -r tests.in
     #   pytest-timeout
-    #   pytest-xprocess
 pytest-timeout==2.3.1
-    # via -r tests.in
-pytest-xprocess==0.23.0
     # via -r tests.in
 watchdog==5.0.3
     # via -r tests.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import http.client
 import json
 import os
@@ -8,23 +9,36 @@ import ssl
 import subprocess
 import sys
 import time
+import typing as t
 from contextlib import closing
 from contextlib import ExitStack
 from pathlib import Path
+from types import TracebackType
 
 import ephemeral_port_reserve
 import pytest
 
+if t.TYPE_CHECKING:
+    import typing_extensions as te
+
 
 class UnixSocketHTTPConnection(http.client.HTTPConnection):
-    def connect(self):
+    def connect(self) -> None:
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         # Raises FileNotFoundError if the server hasn't started yet.
         self.sock.connect(self.host)
 
 
+# Used to annotate the ``DevServerClient.request`` return value.
+class DataHTTPResponse(http.client.HTTPResponse):
+    data: bytes
+    json: t.Any
+
+
 class DevServerClient:
-    def __init__(self, app_name="standard", *, tmp_path, **server_kwargs):
+    def __init__(
+        self, app_name: str = "standard", *, tmp_path: Path, **server_kwargs: t.Any
+    ) -> None:
         host = server_kwargs.get("hostname", "127.0.0.1")
 
         if not host.startswith("unix://"):
@@ -44,11 +58,11 @@ class DevServerClient:
         self._app_name = app_name
         self._server_kwargs = server_kwargs
         self._tmp_path = tmp_path
-        self._log_write = None
-        self._log_read = None
-        self._proc = None
+        self._log_write: t.IO[bytes] | None = None
+        self._log_read: t.IO[str] | None = None
+        self._proc: subprocess.Popen[bytes] | None = None
 
-    def __enter__(self):
+    def __enter__(self) -> te.Self:
         log_path = self._tmp_path / "log.txt"
         self._log_write = open(log_path, "wb")
         self._log_read = open(log_path, encoding="utf8", errors="surrogateescape")
@@ -69,16 +83,24 @@ class DevServerClient:
         self.wait_ready()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> None:
+        assert self._proc is not None
         self._proc.terminate()
         self._proc.wait()
         self._proc = None
+        assert self._log_read is not None
         self._log_read.close()
         self._log_read = None
+        assert self._log_write is not None
         self._log_write.close()
         self._log_write = None
 
-    def connect(self, **kwargs):
+    def connect(self, **kwargs: t.Any) -> http.client.HTTPConnection:
         if self.scheme == "https":
             if "context" not in kwargs:
                 context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -93,14 +115,15 @@ class DevServerClient:
 
         return http.client.HTTPConnection(self.addr, **kwargs)
 
-    def request(self, url: str, **kwargs):
+    def request(self, url: str = "", **kwargs: t.Any) -> DataHTTPResponse:
         kwargs.setdefault("method", "GET")
         kwargs["url"] = url
+        response: DataHTTPResponse
 
         with closing(self.connect()) as conn:
             conn.request(**kwargs)
 
-            with conn.getresponse() as response:
+            with conn.getresponse() as response:  # type: ignore[assignment]
                 response.data = response.read()
 
         if response.headers.get("Content-Type", "").startswith("application/json"):
@@ -110,7 +133,7 @@ class DevServerClient:
 
         return response
 
-    def wait_ready(self):
+    def wait_ready(self) -> None:
         while True:
             try:
                 self.request("/ensure")
@@ -120,9 +143,11 @@ class DevServerClient:
                 time.sleep(0.1)
 
     def read_log(self) -> str:
+        assert self._log_read is not None
         return self._log_read.read()
 
-    def wait_for_log(self, value):
+    def wait_for_log(self, value: str) -> None:
+        assert self._log_read is not None
         while True:
             for line in self._log_read:
                 if value in line:
@@ -130,21 +155,25 @@ class DevServerClient:
 
             time.sleep(0.1)
 
-    def wait_for_reload(self):
+    def wait_for_reload(self) -> None:
         self.wait_for_log("Restarting with")
         self.wait_ready()
 
 
+class StartDevServer(t.Protocol):
+    def __call__(self, name: str = "standard", **kwargs: t.Any) -> DevServerClient: ...
+
+
 @pytest.fixture()
-def dev_server(tmp_path):
+def dev_server(tmp_path: Path) -> cabc.Iterator[StartDevServer]:
     """A function that will start a dev server in a subprocess and return a
     client for interacting with the server.
     """
     exit_stack = ExitStack()
 
-    def start_dev_server(name="standard", **kwargs):
+    def start_dev_server(name: str = "standard", **kwargs: t.Any) -> DevServerClient:
         client = DevServerClient(name, tmp_path=tmp_path, **kwargs)
-        exit_stack.enter_context(client)
+        exit_stack.enter_context(client)  # type: ignore[arg-type]
         return client
 
     with exit_stack:
@@ -152,6 +181,6 @@ def dev_server(tmp_path):
 
 
 @pytest.fixture()
-def standard_app(dev_server):
+def standard_app(dev_server: t.Callable[..., DevServerClient]) -> DevServerClient:
     """Equivalent to ``dev_server("standard")``."""
     return dev_server()

--- a/tests/middleware/test_http_proxy.py
+++ b/tests/middleware/test_http_proxy.py
@@ -5,7 +5,6 @@ from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_http_proxy(standard_app):
     app = ProxyMiddleware(

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -245,7 +245,6 @@ def test_get_machine_id():
     assert isinstance(rv, bytes)
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("crash", (True, False))
 @pytest.mark.dev_server
 def test_basic(dev_server, crash):

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -116,7 +116,7 @@ def test_reloader_sys_path(tmp_path, dev_server, reloader_type):
     assert client.request().status == 500
 
     shutil.copyfile(Path(__file__).parent / "live_apps" / "standard_app.py", real_path)
-    client.wait_for_log(f" * Detected change in {str(real_path)!r}, reloading")
+    client.wait_for_log(f"Detected change in {str(real_path)!r}")
     client.wait_for_reload()
     assert client.request().status == 200
 
@@ -195,7 +195,7 @@ def test_wrong_protocol(standard_app):
     with pytest.raises(ssl.SSLError):
         conn.request("GET", f"https://{standard_app.addr}")
 
-    assert "Traceback" not in standard_app.log.read()
+    assert "Traceback" not in standard_app.read_log()
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
@@ -347,4 +347,4 @@ def test_host_with_ipv6_scope(dev_server):
 
     assert r.status == 500
     assert b"Internal Server Error" in r.data
-    assert "Logging error" not in client.log.read()
+    assert "Logging error" not in client.read_log()

--- a/tests/test_serving.py
+++ b/tests/test_serving.py
@@ -25,7 +25,7 @@ from werkzeug.serving import make_ssl_devcert
 from werkzeug.test import stream_encode_multipart
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -52,7 +52,6 @@ def test_server(tmp_path, dev_server, kwargs: dict):
     assert r.json["PATH_INFO"] == "/"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_untrusted_host(standard_app):
     r = standard_app.request(
@@ -66,7 +65,6 @@ def test_untrusted_host(standard_app):
     assert r.json["SERVER_PORT"] == port
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_double_slash_path(standard_app):
     r = standard_app.request("//double-slash")
@@ -74,7 +72,6 @@ def test_double_slash_path(standard_app):
     assert r.json["PATH_INFO"] == "/double-slash"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_500_error(standard_app):
     r = standard_app.request("/crash")
@@ -82,7 +79,6 @@ def test_500_error(standard_app):
     assert b"Internal Server Error" in r.data
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_ssl_dev_cert(tmp_path, dev_server):
     client = dev_server(ssl_context=make_ssl_devcert(tmp_path))
@@ -90,7 +86,6 @@ def test_ssl_dev_cert(tmp_path, dev_server):
     assert r.json["wsgi.url_scheme"] == "https"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_ssl_object(dev_server):
     client = dev_server(ssl_context="custom")
@@ -98,7 +93,6 @@ def test_ssl_object(dev_server):
     assert r.json["wsgi.url_scheme"] == "https"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("reloader_type", ["stat", "watchdog"])
 @pytest.mark.skipif(
     os.name == "nt" and "CI" in os.environ, reason="unreliable on Windows during CI"
@@ -170,7 +164,6 @@ def test_windows_get_args_for_reloading(monkeypatch, tmp_path):
     assert rv == argv
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("find", [_find_stat_paths, _find_watchdog_paths])
 def test_exclude_patterns(find):
     # Select a path to exclude from the unfiltered list, assert that it is present and
@@ -184,7 +177,6 @@ def test_exclude_patterns(find):
     assert not any(p.startswith(path_to_exclude) for p in paths)
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_wrong_protocol(standard_app):
     """An HTTPS request to an HTTP server doesn't show a traceback.
@@ -198,7 +190,6 @@ def test_wrong_protocol(standard_app):
     assert "Traceback" not in standard_app.read_log()
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_content_type_and_length(standard_app):
     r = standard_app.request()
@@ -215,7 +206,6 @@ def test_port_is_int():
         run_simple("127.0.0.1", "5000", None)
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("send_length", [False, True])
 @pytest.mark.dev_server
 def test_chunked_request(monkeypatch, dev_server, send_length):
@@ -258,7 +248,6 @@ def test_chunked_request(monkeypatch, dev_server, send_length):
     assert environ["wsgi.input_terminated"]
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_multiple_headers_concatenated(standard_app):
     """A header key can be sent multiple times. The server will join all
@@ -283,7 +272,6 @@ def test_multiple_headers_concatenated(standard_app):
     assert data["HTTP_XYZ"] == "a ,b,c ,d"
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_multiline_header_folding(standard_app):
     """A header value can be split over multiple lines with a leading
@@ -303,7 +291,6 @@ def test_multiline_header_folding(standard_app):
 
 
 @pytest.mark.parametrize("endpoint", ["", "crash"])
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_streaming_close_response(dev_server, endpoint):
     """When using HTTP/1.0, chunked encoding is not supported. Fall
@@ -315,7 +302,6 @@ def test_streaming_close_response(dev_server, endpoint):
     assert r.data == "".join(str(x) + "\n" for x in range(5)).encode()
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_streaming_chunked_response(dev_server):
     """When using HTTP/1.1, use Transfer-Encoding: chunked for streamed
@@ -329,7 +315,6 @@ def test_streaming_chunked_response(dev_server):
     assert r.data == "".join(str(x) + "\n" for x in range(5)).encode()
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_streaming_chunked_truncation(dev_server):
     """When using HTTP/1.1, chunked encoding allows the client to detect
@@ -339,7 +324,6 @@ def test_streaming_chunked_truncation(dev_server):
         dev_server("streaming", threaded=True).request("/crash")
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.dev_server
 def test_host_with_ipv6_scope(dev_server):
     client = dev_server(override_client_addr="fe80::1ff:fe23:4567:890a%eth2")


### PR DESCRIPTION
Directly manage the dev server subprocess instead of using pytest-xprocess. While this adds some code, overall it's less complex than how pytest-xprocess works, and we didn't seem to need those complexities. I found it's easier to step through and access the different parts during a test if needed. It's also easier to start the server and use the client outside of a pytest session, if we need to debug something really tricky and don't want to deal with pytest. Calling `proc.wait()` after `proc.terminate()` ensures we don't seen any resource warnings, so those ignores can be removed. The tests seem to run about 1-2 seconds faster on my machine.

closes #2906