### PR TITLE
handle chunked input that splits `\r\n`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 3.1.4
 Unreleased
 
 -   The debugger pin fails after 10 attempts instead of 11. :pr:`3020`
+-   The multipart form parser handles a ``\r\n`` sequence at a chunk boundary.
+    :issue:`3065`
 
 
 Version 3.1.3

--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -79,6 +79,9 @@ class MultipartDecoder:
 
     The part data is returned as available to allow the caller to save
     the data from memory to disk, if desired.
+
+    .. versionchanged:: 3.1.4
+        Handle chunks that split a``\r\n`` sequence.
     """
 
     def __init__(
@@ -282,6 +285,11 @@ class MultipartDecoder:
             else:
                 data_end = del_index = self.last_newline(data[data_start:]) + data_start
             more_data = match is None
+
+        # Keep \r\n sequence intact rather than splitting across chunks.
+        if data_end > data_start and data[data_end - 1] == 0x0D:
+            data_end -= 1
+            del_index -= 1
 
         return bytes(data[data_start:data_end]), del_index, more_data
 

--- a/tests/sansio/test_multipart.py
+++ b/tests/sansio/test_multipart.py
@@ -85,7 +85,16 @@ def test_decoder_data_start_with_different_newline_positions(
     # We want to check up to data start event
     while not isinstance(events[-1], Data):
         events.append(decoder.next_event())
-    expected = data_start if data_end == b"" else data_start + b"\r\nBCDE"
+
+    expected = data_start
+
+    if data_end == b"":
+        # a split \r\n is deferred to the next event
+        if expected[-1] == 0x0D:
+            expected = expected[:-1]
+    else:
+        expected += b"\r\nBCDE"
+
     assert events == [
         Preamble(data=b""),
         File(


### PR DESCRIPTION
Save a trailing \r for the next stream even in order to avoid a newline marker being split by a chunk boundary.

This requires an adjustment of the test
`test_decoder_data_start_with_different_newline_positions` in `tests/sansio/test_multipart.py`. The difficult bit is relative to where the state machine of the parsing ends up while parsing invalid input. The only thing that happens is that the very first event is one byte smaller, and that is by design.

fixes #3065.