### PR TITLE
Expose redirect path in RequestRedirect

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.2.0
 
 Unreleased
 
+- The ``RequestRedirect`` exception now exposes ``new_path`` that
+  contains the request path used to compute the ``new_url``.
 
 Version 3.1.2
 -------------

--- a/src/werkzeug/routing/exceptions.py
+++ b/src/werkzeug/routing/exceptions.py
@@ -34,9 +34,10 @@ class RequestRedirect(HTTPException, RoutingException):
 
     code = 308
 
-    def __init__(self, new_url: str) -> None:
+    def __init__(self, new_url: str, new_path: t.Optional[str] = None) -> None:
         super().__init__(new_url)
         self.new_url = new_url
+        self.new_path = new_path
 
     def get_response(
         self,
@@ -98,7 +99,8 @@ class BuildError(RoutingException, LookupError):
                         str(rule.endpoint),
                         str(self.endpoint),
                     ).ratio(),
-                    0.01 * bool(set(self.values or ()).issubset(rule.arguments)),
+                    0.01 * bool(set(self.values or ()
+                                    ).issubset(rule.arguments)),
                     0.01 * bool(rule.methods and self.method in rule.methods),
                 ]
             )
@@ -134,7 +136,8 @@ class BuildError(RoutingException, LookupError):
                         f" Did you forget to specify values {sorted(missing_values)!r}?"
                     )
             else:
-                message.append(f" Did you mean {self.suggested.endpoint!r} instead?")
+                message.append(
+                    f" Did you mean {self.suggested.endpoint!r} instead?")
         return "".join(message)
 
 


### PR DESCRIPTION
When we raise the RequestRedirect exception
we have already computed the new url that
should be redirected to in the exception
(new_url) but we don't pass the the
new path that we used to compute the url.

This causes another layer of redirection
in depending code that needs to urlparse()
the url to get the path we already have
the data for.

This adds new_path to the RequestRedirect
exception and populates it with the path
used when computing new_url.

Fixes: #3000
