### PR TITLE
`Request.json` property is only `Any`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 -   The multipart form parser handles a ``\r\n`` sequence at a chunk boundary.
     :issue:`3065`
 -   Improve CPU usage during Watchdog reloader. :issue:`3054`
+-   `Request.json` annotation is more accurate. :issue:`3067`
 
 
 Version 3.1.3

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -542,7 +542,7 @@ class Request(_SansIORequest):
     json_module = json
 
     @property
-    def json(self) -> t.Any | None:
+    def json(self) -> t.Any:
         """The parsed JSON data if :attr:`mimetype` indicates JSON
         (:mimetype:`application/json`, see :attr:`is_json`).
 


### PR DESCRIPTION
The property can be any JSON value, including `None`, which is covered by `Any`. Contrast with the `get_json` method, which distinguishes `Any | None` since `silent=True` can result in `None` from an error rather than a value.

fixes #3067