### PR TITLE
deprecate Pragma header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Version 3.2.0
     rather than upper case. :pr:`3139`
 -   The ``content_md5`` header property on ``Request`` and ``Response`` is
     deprecated. The header has not been used for a long time. :pr:`3158`
+-   The ``pragma`` header property on ``Request`` is deprecated. The header has
+    been officially deprecated for a long time. :pr:`3160`
 -   ``redirect`` returns a ``303`` status code by default instead of ``302``.
     This tells the client to always switch to ``GET``, rather than only
     switching ``POST`` to ``GET``. This preserves the current behavior of

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -362,15 +362,22 @@ class Request:
         self._parse_content_type()
         return self._parsed_content_type[1]
 
-    @cached_property
+    @property
     def pragma(self) -> HeaderSet:
-        """The Pragma general-header field is used to include
-        implementation-specific directives that might apply to any recipient
-        along the request/response chain.  All pragma directives specify
-        optional behavior from the viewpoint of the protocol; however, some
-        systems MAY require that behavior be consistent with the directives.
+        """The ``Pragma`` header.
+
+        .. deprecated:: 3.2
+            Use ``cache_control`` instead. Will be removed in Werkzeug 3.3.
         """
-        return parse_set_header(self.headers.get("Pragma", ""))
+        import warnings
+
+        warnings.warn(
+            "The 'pragma' attribute is deprecated and will be removed in"
+            " Werkzeug 3.3. Use 'cache_control' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return parse_set_header(self.headers.get("Pragma"))
 
     # Accept
 

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -779,7 +779,6 @@ def test_common_request_descriptors():
             "Referer": "http://www.example.com/",
             "Date": "Sat, 28 Feb 2009 19:04:35 GMT",
             "Max-Forwards": "10",
-            "Pragma": "no-cache",
             "Content-Encoding": "gzip",
         },
     )
@@ -791,7 +790,6 @@ def test_common_request_descriptors():
     assert request.referrer == "http://www.example.com/"
     assert request.date == datetime(2009, 2, 28, 19, 4, 35, tzinfo=timezone.utc)
     assert request.max_forwards == 10
-    assert "no-cache" in request.pragma
     assert request.content_encoding == "gzip"
 
 


### PR DESCRIPTION
It's been deprecated since HTTP/1.1 was released, was fully replaced by `Cache-Control`. If an application needs it, it can still parse the header value.