### PR TITLE
validate host characters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,10 @@ Version 3.2.0
     ``sec_fetch_dest`` header properties. :pr:`3082`
 -   ``Response.make_conditional`` sets the ``Accept-Ranges`` header even if it
     is not a satisfiable range request. :issue:`3108`
+-   ``Request.host``, ``get_host``, and ``host_is_trusted`` validate the
+    characters of the value. An empty value is no longer allowed. A Unix socket
+    server address is ignored. The ``trusted_list`` argument to
+    ``host_is_trusted`` is optional. :pr:`3113`
 
 
 Version 3.1.6

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -233,6 +233,8 @@ class Request:
     def host(self) -> str:
         """The host name the request was made to, including the port if
         it's non-standard. Validated with :attr:`trusted_hosts`.
+
+        See :func:`.get_host` for a detailed explanation.
         """
         return get_host(
             self.scheme, self.headers.get("host"), self.server, self.trusted_hosts


### PR DESCRIPTION
`Request.host`, `get_host`, and `host_is_trusted` validate the characters of the host value. They do not validate the value, only that its characters _could_ form a valid host. The empty string is no longer allowed, the host value must contain characters.

The `trusted_list` argument to `host_is_trusted` is optional to make it easier to use to validate the characters only, if trusted hosts aren't configured.

If no `Host` header is present, these would fall back to using the server's configured address `(host, port)`. When listening on a unix socket, this would end up like `("/path/to/socket", None)`, which is not valid as a host value. A unix socket address is now ignored, as it would not produce a useful value when used by other functions such as URL building anyway.

Rewrite the docs for these.