### PR TITLE
more cache-control cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,21 +18,19 @@ Unreleased
     -   Dict values are always ``str | None``. Setting properties will convert
         the value to a string. Setting a property to ``False`` is equivalent to
         setting it to ``None``. Getting typed properties will return ``None`` if
-        conversion raises ``ValueError``, rather than the string.  :issue:`2980`
-    -   ``max_age`` is ``None`` if not present, rather than ``-1``.
+        conversion raises ``ValueError``, rather than the string. :issue:`2980`
+    -   ``max_age`` is ``None`` if present without a value, rather than ``-1``.
         :issue:`2980`
-    -   ``no_cache`` is a boolean for requests, it is ``False`` instead of
-        ``"*"`` when not present. It remains a string for responses.
-        issue:`2980`
-    -   ``max_stale`` is an int, it is ``None`` instead of ``"*"`` if it is
-        present with no value. ``max_stale_any`` is a boolean indicating if
-        the property is present regardless of if it has a value. :issue:`2980`
+    -   ``no_cache`` is a boolean for requests, it is ``True`` instead of
+        ``"*"`` when present. It remains a string for responses. :issue:`2980`
+    -   ``max_stale`` is ``True`` if present without a value, rather
+        than ``"*"``. :issue:`2980`
     -   ``no_transform`` is a boolean. Previously it was mistakenly always
         ``None``. :issue:`2881`
-    -   ``min_fresh`` is ``None`` if not present instead of ``"*"``.
-        :issue:`2881`
-    -   ``private`` is a boolean, it is ``False`` instead of ``"*"`` when not
-        present. :issue:`2980`
+    -   ``min_fresh`` is ``None`` if present without a value, rather than
+        ``"*"``. :issue:`2881`
+    -   ``private`` is ``True`` if present without a value, rather than ``"*"``.
+        :issue:`2980`
     -   Added the ``must_understand`` property. :issue:`2881`
     -   Added the ``stale_while_revalidate``, and ``stale_if_error``
         properties. :issue:`2948`

--- a/src/werkzeug/datastructures/cache_control.py
+++ b/src/werkzeug/datastructures/cache_control.py
@@ -171,23 +171,24 @@ class RequestCacheControl(ImmutableDictMixin[str, t.Optional[str]], _CacheContro
         ``ValueError``, rather than the string.
 
     .. versionchanged:: 3.1
-       ``max_age`` is ``None`` if not present, rather than ``-1``.
+       ``max_age`` is ``None`` if present without a value, rather
+       than ``-1``.
 
     .. versionchanged:: 3.1
-        ``no_cache`` is a boolean, it is ``False`` instead of ``"*"``
-        when not present.
+        ``no_cache`` is a boolean, it is ``True`` instead of ``"*"``
+        when present.
 
     .. versionchanged:: 3.1
-        ``max_stale`` is an int, it is ``None`` instead of ``"*"`` if it is
-        present with no value. ``max_stale_any`` is a boolean indicating if
-        the property is present regardless of if it has a value.
+        ``max_stale`` is ``True`` if present without a value, rather
+        than ``"*"``.
 
     .. versionchanged:: 3.1
        ``no_transform`` is a boolean. Previously it was mistakenly
        always ``None``.
 
     .. versionchanged:: 3.1
-       ``min_fresh`` is ``None`` if not present instead of ``"*"``.
+       ``min_fresh`` is ``None`` if present without a value, rather
+       than ``"*"``.
 
     .. versionchanged:: 2.1
         Setting int properties such as ``max_age`` will convert the
@@ -198,26 +199,10 @@ class RequestCacheControl(ImmutableDictMixin[str, t.Optional[str]], _CacheContro
     """
 
     no_cache: bool = cache_control_property("no-cache", None, bool)
-    max_stale: int | None = cache_control_property(
+    max_stale: int | t.Literal[True] | None = cache_control_property(
         "max-stale",
-        None,
+        True,
         int,
-        doc="""The ``max-stale`` attribute if it has a value. A ``int``, or
-        ``None`` if not present or no value.
-
-        This attribute can also be present without a value. To check that, use
-        :attr:`max_stale_any`.
-        """,
-    )
-    max_stale_any: bool = cache_control_property(
-        "max-stale",
-        None,
-        bool,
-        doc="""The ``max-stale`` attribute presence regardless of value. A
-        ``bool``, either present or not.
-
-        To check the value of the attribute if present, use :attr:`max_stale`.
-        """,
     )
     min_fresh: int | None = cache_control_property("min-fresh", None, int)
     only_if_cached: bool = cache_control_property("only-if-cached", None, bool)
@@ -241,12 +226,16 @@ class ResponseCacheControl(_CacheControl):
         ``ValueError``, rather than the string.
 
     .. versionchanged:: 3.1
-        ``private`` is a boolean, it is ``False`` instead of ``"*"``
-        when not present.
+        ``no_cache`` is ``True`` if present without a value, rather than
+        ``"*"``.
 
     .. versionchanged:: 3.1
-       ``no_transform`` is a boolean. Previously it was mistakenly always
-       ``None``.
+        ``private`` is ``True`` if present without a value, rather than
+        ``"*"``.
+
+    .. versionchanged:: 3.1
+       ``no_transform`` is a boolean. Previously it was mistakenly
+       always ``None``.
 
     .. versionchanged:: 3.1
         Added the ``must_understand``, ``stale_while_revalidate``, and
@@ -263,9 +252,13 @@ class ResponseCacheControl(_CacheControl):
        Request-only properties are not present on this response class.
     """
 
-    no_cache: str | bool | None = cache_control_property("no-cache", "*", None)
+    no_cache: str | t.Literal[True] | None = cache_control_property(
+        "no-cache", True, None
+    )
     public: bool = cache_control_property("public", None, bool)
-    private: bool = cache_control_property("private", None, bool)
+    private: str | t.Literal[True] | None = cache_control_property(
+        "private", True, None
+    )
     must_revalidate: bool = cache_control_property("must-revalidate", None, bool)
     proxy_revalidate: bool = cache_control_property("proxy-revalidate", None, bool)
     s_maxage: int | None = cache_control_property("s-maxage", None, int)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -125,24 +125,24 @@ class TestHTTPUtility:
         cc = http.parse_cache_control_header(
             'private, community="UCI"', None, datastructures.ResponseCacheControl
         )
-        assert cc.private is True
+        assert cc.private
         assert cc["community"] == "UCI"
 
         c = datastructures.ResponseCacheControl()
         assert c.no_cache is None
-        assert c.private is False
+        assert c.private is None
         c.no_cache = True
-        assert c.no_cache == "*"
+        assert c.no_cache and c.no_cache is True
         c.private = True
-        assert c.private is True
+        assert c.private and c.private is True
         del c.private
-        assert c.private is False
+        assert not c.private and c.private is None
         # max_age is an int, other types are converted
         c.max_age = 3.1
-        assert c.max_age == 3
+        assert c.max_age == 3 and c["max-age"] == "3"
         del c.max_age
         c.s_maxage = 3.1
-        assert c.s_maxage == 3
+        assert c.s_maxage == 3 and c["s-maxage"] == "3"
         del c.s_maxage
         assert c.to_header() == "no-cache"
 


### PR DESCRIPTION
A few additional cleanups based on #2982 reviewing #2981. Most significantly, use `t.Literal[True]` instead of `str` for properties that can be present with an optional value. This matches other boolean properties better, and makes type checkers happier.

fixes #2982