### PR TITLE
fix(wrappers/request): use utf8 to encode query_string

### DIFF
--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -122,7 +122,7 @@ class Request(_SansIORequest):
             server=_get_server(environ),
             root_path=_wsgi_decoding_dance(environ.get("SCRIPT_NAME") or ""),
             path=_wsgi_decoding_dance(environ.get("PATH_INFO") or ""),
-            query_string=environ.get("QUERY_STRING", "").encode("latin1"),
+            query_string=environ.get("QUERY_STRING", "").encode(),
             headers=EnvironHeaders(environ),
             remote_addr=environ.get("REMOTE_ADDR"),
         )

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1031,6 +1031,11 @@ def test_values():
     assert "b" not in r.values
 
 
+def test_query_string_encoding():
+    r = wrappers.Request({"QUERY_STRING": "q=ß"})
+    assert r.values["q"] == "ß"
+
+
 def test_storage_classes():
     class MyRequest(wrappers.Request):
         dict_storage_class = dict


### PR DESCRIPTION
The constructor of `wrappers.request.Request` was using `latin1` when encoding the `QUERY_STRING` environment variable into the `query_string` attribute. However, elsewhere in this class/its super class, the bytes would be decoded again without specifying an encoding (so the default, `utf8`, would get used).

This works fine, *unless* the query string contains characters that are encoded differently between Latin-1 and UTF-8.

This PR fixes the bug by not using `latin1`, but using the default (`utf8`).