### PR TITLE
Debugger security enhancements

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -487,7 +487,7 @@ class DebuggedApplication:
             auth = True
 
         # If we failed too many times, then we're locked out.
-        elif self._failed_pin_auth.value > 10:
+        elif self._failed_pin_auth.value >= 10:
             exhausted = True
 
         # Otherwise go through pin based authentication

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -438,6 +438,11 @@ class DebuggedApplication:
         """
         if self.pin is None:
             return True
+
+         # If we failed too many times, then we're locked out.
+        if self._failed_pin_auth.value >= 10:
+            return False
+
         val = parse_cookie(environ).get(self.pin_cookie_name)
         if not val or "|" not in val:
             return False


### PR DESCRIPTION
This pull request introduces 2 changes:

- Number of pin-based failed authentication attempts before the debugger is locked (brute force protection) has been reduced from 11 to 10. This was because 11 seemed like an odd number to choose and I think it's likely that the intention was 10 but it is off-by-one.
- Even when the debugger was locked due to too many failed authentication attempts, it was still possible to authenticate using a cookie. This change prevents cookie-based authentication when the debugger is locked for pin-based authentication.

These changes enhance the security of the debugger because it is possible to generate a cookie if knowledge of the environment is known (i.e. APPNAME, CGROUP, FLASKPATH, MACADDRESS, MACHINEID, MODULENAME & SERVICEUSER). It may be possible to access enough information about the environment if the application using werkzeug contains a vulnerability such as arbitrary file read, e.g. using path traversal. This could result in the debugger being used to turn a medium-risk vulnerability into a critical-risk one (i.e. remote code execution).

[An exploit module for Metasploit is publicly available](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/multi/http/werkzeug_debug_rce.md) that will generate a cookie when provided with the required information (disclaimer: I am the author of the module, but I also want to improve the security of werkzeug, even though it will make the exploit less effective).