### PR TITLE
document rule priority

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -87,6 +87,28 @@ merged. If you want to disable ``merge_slashes`` for a :class:`Rule` or
 appropriately.
 
 
+Rule Priority
+=============
+
+In general, the map matches more specific rules first. Rules are made up of
+static and variable parts, separated by slash ``/``. For a given segment, rules
+with a static part in that position take priority, and longer static values take
+priority over shorter. Variable parts are weighted based on the type of data
+they match.
+
+If you're using subdomain or host matching, the domain part can use converters
+as well. The domain part is matched before the path parts. Like the path parts,
+a static domain part take priority over a variable part.
+
+Rules may end up with the same priority, by having static parts with the same
+length, and dynamic parts with the same weight, in the same positions. In this
+case, sorting is stable, so rules added earlier take priority.
+
+The exact way that rules are sorted internally is pretty complicated, but the
+result should be that you can rely on more specific rules matching before more
+general ones.
+
+
 Built-in Converters
 ===================
 


### PR DESCRIPTION
Describe at a high level how rules are sorted for matching. closes #2924

Removes the low level description of the state machine, and the API docs for it, as it's not intended to be public.