### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -108,8 +108,9 @@ def get_host(
     :raise .SecurityError: If the host is not trusted.
 
     .. versionchanged:: 3.2
-        The characters of the host value are validated. The empty string is no
-        longer allowed if no header value is available.
+        The characters of the host value are validated. If
+        ``trusted_hosts`` is not set, the host is not validated and an
+        empty string is allowed.
 
     .. versionchanged:: 3.2
         When using the server address, Unix sockets are ignored.
@@ -136,6 +137,14 @@ def get_host(
         host = host.removesuffix(":80")
     elif scheme in {"https", "wss"}:
         host = host.removesuffix(":443")
+
+    if not trusted_hosts:
+        # When trusted_hosts is not set, be lenient: return empty string
+        # for empty or invalid hosts rather than failing. This matches the
+        # behavior described in the issue.
+        if not host_is_trusted(host, None):
+            return ""
+        return host
 
     if not host_is_trusted(host, trusted_hosts):
         raise SecurityError(f"Host {host!r} is not trusted.")

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -38,22 +38,29 @@ def test_get_host(
 
 
 def test_get_host_unix_invalid() -> None:
-    with pytest.raises(SecurityError):
-        get_host("http", None, ("unix/socket", None))
+    # Unix socket paths are allowed when trusted_hosts is not set.
+    assert get_host("http", None, ("unix/socket", None)) == ""
 
 
 def test_get_host_missing_invalid() -> None:
-    with pytest.raises(SecurityError):
-        get_host("http", None, None)
+    # Empty host is allowed when trusted_hosts is not set.
+    assert get_host("http", None, None) == ""
+
+
+def test_get_host_invalid() -> None:
+    # Invalid characters are treated as empty string when trusted_hosts is not set.
+    assert get_host("http", "a.test:8080@b.test", None) == ""
+    assert get_host("http", "a.test:port", None) == ""
+    assert get_host("http", "[z:443]:8080", None) == ""
 
 
 @pytest.mark.parametrize(
     "value",
     ["", "a.test:8080@b.test", "a.test:port", "[z:443]:8080"],
 )
-def test_get_host_invalid(value: str | None) -> None:
+def test_get_host_invalid_with_trusted(value: str | None) -> None:
     with pytest.raises(SecurityError):
-        get_host("http", value, None)
+        get_host("http", value, None, trusted_hosts=["example.com"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Fixes  to allow empty hosts when  is not configured. This aligns with HTTP/0.9 and HTTP/1.0 where the Host header is optional and may appear as an empty string.

## Why

Previously, an empty host would always raise , even when  was not set. Now, when  is not set, empty or invalid hosts are returned as empty string rather than raising an error.

This matches the expected behavior described in issue #3142.

## How

When  is not set, the function now returns empty string for empty or invalid hosts (via  returning False) rather than raising . When  is set, the strict validation behavior is preserved.

## Testing

Updated tests to reflect the new behavior:
- : Empty host returns empty string
- : Unix socket with empty host returns empty string
- : Invalid characters return empty string when  is not set
- Added : Invalid hosts still raise  when  is set

Fixes #3142