### PR TITLE
don't add interface addresses

### DIFF
--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -1081,9 +1081,11 @@ def run_simple(
         from .debug import DebuggedApplication
 
         application = DebuggedApplication(application, evalex=use_evalex)
+
         # Allow the specified hostname to use the debugger, in addition to
         # localhost domains.
-        application.trusted_hosts.append(hostname)
+        if hostname not in {"0.0.0.0", "[::]"}:
+            application.trusted_hosts.append(hostname)
 
     if not is_running_from_reloader():
         fd = None


### PR DESCRIPTION
The dev server adds the hostname it starts with to `DebuggedApplication.trusted_hosts`. While the dev server must never be exposed externally, it may be run within Docker where passing `0.0.0.0` or `[::]` is used to get outside of Docker to the local machine without knowing the container's IP address. Don't add these to `trusted_hosts`, as they're not valid in that context.