### PR TITLE
fix Weighting calculation for path converters and add tests

### DIFF
--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -623,6 +623,7 @@ class Rule(RuleFactory):
                 self._trace.append((False, data["static"]))
                 content += data["static"] if static else re.escape(data["static"])
 
+            haspath = False
             if data["variable"] is not None:
                 if static:
                     # Switching content to represent regex, hence the need to escape
@@ -640,6 +641,7 @@ class Rule(RuleFactory):
                 convertor_number += 1
                 argument_weights.append(convobj.weight)
                 self._trace.append((True, data["variable"]))
+                haspath = data["converter"] == "path"
 
             if data["slash"] is not None:
                 self._trace.append((False, "/"))
@@ -651,7 +653,7 @@ class Rule(RuleFactory):
                     weight = Weighting(
                         -len(static_weights),
                         static_weights,
-                        -len(argument_weights),
+                        float("+inf") if haspath else len(argument_weights),
                         argument_weights,
                     )
                     yield RulePart(
@@ -681,7 +683,7 @@ class Rule(RuleFactory):
         weight = Weighting(
             -len(static_weights),
             static_weights,
-            -len(argument_weights),
+            float("+inf") if haspath else len(argument_weights),
             argument_weights,
         )
         yield RulePart(


### PR DESCRIPTION
Fix issue #2924 where Rules with dynamic elements would take priority over rules with static elements of the same length.

The underlying issue was that the ordering for rules was backwards with regard to number of argument weights. In order to ensure that static elements match first the shortest rule must be tested first.

To ensure that a RulePart that contains a path converter does not incorrectly take priority over other RuleParts that are part of other Rules that should have priority, RuleParts containing a path converter are assigned an infinite number of argument weights because they can consume an arbitrary number of url path elements when matching.

With this change, two consecutive path converters give priority to the first converter. In general two consecutive path converters with different names cannot have consistent or predicatable behavior (where would you cut?). Tests are updated accordingly. Might consider making back to back path converters an error.

fixes #2924
