### PR TITLE
Correct parsing up to a potential partial boundary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Version 3.1.5
 
 Unreleased
 
+-   The multipart form parser handles a ``\r\n`` sequence at a chunk boundary.
+    This fixes the previous attempt, which caused incorrect content lengths.
+    :issue:`3065` :issue:`3077`
 -   Fix ``AttributeError`` when initializing ``DebuggedApplication`` with
     ``pin_security=False``. :issue:`3075`
 

--- a/tests/sansio/test_multipart.py
+++ b/tests/sansio/test_multipart.py
@@ -86,14 +86,7 @@ def test_decoder_data_start_with_different_newline_positions(
     while not isinstance(events[-1], Data):
         events.append(decoder.next_event())
 
-    expected = data_start
-
-    if data_end == b"":
-        # a split \r\n is deferred to the next event
-        if expected[-1] == 0x0D:
-            expected = expected[:-1]
-    else:
-        expected += b"\r\nBCDE"
+    expected = data_start if data_end == b"" else data_start + b"\r\nBCDE"
 
     assert events == [
         Preamble(data=b""),

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -200,6 +200,14 @@ class TestFormParser:
         assert len(form) == 0
         assert len(files) == 0
 
+    def test_parse_form_post_data_trailing_CR(self):
+        for k in [1, 2]:
+            sample = b"\0" * 65535 + b"\x0d" * k
+            with Request.from_values(
+                data={"foo": (io.BytesIO(sample), "test.txt")}, method="POST"
+            ) as req:
+                assert req.files["foo"].read() == sample
+
     @pytest.mark.parametrize(
         ("no_spooled", "size"), ((False, 100), (False, 3000), (True, 100), (True, 3000))
     )


### PR DESCRIPTION
This adjusts b1916c0c083e0be1c9d887ee2f3d696922bfc5c1 by ensuring CR, \r, are not ignored if an earlier LR, \n, is present when considering if a partial boundary can exist. This would result in trailing CR, \r, being added to the data rather than part of a potential partial boundary.

This correctly fixes https://github.com/pallets/werkzeug/issues/3065 and fixes https://github.com/pallets/werkzeug/issues/3077.
