### PR TITLE
fix typos

### DIFF
--- a/src/werkzeug/datastructures/csp.py
+++ b/src/werkzeug/datastructures/csp.py
@@ -26,7 +26,7 @@ class ContentSecurityPolicy(CallbackDict[str, str]):
     Because the csp directives in the HTTP header use dashes the
     python descriptors use underscores for that.
 
-    To get a header of the :class:`ContentSecuirtyPolicy` object again
+    To get a header of the :class:`ContentSecurityPolicy` object again
     you can convert the object into a string or call the
     :meth:`to_header` method.  If you plan to subclass it and add your
     own items have a look at the sourcecode for that class.

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -579,7 +579,7 @@ class Response:
         To unset this header, assign ``None`` or use ``del``.
 
         .. versionchanged:: 2.3
-            This attribute can be assigned to to set the header. A list can be assigned
+            This attribute can be assigned to set the header. A list can be assigned
             to set multiple header values. Use ``del`` to unset the header.
 
         .. versionchanged:: 2.3


### PR DESCRIPTION
Hi Pallets team! Hope you're having a great day.

I was recently exploring the Werkzeug codebase and spotted a couple of small typos in the docstrings that I thought would be worth tidying up to keep the documentation polished.

**Changes:**

1.  **`src/werkzeug/datastructures/csp.py`**: Fixed a typo where `ContentSecuirtyPolicy` was written instead of `ContentSecurityPolicy`. Correcting this ensures that Sphinx can properly resolve the `:class:` cross-reference in the generated documentation.
2.  **`src/werkzeug/sansio/response.py`**: Removed a duplicated "to" ("assigned to to set" → "assigned to set") in the `www_authenticate` property docstring.

**Verification:**

I have verified these changes by running the project's style check suite via `tox -e style`, and all checks (including `ruff` and `codespell`) passed successfully.

Thank you for maintaining such a fantastic project!

---
*Note: I also ran a full `codespell` scan across the repository to ensure no other common typos were missed, and these appeared to be the only remaining items.*