### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: fa1ed65ba95bfa7771a71003a9d74402541f5a5c  # frozen: v0.14.6
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 016d6d8dbc18eb9cc42594297fa8af0c79f6df72  # frozen: 0.9.12
@@ -16,3 +16,11 @@ repos:
       - id: fix-byte-order-marker
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/codespell-project/codespell
+    rev: 63c8f8312b7559622c0d82815639671ae42132ac  # frozen: v2.4.1
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=fo,te,worl
+        additional_dependencies:
+          - tomli

--- a/examples/partial/README
+++ b/examples/partial/README
@@ -1,3 +1,3 @@
 This directory contains modules that have code but that are
-not excutable.  For example routing definitions to play around
+not executable.  For example routing definitions to play around
 in the python interactive prompt.

--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -80,7 +80,7 @@ class Map:
         The ``encoding_errors`` and ``host_matching`` parameters were added.
 
     .. versionchanged:: 0.5
-        The ``sort_parameters`` and ``sort_key``  paramters were added.
+        The ``sort_parameters`` and ``sort_key``  parameters were added.
     """
 
     #: A dict of default converters to be used.

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -894,7 +894,7 @@ def test_raw_request_uri():
 
 
 def no_response_headers_app(environ, start_response):
-    """A WSGI application which returns a resposne with no headers."""
+    """A WSGI application which returns a response with no headers."""
     response = Response("Response")
     response.headers.clear()
     return response(environ, start_response)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -538,7 +538,7 @@ def test_etag_response():
     assert resp.status_code == 304
     assert "content-length" not in resp.headers
 
-    # make sure date is not overriden
+    # make sure date is not overridden
     response = wrappers.Response("Hello World")
     response.date = 1337
     d = response.date
@@ -582,7 +582,7 @@ def test_etag_response_412():
     # Make sure there is a body still
     assert resp.data != b""
 
-    # make sure date is not overriden
+    # make sure date is not overridden
     response = wrappers.Response("Hello World")
     response.date = 1337
     d = response.date


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=fo,te,worl`
```
./tests/test_test.py:897: resposne ==> response
./tests/test_wrappers.py:541: overriden ==> overridden
./tests/test_wrappers.py:585: overriden ==> overridden
./examples/partial/README:2: excutable ==> executable
./src/werkzeug/routing/map.py:83: paramters ==> parameters
```
% `codespell --ignore-words-list=fo,te,worl --write-changes` 

---
```diff
- ruff (legacy alias)......................................................Passed
- ruff format..............................................................Passed
+ ruff check...............................................................Passed
+ ruff format..............................................................Passed
```