### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -722,7 +722,7 @@ class Rule(RuleFactory):
         self._trace.append((False, "|"))
         rule = self.rule
         if self.merge_slashes:
-            rule = re.sub("/{2,}?", "/", self.rule)
+            rule = re.sub("/{2,}", "/", self.rule)
         self._parts.extend(self._parse_rule(rule))
 
         self._build: t.Callable[..., tuple[str, str]]

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -99,6 +99,7 @@ def test_merge_slashes_match():
         [
             r.Rule("/no/tail", endpoint="no_tail"),
             r.Rule("/yes/tail/", endpoint="yes_tail"),
+            r.Rule("/foo/bar/", endpoint="foo_bar"),
             r.Rule("/with/<path:path>", endpoint="with_path"),
             r.Rule("/no//merge", endpoint="no_merge", merge_slashes=False),
             r.Rule("/no/merging", endpoint="no_merging", merge_slashes=False),
@@ -133,6 +134,11 @@ def test_merge_slashes_match():
 
     assert adapter.match("/no/merging")[0] == "no_merging"
     pytest.raises(NotFound, lambda: adapter.match("/no//merging"))
+
+    # Verify three or more consecutive slashes are collapsed (fixes #3121)
+    with pytest.raises(r.RequestRedirect) as excinfo:
+        adapter.match("///foo///bar///")
+    assert excinfo.value.new_url.endswith("/foo/bar/")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Fix `Rule.compile()` to use greedy regex `/{2,}` instead of non-greedy `/{2,}?` when `merge_slashes=True`
- The non-greedy quantifier only matches exactly 2 slashes, leaving paths like `///foo` partially unmerged

## Root Cause
In `Rule.compile()`, the regex replacement `/{2,}?` is non-greedy, meaning it matches the minimum (2 slashes) instead of all consecutive slashes.

## Testing
- Verified that `///foo///bar` correctly collapses to `/foo/bar` after the fix
- Added test case for `///foo///bar///` -> `/foo/bar/`
- Existing test suite passes

Fixes #3121

Made with [Cursor](https://cursor.com)