### PR TITLE
if-range discards weak etag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ Version 3.2.0
 -   The development server does not send an extra ``100 Continue`` response, as
     Python's base server already sends it. :issue:`3138`
 -   The float URL converter does not produce scientific notation. :issue:`3146`
+-   ``Request.if_range`` discards the header if it is an invalid weak ETag.
+    :pr:`3163`
 
 
 Version 3.1.8

--- a/src/werkzeug/datastructures/range.py
+++ b/src/werkzeug/datastructures/range.py
@@ -18,23 +18,25 @@ T = t.TypeVar("T")
 
 
 class IfRange:
-    """Very simple object that represents the `If-Range` header in parsed
-    form.  It will either have neither a etag or date or one of either but
-    never both.
+    """A parsed ``If-Range`` header. Either a strong ETag or a date, but not
+    both. Weak ETag values must not be used.
 
     .. versionadded:: 0.7
     """
 
     def __init__(self, etag: str | None = None, date: datetime | None = None):
-        #: The etag parsed and unquoted.  Ranges always operate on strong
-        #: etags so the weakness information is not necessary.
         self.etag = etag
-        #: The date in parsed format or `None`.
+        """A strong ETag value, unquoted, without weakness information. Weak
+        ETag values must not be used.
+        """
+
         self.date = date
+        """A parsed datetime object."""
 
     @classmethod
     def from_header(cls, value: str | None) -> te.Self:
-        """Parse an ``If-Range`` header value and create an instance of this class.
+        """Parse an ``If-Range`` header value and create an instance of this
+        class. A weak ETag value is discarded.
 
         .. versionadded:: 3.2
         """
@@ -44,8 +46,12 @@ class IfRange:
         if (date := parse_date(value)) is not None:
             return cls(date=date)
 
-        # drop weakness information
-        return cls(unquote_etag(value)[0])
+        value, weak = unquote_etag(value)
+
+        if weak:
+            return cls()
+
+        return cls(etag=value)
 
     def to_header(self) -> str:
         """Convert to an ``If-Range`` header value."""

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -460,6 +460,9 @@ class Request:
     def if_range(self) -> IfRange:
         """The parsed ``If-Range`` header.
 
+        .. versionchanged:: 3.2
+            A weak ETag is discarded.
+
         .. versionchanged:: 2.0
             ``IfRange.date`` is timezone-aware.
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -606,17 +606,17 @@ class TestRange:
         assert rv.date is None
         assert rv.to_header() == '"Test"'
 
-        # weak information is dropped
+        # weak etag is discarded
         rv = IfRange.from_header('W/"Test"')
-        assert rv.etag == "Test"
+        assert rv.etag is None
         assert rv.date is None
-        assert rv.to_header() == '"Test"'
+        assert rv.to_header() == ""
 
         # broken etags are supported too
-        rv = IfRange.from_header("bullshit")
-        assert rv.etag == "bullshit"
+        rv = IfRange.from_header("unquoted")
+        assert rv.etag == "unquoted"
         assert rv.date is None
-        assert rv.to_header() == '"bullshit"'
+        assert rv.to_header() == '"unquoted"'
 
         rv = IfRange.from_header("Thu, 01 Jan 1970 00:00:00 GMT")
         assert rv.etag is None


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/If-Range

> A weak entity tag (one prefixed by W/) must not be used in this header.

Previously, Werkzeug was discarding the weak marker and treating the etag a strong. Now it treats it as invalid and discards it.