### PR TITLE
fix: Request.json type annotation

### DIFF
--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -542,7 +542,7 @@ class Request(_SansIORequest):
     json_module = json
 
     @property
-    def json(self) -> t.Any | None:
+    def json(self) -> t.Any:
         """The parsed JSON data if :attr:`mimetype` indicates JSON
         (:mimetype:`application/json`, see :attr:`is_json`).
 


### PR DESCRIPTION
The `json` property calls `get_json()` with default arguments. The argument `silent = False` is used, so `None` will never be returned. See the first overload of `get_json()`.