### PR TITLE
fix `str(request.headers)`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 3.1.1
 
 Unreleased
 
+-   Fix an issue that caused ``str(Request.headers)`` to always appear empty.
+    :issue:`2985`
+
 
 Version 3.1.0
 -------------

--- a/src/werkzeug/datastructures/headers.py
+++ b/src/werkzeug/datastructures/headers.py
@@ -568,13 +568,13 @@ class Headers(cabc.MutableMapping[str, str]):
     def __str__(self) -> str:
         """Returns formatted headers suitable for HTTP transmission."""
         strs = []
-        for key, value in self._list:
+        for key, value in self.to_wsgi_list():
             strs.append(f"{key}: {value}")
         strs.append("\r\n")
         return "\r\n".join(strs)
 
     def __repr__(self) -> str:
-        return f"{type(self).__name__}({self._list!r})"
+        return f"{type(self).__name__}({list(self)!r})"
 
 
 def _options_header_vkw(value: str, kw: dict[str, t.Any]) -> str:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -885,6 +885,10 @@ class TestEnvironHeaders:
         with pytest.raises(TypeError):
             headers |= {"y": "2"}
 
+    def test_str(self) -> None:
+        headers = ds.EnvironHeaders({"CONTENT_LENGTH": "50", "HTTP_HOST": "test"})
+        assert str(headers) == "Content-Length: 50\r\nHost: test\r\n\r\n"
+
 
 class TestHeaderSet:
     storage_class = ds.HeaderSet


### PR DESCRIPTION
Revert the refactored lines in `Headers.__str__` and `Headers.__repr__` to iterate instead of using the internal list directly. Add a test for `str(EnvironHeaders)`.

fixes #2985 