### PR TITLE
skip rendering missing source

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Unreleased
     :issue:`3065`
 -   Improve CPU usage during Watchdog reloader. :issue:`3054`
 -   `Request.json` annotation is more accurate. :issue:`3067`
+-   Traceback rendering handles when thd line number is beyond the available
+    source lines. :issue:`3044`
 
 
 Version 3.1.3

--- a/src/werkzeug/debug/tbtools.py
+++ b/src/werkzeug/debug/tbtools.py
@@ -420,7 +420,7 @@ class DebugFrameSummary(traceback.FrameSummary):
                 f"{arrow if arrow else ''}</pre>"
             )
 
-        if lines:
+        if line_idx < len(lines):
             for line in lines[start_idx:line_idx]:
                 render_line(line, "before")
 


### PR DESCRIPTION
When `linecache.getlines` returns fewer lines than `lineno`, skip rendering the source.

fixes #3044 