### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,9 @@ Unreleased
 -   ``SpooledTemporaryFile`` is always used for multipart file parsing.
     :pr:`3101`
 -   Raise a ``DuplicateRuleError`` when attempting to add a rule to a map with
-    an equal rule. :issue:`3037`
+    an equal rule. Rules are now properly compared including methods (checking
+    for overlap), ``strict_slashes``, and ``merge_slashes`` values.
+    :issue:`3037`, :issue:`3105`
 
 
 Version 3.1.5

--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -96,10 +96,22 @@ variables. Unlike the path, where multiple parts are separated by ``/``, the
 domain is always matched as a single part.
 
 If a duplicate rule is added to a map, a :exc:`.DuplicateRuleError` will be
-raised. Rules are compared based on their path, subdomain or host, and websocket
-mode. Variable parts are not equal if they use different converters, although
-this heuristic may not be perfect depending on what the different converters can
-actually match.
+raised. Rules are checked for routing conflicts using the
+:meth:`~.Rule.conflicts_with` method. Two rules conflict if they would match
+the same request - this is determined by their path, subdomain or host,
+websocket mode, slash handling behavior (``strict_slashes`` and
+``merge_slashes``), and whether their HTTP methods overlap. Variable parts are
+not equal if they use different converters, although this heuristic may not be
+perfect depending on what the different converters can actually match.
+
+Rules with overlapping HTTP methods are considered conflicting. For example,
+rules that both accept ``POST`` will conflict. Rules with non-overlapping
+methods (one accepts only ``GET``, another only ``POST``) do not conflict and
+can coexist. A rule with ``methods=None`` (accepting all methods) will conflict
+with any rule on the same path.
+
+Rules with different ``strict_slashes`` or ``merge_slashes`` values do not
+conflict, as they have different matching behavior.
 
 
 Rule Priority
@@ -161,7 +173,7 @@ Maps, Rules and Adapters
    :members:
 
 .. autoclass:: Rule
-   :members: empty
+   :members: empty, conflicts_with
 
 .. currentmodule:: werkzeug.routing.exceptions
 

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -53,7 +53,7 @@ class StateMachineMatcher:
                     state = new_state
 
         for existing in state.rules:
-            if rule == existing:
+            if rule.conflicts_with(existing):
                 raise DuplicateRuleError(existing, rule)
 
         state.rules.append(rule)

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -908,12 +908,12 @@ class Rule(RuleFactory):
 
     def __eq__(self, other: object) -> bool:
         """Check if two rules are structurally equal.
-        
+
         This checks for true equality. Two rules are equal if all their
         attributes match exactly. This must remain a true equivalence relation
         (reflexive/symmetric/transitive), so it cannot encode "overlaps/conflicts"
         semantics.
-        
+
         :internal:
         """
         if not isinstance(other, type(self)):
@@ -936,17 +936,17 @@ class Rule(RuleFactory):
 
     def conflicts_with(self, other: Rule) -> bool:
         """Check if this rule conflicts with another rule for routing purposes.
-        
+
         Two rules conflict if they would match the same request. This happens when:
         - They have the same path structure (_parts)
         - They have the same websocket mode
         - They have the same subdomain/host (based on matching settings)
         - They have the same strict_slashes and merge_slashes behavior
         - Their HTTP methods overlap (share at least one common method)
-        
+
         :param other: Another rule to check for conflicts.
         :return: True if the rules would conflict during routing.
-        
+
         .. versionadded:: 3.2
         """
         # Must have the same path structure

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -320,6 +320,58 @@ def test_no_duplicate_different_converters() -> None:
     )
 
 
+def test_no_duplicate_different_methods() -> None:
+    """Rules with non-overlapping methods are not duplicates."""
+    r.Map(
+        [
+            r.Rule("/test", methods=["GET"], endpoint="get"),
+            r.Rule("/test", methods=["POST"], endpoint="post"),
+        ]
+    )
+
+
+def test_duplicate_overlapping_methods() -> None:
+    """Rules with overlapping methods are duplicates."""
+    with pytest.raises(DuplicateRuleError):
+        r.Map(
+            [
+                r.Rule("/test", methods=["GET", "POST"], endpoint="a"),
+                r.Rule("/test", methods=["POST", "DELETE"], endpoint="b"),
+            ]
+        )
+
+
+def test_duplicate_methods_none() -> None:
+    """Rules where one has methods=None (all methods) are duplicates."""
+    with pytest.raises(DuplicateRuleError):
+        r.Map(
+            [
+                r.Rule("/test", methods=None, endpoint="a"),
+                r.Rule("/test", methods=["GET"], endpoint="b"),
+            ]
+        )
+
+
+def test_no_duplicate_different_strict_slashes() -> None:
+    """Rules with different strict_slashes values are not duplicates."""
+    r.Map(
+        [
+            r.Rule("/test/", strict_slashes=True, endpoint="a"),
+            r.Rule("/test/", strict_slashes=False, endpoint="b"),
+        ]
+    )
+
+
+def test_no_duplicate_different_merge_slashes() -> None:
+    """Rules with different merge_slashes values are not duplicates."""
+    r.Map(
+        [
+            r.Rule("/test", merge_slashes=True, endpoint="a"),
+            r.Rule("/test", merge_slashes=False, endpoint="b"),
+        ]
+    )
+
+
 def test_environ_defaults():
     environ = create_environ("/foo")
     assert environ["PATH_INFO"] == "/foo"


### PR DESCRIPTION


The current check uses `Rule.__eq__`, which compares only parts/websocket (and/or compares
methods by equality). That can incorrectly report duplicates when two rules share a path
but are disjoint by method (common in real apps), and it can also miss duplicates when
methods differ but overlap (e.g. `{"GET","POST"}` vs `{"POST","DELETE"}`).

This PR introduces a dedicated `Rule.conflicts_with` method used only for duplicate
detection. It treats two rules as duplicates when they can match the same request:

- Same compiled parts and websocket mode.
- Same resolved `strict_slashes` and `merge_slashes` behavior.
- HTTP methods overlap (set intersection). `methods=None` is treated as “any method”,
  so it overlaps with all method sets.

`Rule.__eq__` remains structural equality and is not used to decide overlap/conflicts.

fixes #3105
