### PR TITLE
Fix invalid exception handling in the URL Routing docs

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -39,7 +39,7 @@ Here is a simple example which could be the URL definition for a blog::
         urls = url_map.bind_to_environ(environ)
         try:
             endpoint, args = urls.match()
-        except HTTPException, e:
+        except HTTPException as e:
             return e(environ, start_response)
         start_response('200 OK', [('Content-Type', 'text/plain')])
         return [f'Rule points to {endpoint!r} with arguments {args!r}'.encode()]


### PR DESCRIPTION
`except HTTPException, e:` is the Python 2 syntax of capturing the exception value and it doesn't work in Python 3 (it's valid syntax in 3.14 but means something else).  Seems like it wasn't updated.