### PR TITLE
use base64 instead of hex digest

### DIFF
--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -5,6 +5,7 @@ import hashlib
 import re
 import typing as t
 import warnings
+from base64 import b64encode
 from datetime import date
 from datetime import datetime
 from datetime import time
@@ -1062,14 +1063,16 @@ def generate_etag(data: bytes) -> str:
     """Generate a strong ETag value by hashing the given data.
 
     .. versionchanged:: 3.2
-        Use SHA3-256. SHA-1 is not allowed in FIPS-enabled systems. This
-        increases the length from 40 to 64 characters.
+        Use SHA3-256. SHA-1 is not allowed in FIPS-enabled systems. Use base64
+        instead of hex digest. This increases the length from 40 to 43
+        characters.
 
     .. versionchanged:: 2.0
         Use SHA-1. MD5 is not allowed in FIPS-enabled systems. This increases
         the length from 32 to 40 characters.
     """
-    return hashlib.sha3_256(data, usedforsecurity=False).hexdigest()
+    digest = hashlib.sha3_256(data, usedforsecurity=False).digest()
+    return b64encode(digest).decode().rstrip("=")
 
 
 def parse_date(value: str | None) -> datetime | None:

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -509,10 +509,7 @@ def test_etag_response():
     response = wrappers.Response("Hello World")
     assert response.get_etag() == (None, None)
     response.add_etag()
-    assert response.get_etag() == (
-        "e167f68d6563d75bb25f3aa49c29ef612d41352dc00606de7cbd630bb2665f51",
-        False,
-    )
+    assert response.get_etag() == ("4Wf2jWVj11uyXzqknCnvYS1BNS3ABgbefL1jC7JmX1E", False)
     assert not response.cache_control
     response.cache_control.must_revalidate = True
     response.cache_control.max_age = 60
@@ -553,10 +550,7 @@ def test_etag_response_412():
     response = wrappers.Response("Hello World")
     assert response.get_etag() == (None, None)
     response.add_etag()
-    assert response.get_etag() == (
-        "e167f68d6563d75bb25f3aa49c29ef612d41352dc00606de7cbd630bb2665f51",
-        False,
-    )
+    assert response.get_etag() == ("4Wf2jWVj11uyXzqknCnvYS1BNS3ABgbefL1jC7JmX1E", False)
     assert not response.cache_control
     response.cache_control.must_revalidate = True
     response.cache_control.max_age = 60


### PR DESCRIPTION
This reduces the etag size (now using SHA3-256) from 64 to 44.