### PR TITLE
Add natural_types() return function if flat==None in MultiDict.to_dict()

### DIFF
--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -372,6 +372,13 @@ class MultiDict(TypeConversionDict[K, V]):
         for key, values in super().items():  # type: ignore[assignment]
             yield key, list(values)
 
+    def natural_types(self):
+        """Return an iterator of ``(key, value)`` pairs where values is the list
+        of all values associated with the key, and the values are either lists or
+        single values depending on the value of the input."""
+        for key, values in dict.items(self):
+            yield key, values if len(values) > 1 else values[0]
+
     def values(self) -> cabc.Iterable[V]:  # type: ignore[override]
         """Returns an iterator of the first value on every key's value list."""
         values: list[V]
@@ -401,7 +408,7 @@ class MultiDict(TypeConversionDict[K, V]):
     def to_dict(self) -> dict[K, V]: ...
     @t.overload
     def to_dict(self, flat: t.Literal[False]) -> dict[K, list[V]]: ...
-    def to_dict(self, flat: bool = True) -> dict[K, V] | dict[K, list[V]]:
+    def to_dict(self, flat: bool | None = True) -> dict[K, V] | dict[K, list[V]]:
         """Return the contents as regular dict.  If `flat` is `True` the
         returned dict will only have the first item present, if `flat` is
         `False` all values will be returned as lists.
@@ -411,9 +418,12 @@ class MultiDict(TypeConversionDict[K, V]):
                      contain the first value for each key.
         :return: a :class:`dict`
         """
-        if flat:
+        if flat == True:
             return dict(self.items())
-        return dict(self.lists())
+        elif flat == None:
+            return dict(self.natural_types())
+        else:
+            return dict(self.lists())
 
     def update(  # type: ignore[override]
         self,


### PR DESCRIPTION
In forms (e.g. through Flask and HTML), often there are both single inputs (such as text inputs and checkboxes) and multiselect inputs. To be able to retrieve both of these at the moment, the inputs must be retrieved with:

```python
MultiDict.form.to_dict(flat=False)
```
which is called using:
```python
Flask.request.form.to_dict(flat=False)
```

This however turns all of the inputs into lists, which then requires a lot of accessing the `[0]`th index of single-input inputs. To fix this without altering the pre-existing interface usage, I recommend allowing a `None` type to be passed in for the flat parameter, which will prompt for the so-called 'natural type' of the inputs to be returned (the single input if it is a single input, and the list if it is a list). See my issue: https://github.com/pallets/werkzeug/issues/3023

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
