### PR TITLE
always set `Accept-Ranges` header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Version 3.2.0
     an equal rule. :issue:`3037`
 -   Add ``Request.sec_fetch_site``, ``sec_fetch_mode``, ``sec_fetch_user``, and
     ``sec_fetch_dest`` header properties. :pr:`3082`
+-   ``Response.make_conditional`` sets the ``Accept-Ranges`` header even if it
+    is not a satisfiable range request. :issue:`3108`
 
 
 Version 3.1.5

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -595,6 +595,15 @@ def test_etag_response_412():
     assert response.content_length == 999
 
 
+def test_advertise_accept_ranges() -> None:
+    env = create_environ()
+    response = wrappers.Response()
+    response.make_conditional(env, accept_ranges=True)
+    assert response.status_code == 200
+    assert response.headers["Accept-Ranges"] == "bytes"
+    assert "Content-Range" not in response.headers
+
+
 def test_range_request_basic():
     env = create_environ()
     response = wrappers.Response("Hello World")


### PR DESCRIPTION
`Response.make_conditional` always set the `Accept-Ranges` header if `accept_ranges` is enabled, even if the request is not a satisfiable range request.

fixes #3108 
