### PR TITLE
remove previously deprecated code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 3.1.0
 Unreleased
 
 -   Drop support for Python 3.8. :pr:`2966`
+-   Remove previously deprecated code. :pr:`2967`
 -   ``Request.max_form_memory_size`` defaults to 500kB instead of unlimited.
     Non-file form fields over this size will cause a ``RequestEntityTooLarge``
     error. :issue:`2964`

--- a/src/werkzeug/__init__.py
+++ b/src/werkzeug/__init__.py
@@ -1,25 +1,4 @@
-from __future__ import annotations
-
-import typing as t
-
 from .serving import run_simple as run_simple
 from .test import Client as Client
 from .wrappers import Request as Request
 from .wrappers import Response as Response
-
-
-def __getattr__(name: str) -> t.Any:
-    if name == "__version__":
-        import importlib.metadata
-        import warnings
-
-        warnings.warn(
-            "The '__version__' attribute is deprecated and will be removed in"
-            " Werkzeug 3.1. Use feature detection or"
-            " 'importlib.metadata.version(\"werkzeug\")' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return importlib.metadata.version("werkzeug")
-
-    raise AttributeError(name)


### PR DESCRIPTION
Remove code that previously showed a deprecation warning to be removed in 3.1.

- `__version__` is removed. Use feature detection or `importlib.metadata.version("werkzeug")` instead.