### PR TITLE
implement or and ior operators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Unreleased
     :issue:`2970`
 -   ``MultiDict.getlist`` catches ``TypeError`` in addition to ``ValueError``
     when doing type conversion. :issue:`2976`
+-   Implement ``|`` and ``|=`` operators for ``MultiDict``, ``Headers``, and
+    ``CallbackDict``, and disallow ``|=`` on immutable types. :issue:`2977`
 
 
 Version 3.0.6

--- a/src/werkzeug/datastructures/headers.py
+++ b/src/werkzeug/datastructures/headers.py
@@ -41,6 +41,9 @@ class Headers(cabc.MutableMapping[str, str]):
 
     :param defaults: The list of default values for the :class:`Headers`.
 
+    .. versionchanged:: 3.1
+        Implement ``|`` and ``|=`` operators.
+
     .. versionchanged:: 2.1.0
         Default values are validated the same as values added later.
 
@@ -524,6 +527,31 @@ class Headers(cabc.MutableMapping[str, str]):
             else:
                 self.set(key, value)
 
+    def __or__(
+        self, other: cabc.Mapping[str, t.Any | cabc.Collection[t.Any]]
+    ) -> te.Self:
+        if not isinstance(other, cabc.Mapping):
+            return NotImplemented
+
+        rv = self.copy()
+        rv.update(other)
+        return rv
+
+    def __ior__(
+        self,
+        other: (
+            cabc.Mapping[str, t.Any | cabc.Collection[t.Any]]
+            | cabc.Iterable[tuple[str, t.Any]]
+        ),
+    ) -> te.Self:
+        if not isinstance(other, (cabc.Mapping, cabc.Iterable)) or isinstance(
+            other, str
+        ):
+            return NotImplemented
+
+        self.update(other)
+        return self
+
     def to_wsgi_list(self) -> list[tuple[str, str]]:
         """Convert the headers into a list suitable for WSGI.
 
@@ -618,6 +646,9 @@ class EnvironHeaders(ImmutableHeadersMixin, Headers):  # type: ignore[misc]
                 yield key.replace("_", "-").title(), value
 
     def copy(self) -> t.NoReturn:
+        raise TypeError(f"cannot create {type(self).__name__!r} copies")
+
+    def __or__(self, other: t.Any) -> t.NoReturn:
         raise TypeError(f"cannot create {type(self).__name__!r} copies")
 
 

--- a/src/werkzeug/datastructures/mixins.py
+++ b/src/werkzeug/datastructures/mixins.py
@@ -76,6 +76,9 @@ class ImmutableListMixin:
 class ImmutableDictMixin(t.Generic[K, V]):
     """Makes a :class:`dict` immutable.
 
+    .. versionchanged:: 3.1
+        Disallow ``|=`` operator.
+
     .. versionadded:: 0.5
 
     :private:
@@ -115,6 +118,9 @@ class ImmutableDictMixin(t.Generic[K, V]):
         _immutable_error(self)
 
     def update(self, arg: t.Any, /, **kwargs: t.Any) -> t.NoReturn:
+        _immutable_error(self)
+
+    def __ior__(self, other: t.Any) -> t.NoReturn:
         _immutable_error(self)
 
     def pop(self, key: t.Any, default: t.Any = None) -> t.NoReturn:
@@ -168,6 +174,9 @@ class ImmutableHeadersMixin:
     hashable though since the only usecase for this datastructure
     in Werkzeug is a view on a mutable structure.
 
+    .. versionchanged:: 3.1
+        Disallow ``|=`` operator.
+
     .. versionadded:: 0.5
 
     :private:
@@ -198,6 +207,9 @@ class ImmutableHeadersMixin:
         _immutable_error(self)
 
     def update(self, arg: t.Any, /, **kwargs: t.Any) -> t.NoReturn:
+        _immutable_error(self)
+
+    def __ior__(self, other: t.Any) -> t.NoReturn:
         _immutable_error(self)
 
     def insert(self, pos: t.Any, value: t.Any) -> t.NoReturn:
@@ -232,6 +244,9 @@ def _always_update(f: F) -> F:
 
 class UpdateDictMixin(dict[K, V]):
     """Makes dicts call `self.on_update` on modifications.
+
+    .. versionchanged:: 3.1
+        Implement ``|=`` operator.
 
     .. versionadded:: 0.5
 
@@ -294,3 +309,9 @@ class UpdateDictMixin(dict[K, V]):
             super().update(**kwargs)
         else:
             super().update(arg, **kwargs)
+
+    @_always_update
+    def __ior__(  # type: ignore[override]
+        self, other: cabc.Mapping[K, V] | cabc.Iterable[tuple[K, V]]
+    ) -> te.Self:
+        return super().__ior__(other)

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -170,6 +170,9 @@ class MultiDict(TypeConversionDict[K, V]):
     :param mapping: the initial value for the :class:`MultiDict`.  Either a
                     regular dict, an iterable of ``(key, value)`` tuples
                     or `None`.
+
+    .. versionchanged:: 3.1
+        Implement ``|`` and ``|=`` operators.
     """
 
     def __init__(
@@ -434,6 +437,28 @@ class MultiDict(TypeConversionDict[K, V]):
         """
         for key, value in iter_multi_items(mapping):
             self.add(key, value)
+
+    def __or__(  # type: ignore[override]
+        self, other: cabc.Mapping[K, V | cabc.Collection[V]]
+    ) -> MultiDict[K, V]:
+        if not isinstance(other, cabc.Mapping):
+            return NotImplemented
+
+        rv = self.copy()
+        rv.update(other)
+        return rv
+
+    def __ior__(  # type: ignore[override]
+        self,
+        other: cabc.Mapping[K, V | cabc.Collection[V]] | cabc.Iterable[tuple[K, V]],
+    ) -> te.Self:
+        if not isinstance(other, (cabc.Mapping, cabc.Iterable)) or isinstance(
+            other, str
+        ):
+            return NotImplemented
+
+        self.update(other)
+        return self
 
     @t.overload
     def pop(self, key: K) -> V: ...


### PR DESCRIPTION
`MultiDict` and `Headers` implement `|` and `|=`. Similar to the `dict` implementation, `|` only works with other mappings, and `|=` works with mappings or iterators. `UpdateDictMixin` implements `|=` for updates. `ImmutableDictMixin` and `ImmutableHeadersMixin` disallow `|=`. `EnvironHeaders` disallows `|` as well to match its `copy`.

closes #2977 