### PR TITLE
use sha3-256 instead of sha-1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ Version 3.2.0
 -   The float URL converter does not produce scientific notation. :issue:`3146`
 -   ``Request.if_range`` discards the header if it is an invalid weak ETag.
     :pr:`3163`
+-   Use SHA3-256 instead of SHA-1 for generating ETags and the debugger pin.
+    SHA-1 is not available FIPS 140. This may invalidate some caches since the
+    ETag will be different. :pr:`3164`
 
 
 Version 3.1.8

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -43,7 +43,9 @@ PIN_TIME = 60 * 60 * 24 * 7
 
 
 def hash_pin(pin: str) -> str:
-    return hashlib.sha1(f"{pin} added salt".encode("utf-8", "replace")).hexdigest()[:12]
+    return hashlib.sha3_256(f"{pin} added salt".encode("utf-8", "replace")).hexdigest()[
+        :12
+    ]
 
 
 _machine_id: str | bytes | None = None
@@ -188,7 +190,7 @@ def get_pin_and_cookie_name(
     # within the unauthenticated debug page.
     private_bits = [str(uuid.getnode()), get_machine_id()]
 
-    h = hashlib.sha1()
+    h = hashlib.sha3_256()
     for bit in chain(probably_public_bits, private_bits):
         if not bit:
             continue

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import email.utils
+import hashlib
 import re
 import typing as t
 import warnings
@@ -10,7 +11,6 @@ from datetime import time
 from datetime import timedelta
 from datetime import timezone
 from enum import Enum
-from hashlib import sha1
 from time import mktime
 from time import struct_time
 from urllib.parse import quote
@@ -1059,12 +1059,17 @@ def _parse_etags(value: str | None) -> ds.ETags:
 
 
 def generate_etag(data: bytes) -> str:
-    """Generate an etag for some data.
+    """Generate a strong ETag value by hashing the given data.
+
+    .. versionchanged:: 3.2
+        Use SHA3-256. SHA-1 is not allowed in FIPS-enabled systems. This
+        increases the length from 40 to 64 characters.
 
     .. versionchanged:: 2.0
-        Use SHA-1. MD5 may not be available in some environments.
+        Use SHA-1. MD5 is not allowed in FIPS-enabled systems. This increases
+        the length from 32 to 40 characters.
     """
-    return sha1(data).hexdigest()
+    return hashlib.sha3_256(data, usedforsecurity=False).hexdigest()
 
 
 def parse_date(value: str | None) -> datetime | None:
@@ -1188,11 +1193,7 @@ def is_resource_modified(
                             account.
     :return: `True` if the resource was modified, otherwise `False`.
 
-    .. versionchanged:: 2.0
-        SHA-1 is used to generate an etag value for the data. MD5 may
-        not be available in some environments.
-
-    .. versionchanged:: 1.0.0
+    .. versionchanged:: 1.0
         The check is run for methods other than ``GET`` and ``HEAD``.
     """
     return _sansio_http.is_resource_modified(

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -783,11 +783,18 @@ class Response(_SansIOResponse):
         return self
 
     def add_etag(self, overwrite: bool = False, weak: bool = False) -> None:
-        """Add an etag for the current response if there is none yet.
+        """Add an ETag by hashing this response's data. This causes the data to
+        be read, don't call this on a streaming response.
+
+        :param overwrite: Overwrite an existing ``ETag`` header.
+        :param weak: Mark the ETag as weak. This is unlikely what you want, as
+            a hash of the data is typically considered strong.
+
+        .. versionchanged:: 3.2
+            Use SHA3-256.
 
         .. versionchanged:: 2.0
-            SHA-1 is used to generate the value. MD5 may not be
-            available in some environments.
+            Use SHA-1.
         """
         if overwrite or "ETag" not in self.headers:
             self.set_etag(generate_etag(self.get_data()), weak)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -509,7 +509,10 @@ def test_etag_response():
     response = wrappers.Response("Hello World")
     assert response.get_etag() == (None, None)
     response.add_etag()
-    assert response.get_etag() == ("0a4d55a8d778e5022fab701977c5d840bbc486d0", False)
+    assert response.get_etag() == (
+        "e167f68d6563d75bb25f3aa49c29ef612d41352dc00606de7cbd630bb2665f51",
+        False,
+    )
     assert not response.cache_control
     response.cache_control.must_revalidate = True
     response.cache_control.max_age = 60
@@ -550,7 +553,10 @@ def test_etag_response_412():
     response = wrappers.Response("Hello World")
     assert response.get_etag() == (None, None)
     response.add_etag()
-    assert response.get_etag() == ("0a4d55a8d778e5022fab701977c5d840bbc486d0", False)
+    assert response.get_etag() == (
+        "e167f68d6563d75bb25f3aa49c29ef612d41352dc00606de7cbd630bb2665f51",
+        False,
+    )
     assert not response.cache_control
     response.cache_control.must_revalidate = True
     response.cache_control.max_age = 60


### PR DESCRIPTION
Same as the change from MD5 to SHA-1 years ago. FIPS 140 systems seem to be disabling SHA-1 now, even though I can't find a concrete reference that it's actually disallowed yet.

This changes the ETag length (and value), which will invalidate caches that look at ETags. Given we did this before and no one complained, seems fine.

I considered using SHAKE-128, but couldn't figure out if a digest length of 20 (same as SHA-1) was useful, or if a length of 32 was any different than using SHA3-256. Also couldn't figure out if FIPS included SHAKE in its approval of SHA-3.