### PR TITLE
consider methods for duplicate rule check

### DIFF
--- a/docs/routing.rst
+++ b/docs/routing.rst
@@ -96,10 +96,13 @@ variables. Unlike the path, where multiple parts are separated by ``/``, the
 domain is always matched as a single part.
 
 If a duplicate rule is added to a map, a :exc:`.DuplicateRuleError` will be
-raised. Rules are compared based on their path, subdomain or host, and websocket
-mode. Variable parts are not equal if they use different converters, although
-this heuristic may not be perfect depending on what the different converters can
-actually match.
+raised. Rules are compared based on their path, subdomain or host, websocket
+mode, and methods. Variable parts are not equal if they use different
+converters, although this heuristic may not be perfect depending on what the
+different converters can actually match. Rules with equal or overlapping (but
+not exactly equal) methods are considered duplicates. The ``HEAD`` and
+``OPTIONS`` methods are not considered for the overlapping check, only for exact
+equality, as they are typically added automatically.
 
 
 Rule Priority

--- a/src/werkzeug/routing/exceptions.py
+++ b/src/werkzeug/routing/exceptions.py
@@ -37,7 +37,7 @@ class DuplicateRuleError(Exception):
         """The new rule that duplicates the existing rule."""
 
     def __str__(self) -> str:
-        return str(self.existing)
+        return repr(self.existing)
 
 
 class RoutingException(Exception):

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -53,7 +53,7 @@ class StateMachineMatcher:
                     state = new_state
 
         for existing in state.rules:
-            if rule == existing:
+            if rule.is_duplicate(existing):
                 raise DuplicateRuleError(existing, rule)
 
         state.rules.append(rule)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -259,6 +259,8 @@ def test_no_duplicates() -> None:
             r.Rule("/", endpoint="index"),
             r.Rule("/", endpoint="websocket", websocket=True),
             r.Rule("/", endpoint="sub", subdomain="a"),
+            r.Rule("/method", methods=["GET"]),
+            r.Rule("/method", methods=["POST"]),
         ]
     )
 
@@ -318,6 +320,38 @@ def test_no_duplicate_different_converters() -> None:
             r.Rule("/<int:b>", endpoint="b"),
         ]
     )
+
+
+def test_duplicate_method_overlap() -> None:
+    """Rules with overlapping methods are duplicates."""
+    with pytest.raises(DuplicateRuleError):
+        r.Map(
+            [
+                r.Rule("/", methods=["GET", "POST"], endpoint="a"),
+                r.Rule("/", methods=["POST", "PUT"], endpoint="b"),
+            ]
+        )
+
+
+def test_no_duplicate_head_options() -> None:
+    """Rules with overlapping HEAD and OPTIONS methods are not duplicates."""
+    r.Map(
+        [
+            r.Rule("/", methods=["GET", "OPTIONS"], endpoint="a"),
+            r.Rule("/", methods=["POST", "OPTIONS"], endpoint="b"),
+        ]
+    )
+
+
+def test_duplicate_options_exact() -> None:
+    """HEAD and OPTIONS methods are considered for duplicates as an exact match."""
+    with pytest.raises(DuplicateRuleError):
+        r.Map(
+            [
+                r.Rule("/", methods=["HEAD", "OPTIONS"], endpoint="a"),
+                r.Rule("/", methods=["HEAD", "OPTIONS"], endpoint="b"),
+            ]
+        )
 
 
 def test_environ_defaults():


### PR DESCRIPTION
A rule's methods are considered for the duplicate check. A few different checks are done:

- Overlap (not exact equality), excluding `HEAD` and `OPTIONS`. This isn't truly a duplicate, but does what people probably expect. If two rules have overlapping methods, there's ambiguity in which would match (the first registered would since sorting is stable). `HEAD` and `OPTIONS` are excluded because `Rule` adds `HEAD` automatically for `GET`, and Flask adds `OPTIONS` automatically to every rule.
- Either rule's methods is `None`. This means it accepts every method and must therefore have overlap.
- Exact equality. This is almost the same as the overlap check, but doesn't exclude `HEAD` and `OPTIONS`. I figure the majority of cases that want to add a specific rule for `HEAD` or `OPTIONS` will be doing so with only those methods, and so exact equality should catch that.

This all turned out to be surprisingly complex to detect. Besides method overlap, there's ambiguity with variable parts that use different converters, and with parts in the same position that are static for one rule and a variable for another. Our goal should be to not produce any false positives, even if we miss some corner cases to accomplish that.

fixes #3105 