### PR TITLE
Add explicit configuration in .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: docs/conf.py
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Automated checks on pull requests were failing because of readthedoc's deprecation of projects using Sphinx or MkDocs without an explicit configuration in the .readthedocs.yaml configuration file.

https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/