### PR TITLE
more cache-control cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,12 +12,33 @@ Unreleased
     error. :issue:`2964`
 -   ``OrderedMultiDict`` and ``ImmutableOrderedMultiDict`` are deprecated.
     Use ``MultiDict`` and ``ImmutableMultiDict`` instead. :issue:`2968`
+-   Behavior of properties on ``request.cache_control`` and
+    ``response.cache_control`` has been significantly adjusted.
+
+    -   Dict values are always ``str | None``. Setting properties will convert
+        the value to a string. Setting a property to ``False`` is equivalent to
+        setting it to ``None``. Getting typed properties will return ``None`` if
+        conversion raises ``ValueError``, rather than the string.  :issue:`2980`
+    -   ``max_age`` is ``None`` if not present, rather than ``-1``.
+        :issue:`2980`
+    -   ``no_cache`` is a boolean for requests, it is ``False`` instead of
+        ``"*"`` when not present. It remains a string for responses.
+        issue:`2980`
+    -   ``max_stale`` is an int, it is ``None`` instead of ``"*"`` if it is
+        present with no value. ``max_stale_any`` is a boolean indicating if
+        the property is present regardless of if it has a value. :issue:`2980`
+    -   ``no_transform`` is a boolean. Previously it was mistakenly always
+        ``None``. :issue:`2881`
+    -   ``min_fresh`` is ``None`` if not present instead of ``"*"``.
+        :issue:`2881`
+    -   ``private`` is a boolean, it is ``False`` instead of ``"*"`` when not
+        present. :issue:`2980`
+    -   Added the ``must_understand`` property. :issue:`2881`
+    -   Added the ``stale_while_revalidate``, and ``stale_if_error``
+        properties. :issue:`2948`
+    -   Type annotations more accurately reflect the values. :issue:`2881`
+
 -   Support Cookie CHIPS (Partitioned Cookies). :issue:`2797`
--   ``CacheControl.no_transform`` is a boolean when present. ``min_fresh`` is
-    ``None`` when not present. Added the ``must_understand`` attribute. Fixed
-    some typing issues on cache control. :issue:`2881`
--   Add ``stale_while_revalidate`` and ``stale_if_error`` properties to
-    ``ResponseCacheControl``. :issue:`2948`
 -   Add 421 ``MisdirectedRequest`` HTTP exception. :issue:`2850`
 -   Increase default work factor for PBKDF2 to 1,000,000 iterations.
     :issue:`2969`

--- a/docs/datastructures.rst
+++ b/docs/datastructures.rst
@@ -93,11 +93,13 @@ HTTP Related
 
 .. autoclass:: RequestCacheControl
     :members:
-    :inherited-members:
+    :inherited-members: ImmutableDictMixin, CallbackDict
+    :member-order: groupwise
 
 .. autoclass:: ResponseCacheControl
     :members:
-    :inherited-members:
+    :inherited-members: CallbackDict
+    :member-order: groupwise
 
 .. autoclass:: ETags
    :members:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1000,7 +1000,7 @@ class TestCacheControl:
         cc.no_cache = None
         assert cc.no_cache is None
         cc.no_cache = False
-        assert cc.no_cache is False
+        assert cc.no_cache is None
 
     def test_no_transform(self):
         cc = ds.RequestCacheControl([("no-transform", None)])

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -121,22 +121,22 @@ class TestHTTPUtility:
     def test_cache_control_header(self):
         cc = http.parse_cache_control_header("max-age=0, no-cache")
         assert cc.max_age == 0
-        assert cc.no_cache
+        assert cc.no_cache is True
         cc = http.parse_cache_control_header(
             'private, community="UCI"', None, datastructures.ResponseCacheControl
         )
-        assert cc.private
+        assert cc.private is True
         assert cc["community"] == "UCI"
 
         c = datastructures.ResponseCacheControl()
         assert c.no_cache is None
-        assert c.private is None
+        assert c.private is False
         c.no_cache = True
         assert c.no_cache == "*"
         c.private = True
-        assert c.private == "*"
+        assert c.private is True
         del c.private
-        assert c.private is None
+        assert c.private is False
         # max_age is an int, other types are converted
         c.max_age = 3.1
         assert c.max_age == 3


### PR DESCRIPTION
This has been on my mind for years. Every time something about the cache-control header comes up and I look at the code, it struck me that there were weird types and values being assigned to attributes. closes #2980

Originally, I wanted to ditch ``cache_control_property`` and implement everything as direct properties, or a few descriptors for different types instead of the overloaded `get`/`set` helpers that handle a bunch of different scenarios. I've decided to hold off on this for now. ``cache_control_property`` is useful since custom attributes are part of the spec. The arguments do represent the different cases: a key present without a value, a value of a specific type. I've added a better docstring generator for the properties, so the types and behavior of the attribute gets documented instead of "accessor for `max-age`". It's also possible to pass in a custom doc for cases where the generator isn't enough, such as for `max_stale`.

This consolidates and organizes the changelog entries for #2881 and #2948. #2881 already began fixing some types/values, and this is going in a feature release, so I felt comfortable enough extending this to the rest of the properties. There was no obvious way to deprecate the old behaviors, but searches suggest they weren't being used often, or in ways that would be affected. The fix if something does break is relatively simple, changing what value is being tested.

Dict values are always ``str | None``. Previously, setting typed properties would set the typed value in the dict, which only worked because converting to a header converted to string. Now they're converted to their type, then to a string. This makes the type annotation when working with the dict interface more useful.

Setting a property to ``False`` is equivalent to setting it to ``None``. This makes `ResponseCacheControl.no_cache = True` type check properly even thought it ends up being a string value.

Getting typed properties will return ``None`` if conversion raises ``ValueError``, rather than the string. This is consistent with how `MultiDict.get(type=)` works.

`max_age` is `None` if not present, rather than `-1`. This makes it consistent with other properties, and makes more sense in a boolean context.

`no_cache` was previously a string for both request and response. But the spec says that it is a boolean with no value for requests. For requests, it is `False` rather than `"*"` when not present.

`max_stale` is a weird part of the spec. It can either be present with no value, have an int value, or not be present. The previous implemenation treated it as `int | str | None`, where the only string value was `"*"` if it was present with no value. As explained in #2980, this does not make type checkers happy. Split this into two properties, `max_stale` is the int value if present, or `None` if not present or no value. `max_stale_any` is a bool that only indicates if it was present or not, regardless of value.

#2881 made `no_transform` is a boolean. Previously it was mistakenly always `None`.

#2881 made `min_fresh` `None` if not present instead of `"*"`.

`private` is a boolean, it is `False` instead of `"*"` when not present.

#2881 added the `must_understand` property.

#2948 added the `stale_while_revalidate` and `stale_if_error` properties. This PR moves `stale_if_error` to be on both request and response.

#2881 and this PR generally cleaned up type annotations.