### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -187,7 +187,7 @@ class Map:
                         and existing.strict_slashes == rule.strict_slashes
                     ):
                         raise ValueError(f"duplicate route registered: {rule.rule}")
-                        
+
             if not rule.build_only:
                 self._matcher.add(rule)
             self._rules_by_endpoint.setdefault(rule.endpoint, []).append(rule)

--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -175,6 +175,19 @@ class Map:
         """
         for rule in rulefactory.get_rules(self):
             rule.bind(self)
+
+            for rules in self._rules_by_endpoint.values():
+                for existing in rules:
+                    if (
+                        existing.rule == rule.rule
+                        and existing.methods == rule.methods
+                        and existing.websocket == rule.websocket
+                        and existing.host == rule.host
+                        and existing.subdomain == rule.subdomain
+                        and existing.strict_slashes == rule.strict_slashes
+                    ):
+                        raise ValueError(f"duplicate route registered: {rule.rule}")
+                        
             if not rule.build_only:
                 self._matcher.add(rule)
             self._rules_by_endpoint.setdefault(rule.endpoint, []).append(rule)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1554,8 +1554,10 @@ def test_regex():
 
 
 def test_duplicate_route_raises():
-    from werkzeug.routing import Map, Rule
     import pytest
+
+    from werkzeug.routing import Map
+    from werkzeug.routing import Rule
 
     m = Map()
     m.add(Rule("/test", methods={"GET"}, endpoint="a"))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1551,3 +1551,14 @@ def test_regex():
     )
     adapter = map_.bind("localhost")
     assert adapter.match("/asdfsa.asdfs") == ("regex", {"value": "asdfsa.asdfs"})
+
+
+def test_duplicate_route_raises():
+    from werkzeug.routing import Map, Rule
+    import pytest
+
+    m = Map()
+    m.add(Rule("/test", methods={"GET"}, endpoint="a"))
+
+    with pytest.raises(ValueError, match="duplicate"):
+        m.add(Rule("/test", methods={"GET"}, endpoint="b"))


### PR DESCRIPTION
### Summary

Registering the same route multiple times currently fails silently. Werkzeug
continues using the first registered rule, which can lead to subtle bugs.

This change raises a `ValueError` when a duplicate route is registered.

### Changes

- Detect duplicate routes in `Map.add`
- Raise an explicit exception on duplicate rule registration
- Add test coverage for duplicate routes

### Motivation

This makes routing errors visible early and aligns route handling with endpoint
duplication checks.

Fixes #3037
