### PR TITLE
Prevent scientific notation being used for floats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,7 @@ Version 3.2.0
     and ``upgrade_insecure_requests`` CSP directives. :pr:`3114`
 -   The development server does not send an extra ``100 Continue`` response, as
     Python's base server already sends it. :issue:`3138`
+-   The float URL converter does not produce scientific notation. :issue:`3146`
 
 
 Version 3.1.8

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -210,6 +210,9 @@ class FloatConverter(NumberConverter):
     :param max: The maximal value.
     :param signed: Allow signed (negative) values.
 
+    .. versionchanged:: 3.2
+        Does not produce scientific notation.
+
     .. versionadded:: 0.15
         The ``signed`` parameter.
     """
@@ -225,6 +228,10 @@ class FloatConverter(NumberConverter):
         signed: bool = False,
     ) -> None:
         super().__init__(map, min=min, max=max, signed=signed)  # type: ignore
+
+    def to_url(self, value: t.Any) -> str:
+        # f format ensures no scientific notation, but forces trailing zeroes
+        return f"{self.num_convert(value):f}".rstrip("0")
 
 
 class UUIDConverter(BaseConverter):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -487,6 +487,12 @@ def test_negative():
     pytest.raises(NotFound, lambda: adapter.match("/bar/-2.0"))
 
 
+def test_float_no_scientific():
+    map = r.Map([r.Rule("/<float:v>", endpoint="a")])
+    adapter = map.bind("test.example")
+    assert "e" not in adapter.build("a", {"v": 0.00001})
+
+
 def test_greedy():
     map = r.Map(
         [


### PR DESCRIPTION
This fixes #3146

`FloatConverter` currently does not support `fixed_digits` (see `IntegerConverter`). This change could make use of the parameter for decimal precision. In this case the constructor in `FloatConverter` could be dropped.

TODO (after discussion regarding `fixed_digits` is resolved):

- [ ] Update CHANGES.rst
- [ ] Add/fix tests
