### PR TITLE
deprecate Accept-Charset header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Version 3.2.0
     deprecated. The header has not been used for a long time. :pr:`3158`
 -   The ``pragma`` header property on ``Request`` is deprecated. The header has
     been officially deprecated for a long time. :pr:`3160`
+-   The ``accept_charsets`` header property on ``Request``, and the
+    ``CharsetAccept`` class, are deprecated. The header has not been used for a
+    long time. :pr:`3161`
 -   ``redirect`` returns a ``303`` status code by default instead of ``302``.
     This tells the client to always switch to ``GET``, rather than only
     switching ``POST`` to ``GET``. This preserves the current behavior of

--- a/src/werkzeug/datastructures/__init__.py
+++ b/src/werkzeug/datastructures/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import typing as t
+
 from .accept import Accept as Accept
-from .accept import CharsetAccept as CharsetAccept
 from .accept import LanguageAccept as LanguageAccept
 from .accept import MIMEAccept as MIMEAccept
 from .auth import Authorization as Authorization
@@ -32,3 +33,21 @@ from .structures import ImmutableTypeConversionDict as ImmutableTypeConversionDi
 from .structures import iter_multi_items as iter_multi_items
 from .structures import MultiDict as MultiDict
 from .structures import TypeConversionDict as TypeConversionDict
+
+
+def __getattr__(name: str) -> t.Any:
+    if name == "CharsetAccept":
+        import warnings
+
+        from .accept import _CharsetAccept
+
+        warnings.warn(
+            "The 'CharsetAccept' class is deprecated and will be removed in"
+            " Werkzeug 3.3. The 'Accept-Charset' header is not sent by"
+            " browsers, and UTF-8 is assumed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _CharsetAccept
+
+    raise AttributeError(name)

--- a/src/werkzeug/datastructures/accept.py
+++ b/src/werkzeug/datastructures/accept.py
@@ -337,7 +337,7 @@ class LanguageAccept(Accept):
         return default
 
 
-class CharsetAccept(Accept):
+class _CharsetAccept(Accept):
     """Like :class:`Accept` but with normalization for charsets."""
 
     def _value_matches(self, value: str, item: str) -> bool:
@@ -348,3 +348,19 @@ class CharsetAccept(Accept):
                 return name.lower()
 
         return item == "*" or _normalize(value) == _normalize(item)
+
+
+def __getattr__(name: str) -> t.Any:
+    if name == "CharsetAccept":
+        import warnings
+
+        warnings.warn(
+            "The 'CharsetAccept' class is deprecated and will be removed in"
+            " Werkzeug 3.3. The 'Accept-Charset' header is not sent by"
+            " browsers, and UTF-8 is assumed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _CharsetAccept
+
+    raise AttributeError(name)

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -6,7 +6,6 @@ from urllib.parse import parse_qsl
 
 from ..datastructures import Accept
 from ..datastructures import Authorization
-from ..datastructures import CharsetAccept
 from ..datastructures import ETags
 from ..datastructures import Headers
 from ..datastructures import HeaderSet
@@ -389,11 +388,26 @@ class Request:
         return parse_accept_header(self.headers.get("Accept"), MIMEAccept)
 
     @cached_property
-    def accept_charsets(self) -> CharsetAccept:
+    def accept_charsets(self) -> Accept:
         """List of charsets this client supports as
         :class:`~werkzeug.datastructures.CharsetAccept` object.
+
+        .. deprecated:: 3.2
+            The header has not been used for a long time. Clients do not send
+            it. Assume UTF-8. Will be removed in Werkzeug 3.3.
         """
-        return parse_accept_header(self.headers.get("Accept-Charset"), CharsetAccept)
+        import warnings
+
+        from ..datastructures.accept import _CharsetAccept
+
+        warnings.warn(
+            "The 'accept_charsets' attribute is deprecated and will be removed"
+            " in Werkzeug 3.3. The header is not sent by browsers, and UTF-8 is"
+            " assumed.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return parse_accept_header(self.headers.get("Accept-Charset"), _CharsetAccept)
 
     @cached_property
     def accept_encodings(self) -> Accept:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -67,15 +67,6 @@ class TestHTTPUtility:
         assert a.best_match(["text/html; version=1", "text/html"]) == "text/html"
         assert a.best_match(["text/html", "text/html; level=1"]) == "text/html; level=1"
 
-    def test_charset_accept(self):
-        a = http.parse_accept_header(
-            "ISO-8859-1,utf-8;q=0.7,*;q=0.7", datastructures.CharsetAccept
-        )
-        assert a["iso-8859-1"] == a["iso8859-1"]
-        assert a["iso-8859-1"] == 1
-        assert a["UTF8"] == 0.7
-        assert a["ebcdic"] == 0.7
-
     def test_language_accept(self):
         a = http.parse_accept_header(
             "de-AT,de;q=0.8,en;q=0.5", datastructures.LanguageAccept

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -11,7 +11,6 @@ import pytest
 from werkzeug import Response
 from werkzeug import wrappers
 from werkzeug.datastructures import Accept
-from werkzeug.datastructures import CharsetAccept
 from werkzeug.datastructures import CombinedMultiDict
 from werkzeug.datastructures import Headers
 from werkzeug.datastructures import ImmutableList
@@ -382,7 +381,6 @@ def test_accept():
         {
             "HTTP_ACCEPT": "text/xml,application/xml,application/xhtml+xml,"
             "text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5",
-            "HTTP_ACCEPT_CHARSET": "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
             "HTTP_ACCEPT_ENCODING": "gzip,deflate",
             "HTTP_ACCEPT_LANGUAGE": "en-us,en;q=0.5",
             "SERVER_NAME": "eggs",
@@ -399,9 +397,6 @@ def test_accept():
             ("text/plain", 0.8),
             ("*/*", 0.5),
         ]
-    )
-    assert request.accept_charsets == CharsetAccept(
-        [("ISO-8859-1", 1), ("utf-8", 0.7), ("*", 0.7)]
     )
     assert request.accept_encodings == Accept([("gzip", 1), ("deflate", 1)])
     assert request.accept_languages == LanguageAccept([("en-us", 1), ("en", 0.5)])


### PR DESCRIPTION
The `Accept-Charset` header is so deprecated it's not listed in MDN anymore. Previous archives of MDN show a warning that no client sends it, and the vast majority of content is UTF-8 now.