### PR TITLE
undeprecated CSP report-uri for now

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,9 +11,9 @@ Version 3.2.0
 
 -   Minimum required version of MarkupSafe is 3.0.3.
 -   Minimum supported version of Watchdog is 6.0.
--   The CSP ``report_uri``, ``prefetch_src``, ``navigate_to``, and
-    ``plugin_types`` properties are deprecated. Their corresponding directives
-    have been deprecated or removed from the spec. :pr:`3114`
+-   The CSP ``prefetch_src``, ``navigate_to``, and ``plugin_types`` properties
+    are deprecated. Their corresponding directives have been deprecated or
+    removed from the spec. :pr:`3114`
 -   ``redirect`` returns a ``303`` status code by default instead of ``302``.
     This tells the client to always switch to ``GET``, rather than only
     switching ``POST`` to ``GET``. This preserves the current behavior of

--- a/src/werkzeug/datastructures/csp.py
+++ b/src/werkzeug/datastructures/csp.py
@@ -28,6 +28,10 @@ class ContentSecurityPolicy(CallbackDict[str, str]):
         Added the ``required_trusted_types_for``, ``trusted_types``, and
         ``upgrade_insecure_requests`` properties.
 
+    .. versionchanged:: 3.2
+        The ``prefetch_src``, ``navigate_to``, and ``plugin_types`` properties
+        are deprecated and will be removed in Werkzeug 3.3.
+
     .. versionadded:: 1.0
     """
 
@@ -62,7 +66,7 @@ class ContentSecurityPolicy(CallbackDict[str, str]):
     trusted_types: str | None = csp_property("trusted-types")
     upgrade_insecure_requests: str | None = csp_property("upgrade-insecure-requests")
     # deprecated directives
-    report_uri: str | None = csp_property("report-uri", deprecated="3.3")
+    report_uri: str | None = csp_property("report-uri")  # still widely supported
     prefetch_src: str | None = csp_property("prefetch-src", deprecated="3.3")
     # removed directives
     navigate_to: str | None = csp_property("navigate-to", deprecated="3.3")


### PR DESCRIPTION
`report-uri` is still widely used and supported by browsers. `report-to` requires setting a feature flag on Firefox.

continues #3114 