### PR TITLE
deprecate Content-MD5 header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Version 3.2.0
 -   ``HTTP_STATUS_CODES`` is deprecated. Use Python's built-in
     ``http.HTTPStatus`` instead. Reason phrases use the more common title case
     rather than upper case. :pr:`3139`
+-   The ``content_md5`` header property on ``Request`` and ``Response`` is
+    deprecated. The header has not been used for a long time. :pr:`3158`
 -   ``redirect`` returns a ``303`` status code by default instead of ``302``.
     This tells the client to always switch to ``GET``, rather than only
     switching ``POST`` to ``GET``. This preserves the current behavior of

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -284,18 +284,27 @@ class Request:
         .. versionadded:: 0.9""",
         read_only=True,
     )
-    content_md5 = header_property[str](
-        "Content-MD5",
-        doc="""The Content-MD5 entity-header field, as defined in
-        RFC 1864, is an MD5 digest of the entity-body for the purpose of
-        providing an end-to-end message integrity check (MIC) of the
-        entity-body. (Note: a MIC is good for detecting accidental
-        modification of the entity-body in transit, but is not proof
-        against malicious attacks.)
 
-        .. versionadded:: 0.9""",
-        read_only=True,
-    )
+    @property
+    def content_md5(self) -> str | None:
+        """The ``Content-MD5`` header, an MD5 digest of the request body.
+
+        .. deprecated:: 3.2
+            The header has not been used for a long time. Will be removed
+            in Werkzeug 3.3.
+
+        .. versionadded:: 0.9
+        """
+        import warnings
+
+        warnings.warn(
+            "The 'content_md5' attribute is deprecated and will be removed in"
+            " Werkzeug 3.3. The header has not been used for a long time.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.headers.get("Content-MD5")
+
     referrer = header_property[str](
         "Referer",
         doc="""The Referer[sic] request-header field allows the client

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -376,15 +376,53 @@ class Response:
         in order to obtain the media-type referenced by the Content-Type
         header field.""",
     )
-    content_md5 = header_property[str](
-        "Content-MD5",
-        doc="""The Content-MD5 entity-header field, as defined in
-        RFC 1864, is an MD5 digest of the entity-body for the purpose of
-        providing an end-to-end message integrity check (MIC) of the
-        entity-body. (Note: a MIC is good for detecting accidental
-        modification of the entity-body in transit, but is not proof
-        against malicious attacks.)""",
-    )
+
+    @property
+    def content_md5(self) -> str | None:
+        """The ``Content-MD5`` header, an MD5 digest of the response body.
+
+        .. deprecated:: 3.2
+            The header has not been used for a long time. Will be removed
+            in Werkzeug 3.3.
+        """
+        import warnings
+
+        warnings.warn(
+            "The 'content_md5' attribute is deprecated and will be removed in"
+            " Werkzeug 3.3. The header has not been used for a long time.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.headers.get("Content-MD5")
+
+    @content_md5.setter
+    def content_md5(self, value: str | None) -> None:
+        import warnings
+
+        warnings.warn(
+            "The 'content_md5' attribute is deprecated and will be removed in"
+            " Werkzeug 3.3. The header has not been used for a long time.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        if value is None:
+            del self.headers["Content-MD5"]
+        else:
+            self.headers["Content-MD5"] = value
+
+    @content_md5.deleter
+    def content_md5(self) -> None:
+        import warnings
+
+        warnings.warn(
+            "The 'content_md5' attribute is deprecated and will be removed in"
+            " Werkzeug 3.3. The header has not been used for a long time.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        del self.headers["Content-MD5"]
+
     date = header_property(
         "Date",
         None,

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -781,7 +781,6 @@ def test_common_request_descriptors():
             "Max-Forwards": "10",
             "Pragma": "no-cache",
             "Content-Encoding": "gzip",
-            "Content-MD5": "9a3bc6dbc47a70db25b84c6e5867a072",
         },
     )
 
@@ -794,7 +793,6 @@ def test_common_request_descriptors():
     assert request.max_forwards == 10
     assert "no-cache" in request.pragma
     assert request.content_encoding == "gzip"
-    assert request.content_md5 == "9a3bc6dbc47a70db25b84c6e5867a072"
 
 
 def test_request_mimetype_always_lowercase():


### PR DESCRIPTION
The header is so unused that it's not even listed on MDN.