### PR TITLE
default max_form_memory_size to 500kB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 3.1.0
 
 Unreleased
 
+-   ``Request.max_form_memory_size`` defaults to 500kB instead of unlimited.
+    Non-file form fields over this size will cause a ``RequestEntityTooLarge``
+    error. :issue:`2964`
 -  Support Cookie CHIPS (Partitioned Cookies). :issue:`2797`
 -   ``CacheControl.no_transform`` is a boolean when present. ``min_fresh`` is
     ``None`` when not present. Added the ``must_understand`` attribute. Fixed

--- a/docs/request_data.rst
+++ b/docs/request_data.rst
@@ -79,15 +79,22 @@ request in such a way that the server uses too many resources to handle it. Each
 these limits will raise a :exc:`~werkzeug.exceptions.RequestEntityTooLarge` if they are
 exceeded.
 
--   :attr:`~Request.max_content_length` Stop reading request data after this number
+-   :attr:`~Request.max_content_length` - Stop reading request data after this number
     of bytes. It's better to configure this in the WSGI server or HTTP server, rather
     than the WSGI application.
--   :attr:`~Request.max_form_memory_size` Stop reading request data if any form part is
-    larger than this number of bytes. While file parts can be moved to disk, regular
-    form field data is stored in memory only.
+-   :attr:`~Request.max_form_memory_size` - Stop reading request data if any
+    non-file form field is larger than this number of bytes. While file parts
+    can be moved to disk, regular form field data is stored in memory only and
+    could fill up memory. The default is 500kB.
 -   :attr:`~Request.max_form_parts` Stop reading request data if more than this number
     of parts are sent in multipart form data. This is useful to stop a very large number
     of very small parts, especially file parts. The default is 1000.
+
+Each of these values can be set on the ``Request`` class to affect the default
+for all requests, or on a ``request`` instance to change the behavior for a
+specific request. For example, a small limit can be set by default, and a large
+limit can be set on an endpoint that accepts video uploads. These values should
+be tuned to the specific needs of your application and endpoints.
 
 Using Werkzeug to set these limits is only one layer of protection. WSGI servers
 and HTTPS servers should set their own limits on size and timeouts. The operating system

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -84,8 +84,11 @@ class Request(_SansIORequest):
     #: data in memory for post data is longer than the specified value a
     #: :exc:`~werkzeug.exceptions.RequestEntityTooLarge` exception is raised.
     #:
+    #: .. versionchanged:: 3.1
+    #:     Defaults to 500kB instead of unlimited.
+    #:
     #: .. versionadded:: 0.5
-    max_form_memory_size: int | None = None
+    max_form_memory_size: int | None = 500_000
 
     #: The maximum number of multipart parts to parse, passed to
     #: :attr:`form_data_parser_class`. Parsing form data with more than this


### PR DESCRIPTION
We already use `SpooledTemporaryFile` to write file fields to disk after 500kB. Applying a 500kB limit to non-file form fields in memory is a reasonable default. Also expand the existing documentation about the limits available on `Request`.

fixes #2964 