### PR TITLE
Add required sphinx configuration path for readthedocs

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,10 +7,10 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: 3.x
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-    - uses: pre-commit-ci/lite-action@9d882e7a565f7008d4faf128f27d1cb6503d4ebf # v1.0.2
+    - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
       if: ${{ !cancelled() }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
       hash: ${{ steps.hash.outputs.hash }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.x'
           cache: pip
@@ -23,7 +23,7 @@ jobs:
       - name: generate hash
         id: hash
         run: cd dist && echo "hash=$(sha256sum * | base64 -w0)" >> $GITHUB_OUTPUT
-      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           path: ./dist
   provenance:
@@ -33,7 +33,7 @@ jobs:
       id-token: write
       contents: write
     # Can't pin with hash due to how this workflow works.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: ${{ needs.build.outputs.hash }}
   create-release:
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       - name: create release
         run: >
           gh release create --draft --repo ${{ github.repository }}
@@ -63,11 +63,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      - uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.10.3
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+      - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
           packages-dir: artifact/
-      - uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.10.3
+      - uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           packages-dir: artifact/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
           - {name: PyPy, python: 'pypy-3.10', tox: pypy310}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
@@ -35,13 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.x'
           cache: pip
           cache-dependency-path: requirements*/*.txt
       - name: cache mypy
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ./.mypy_cache
           key: mypy|${{ hashFiles('pyproject.toml') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.11.6
     hooks:
       - id: ruff
       - id: ruff-format

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,4 +10,5 @@ python:
       path: .
 sphinx:
   builder: dirhtml
+  configuration: docs/conf.py
   fail_on_warning: true

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.2.post1
     # via -r build.in
-packaging==24.1
+packaging==24.2
     # via build
 pyproject-hooks==1.2.0
     # via build

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,191 +6,198 @@
 #
 alabaster==1.0.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
-babel==2.16.0
+babel==2.17.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
-cachetools==5.5.0
+cachetools==5.5.2
     # via tox
-certifi==2024.8.30
+certifi==2025.1.31
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
     #   cryptography
 cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via tox
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   requests
 colorama==0.4.6
     # via tox
-cryptography==43.0.3
-    # via -r tests.txt
+cryptography==44.0.2
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
 distlib==0.3.9
     # via virtualenv
 docutils==0.21.2
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 ephemeral-port-reserve==1.1.4
-    # via -r tests.txt
-filelock==3.16.1
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv
-identify==2.6.1
+identify==2.6.9
     # via pre-commit
 idna==3.10
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   requests
 imagesize==1.4.1
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
-    #   -r tests.txt
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   pytest
-jinja2==3.1.4
+jinja2==3.1.6
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 markupsafe==3.0.2
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   jinja2
-mypy==1.13.0
-    # via -r typing.txt
+mypy==1.15.0
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
 mypy-extensions==1.0.0
     # via
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   mypy
 nodeenv==1.9.1
     # via
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   pre-commit
     #   pyright
-packaging==24.1
+packaging==24.2
     # via
-    #   -r docs.txt
-    #   -r tests.txt
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   pallets-sphinx-themes
     #   pyproject-api
     #   pytest
     #   sphinx
     #   tox
 pallets-sphinx-themes==2.3.0
-    # via -r docs.txt
-platformdirs==4.3.6
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
+platformdirs==4.3.7
     # via
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r tests.txt
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   pytest
     #   tox
-pre-commit==4.0.1
+pre-commit==4.2.0
     # via -r dev.in
 pycparser==2.22
     # via
-    #   -r tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
-pyproject-api==1.8.0
+pyproject-api==1.9.0
     # via tox
-pyright==1.1.386
-    # via -r typing.txt
-pytest==8.3.3
+pyright==1.1.399
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
+pytest==8.3.5
     # via
-    #   -r tests.txt
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   pytest-timeout
 pytest-timeout==2.3.1
-    # via -r tests.txt
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
 pyyaml==6.0.2
     # via pre-commit
 requests==2.32.3
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
+    #   sphinx
+roman-numerals-py==3.1.0
+    # via
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 snowballstemmer==2.2.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
-sphinx==8.1.3
+sphinx==8.2.3
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   pallets-sphinx-themes
     #   sphinx-notfound-page
     #   sphinxcontrib-log-cabinet
-sphinx-notfound-page==1.0.4
+sphinx-notfound-page==1.1.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   pallets-sphinx-themes
 sphinxcontrib-applehelp==2.0.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 sphinxcontrib-devhelp==2.0.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 sphinxcontrib-jsmath==1.0.1
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 sphinxcontrib-log-cabinet==1.0.1
-    # via -r docs.txt
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
 sphinxcontrib-qthelp==2.0.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   sphinx
-tox==4.23.2
+tox==4.25.0
     # via -r dev.in
 types-contextvars==2.4.7.3
-    # via -r typing.txt
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
 types-dataclasses==0.6.6
-    # via -r typing.txt
-types-setuptools==75.2.0.20241019
-    # via -r typing.txt
-typing-extensions==4.12.2
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
+types-setuptools==78.1.0.20250329
+    # via -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
+typing-extensions==4.13.2
     # via
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
     #   mypy
     #   pyright
-urllib3==2.2.3
+urllib3==2.4.0
     # via
-    #   -r docs.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/docs.txt
     #   requests
-virtualenv==20.27.0
+virtualenv==20.30.0
     # via
     #   pre-commit
     #   tox
-watchdog==5.0.3
+watchdog==6.0.0
     # via
-    #   -r tests.txt
-    #   -r typing.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/tests.txt
+    #   -r /Users/pgjones/oss_code/werkzeug/requirements/typing.txt
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -6,11 +6,11 @@
 #
 alabaster==1.0.0
     # via sphinx
-babel==2.16.0
+babel==2.17.0
     # via sphinx
-certifi==2024.8.30
+certifi==2025.1.31
     # via requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 docutils==0.21.2
     # via sphinx
@@ -18,29 +18,31 @@ idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
-jinja2==3.1.4
+jinja2==3.1.6
     # via sphinx
 markupsafe==3.0.2
     # via jinja2
-packaging==24.1
+packaging==24.2
     # via
     #   pallets-sphinx-themes
     #   sphinx
 pallets-sphinx-themes==2.3.0
     # via -r docs.in
-pygments==2.18.0
+pygments==2.19.1
     # via sphinx
 requests==2.32.3
     # via sphinx
+roman-numerals-py==3.1.0
+    # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==8.1.3
+sphinx==8.2.3
     # via
     #   -r docs.in
     #   pallets-sphinx-themes
     #   sphinx-notfound-page
     #   sphinxcontrib-log-cabinet
-sphinx-notfound-page==1.0.4
+sphinx-notfound-page==1.1.0
     # via pallets-sphinx-themes
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -56,5 +58,5 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-urllib3==2.2.3
+urllib3==2.4.0
     # via requests

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,23 +8,23 @@ cffi==1.17.1
     # via
     #   -r tests.in
     #   cryptography
-cryptography==43.0.3
+cryptography==44.0.2
     # via -r tests.in
 ephemeral-port-reserve==1.1.4
     # via -r tests.in
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-packaging==24.1
+packaging==24.2
     # via pytest
 pluggy==1.5.0
     # via pytest
 pycparser==2.22
     # via cffi
-pytest==8.3.3
+pytest==8.3.5
     # via
     #   -r tests.in
     #   pytest-timeout
 pytest-timeout==2.3.1
     # via -r tests.in
-watchdog==5.0.3
+watchdog==6.0.0
     # via -r tests.in

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -4,31 +4,34 @@
 #
 #    pip-compile typing.in
 #
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-mypy==1.13.0
+mypy==1.15.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
     # via pyright
-packaging==24.1
+packaging==24.2
     # via pytest
 pluggy==1.5.0
     # via pytest
-pyright==1.1.386
+pyright==1.1.399
     # via -r typing.in
-pytest==8.3.3
+pytest==8.3.5
     # via -r typing.in
 types-contextvars==2.4.7.3
     # via -r typing.in
 types-dataclasses==0.6.6
     # via -r typing.in
-types-setuptools==75.2.0.20241019
+types-setuptools==78.1.0.20250329
     # via -r typing.in
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via
     #   mypy
     #   pyright
-watchdog==5.0.3
+watchdog==6.0.0
     # via -r typing.in
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -36,9 +36,9 @@ def _wsgi_encoding_dance(s: str) -> str:
 
 def _get_environ(obj: WSGIEnvironment | Request) -> WSGIEnvironment:
     env = getattr(obj, "environ", obj)
-    assert isinstance(
-        env, dict
-    ), f"{type(obj).__name__!r} is not a WSGI environment (has to be a dict)"
+    assert isinstance(env, dict), (
+        f"{type(obj).__name__!r} is not a WSGI environment (has to be a dict)"
+    )
     return env
 
 

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -249,8 +249,7 @@ class DebugTraceback:
                 chained_exc = current.__cause__
             elif current.__context__ is not None and not current.__suppress_context__:
                 chained_msg = (
-                    "During handling of the above exception, another"
-                    " exception occurred"
+                    "During handling of the above exception, another exception occurred"
                 )
                 chained_exc = current.__context__
             else:
@@ -410,7 +409,7 @@ class DebugFrameSummary(traceback.FrameSummary):
             if cls == "current" and colno and end_colno:
                 arrow = (
                     f'\n<span class="ws">{" " * prefix}</span>'
-                    f'{" " * (colno - prefix)}{"^" * (end_colno - colno)}'
+                    f"{' ' * (colno - prefix)}{'^' * (end_colno - colno)}"
                 )
             else:
                 arrow = ""

--- a/src/werkzeug/exceptions.py
+++ b/src/werkzeug/exceptions.py
@@ -181,8 +181,7 @@ class BadRequest(HTTPException):
 
     code = 400
     description = (
-        "The browser (or proxy) sent a request that this server could "
-        "not understand."
+        "The browser (or proxy) sent a request that this server could not understand."
     )
 
 
@@ -208,10 +207,7 @@ class BadRequestKeyError(BadRequest, KeyError):
     @property  # type: ignore
     def description(self) -> str:
         if self.show_exception:
-            return (
-                f"{self._description}\n"
-                f"{KeyError.__name__}: {KeyError.__str__(self)}"
-            )
+            return f"{self._description}\n{KeyError.__name__}: {KeyError.__str__(self)}"
 
         return self._description
 

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -118,7 +118,7 @@ def parse_converter_args(argstr: str) -> tuple[tuple[t.Any, ...], dict[str, t.An
     for item in _converter_args_re.finditer(argstr):
         if item.start() != position:
             raise ValueError(
-                f"Cannot parse converter argument '{argstr[position:item.start()]}'"
+                f"Cannot parse converter argument '{argstr[position : item.start()]}'"
             )
 
         value = item.group("stringval")

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -156,8 +156,7 @@ class TestDebugRepr:
                 raise Exception("broken!")
 
         assert debug_repr(Foo()) == (
-            '<span class="brokenrepr">&lt;broken repr (Exception: '
-            "broken!)&gt;</span>"
+            '<span class="brokenrepr">&lt;broken repr (Exception: broken!)&gt;</span>'
         )
 
 


### PR DESCRIPTION
As per https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
