### PR TITLE
update CSP directives

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Version 3.2.0
 
 -   Minimum required version of MarkupSafe is 3.0.3.
 -   Minimum supported version of Watchdog is 6.0.
+-   The CSP ``report_uri``, ``prefetch_src``, ``navigate_to``, and
+    ``plugin_types`` properties are deprecated. Their corresponding directives
+    have been deprecated or removed from the spec. :pr:`3114`
 -   ``redirect`` returns a ``303`` status code by default instead of ``302``.
     This tells the client to always switch to ``GET``, rather than only
     switching ``POST`` to ``GET``. This preserves the current behavior of
@@ -51,6 +54,8 @@ Version 3.2.0
     characters of the value. An empty value is no longer allowed. A Unix socket
     server address is ignored. The ``trusted_list`` argument to
     ``host_is_trusted`` is optional. :pr:`3113`
+-   Added properties for the ``required_trusted_types_for``, ``trusted_types``,
+    and ``upgrade_insecure_requests`` CSP directives. :pr:`3114`
 
 
 Version 3.1.6


### PR DESCRIPTION
Added three new directive properties: `require_trusted_types_for`, `trusted_types`, and `upgrade_insecure_requests`. Did not add directives that were marked experimental in MDN, or that were marked deprecated but that we never added. Reorganized the properties based on the sections in the MDN docs.

`navigate-to` and `plugin-types` are no longer listed on MDN. `report-uri` and `prefetch-src` are listed as deprecated. These all raise deprecation warnings to be removed in Werkzeug 3.3. It's still possible to set any key using `csp[key] = value` instead of the properties, if needed.