### PR TITLE
reload as soon as trigger_reload is called

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 -   The debugger pin fails after 10 attempts instead of 11. :pr:`3020`
 -   The multipart form parser handles a ``\r\n`` sequence at a chunk boundary.
     :issue:`3065`
+-   Improve CPU usage during Watchdog reloader. :issue:`3054`
 
 
 Version 3.1.3


### PR DESCRIPTION
the watchdog reloader waits until the end of the `ReloaderLoop.interval` to actually reload
by replacing `time.sleep` with a timeout on `threading.Event`, we wake up just in time
this allows increasing the interval to reduce idle CPU usage

fixes #3054

<!--
Ensure each step in CONTRIBUTING.rst is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
