### PR TITLE
better `HTTPException.get_response` annotation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 -   `Request.json` annotation is more accurate. :issue:`3067`
 -   Traceback rendering handles when thd line number is beyond the available
     source lines. :issue:`3044`
+-   `HTTPException.get_response` annotation and doc better conveys the
+    distinction between WSGI and sans-IO responses. :issue:`3056`
 
 
 Version 3.1.3


### PR DESCRIPTION
Use overloads to indicate when a WSGI or sans-IO ASGI response is returned. Clarify in docs as well. Sphinx can't find the WSGIResponse and SansIOResponse aliases to create links in the signature (and sansio purposefully doesn't have docs yet), but the link in the docstring works.

fixes #3056