### PR TITLE
use `secrets.token_urlsafe` for salt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Version 3.2.0
 -   Use SHA3-256 instead of SHA-1 for generating ETags and the debugger pin.
     SHA-1 is not available FIPS 140. This may invalidate some caches since the
     ETag will be different. :pr:`3164`
+-   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
+    The private ``gen_salt`` method is removed. :pr:`3167`
 
 
 Version 3.1.8

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -6,6 +6,7 @@ import json
 import os
 import pkgutil
 import re
+import secrets
 import subprocess
 import sys
 import time
@@ -24,7 +25,6 @@ from ..exceptions import NotFound
 from ..exceptions import SecurityError
 from ..http import parse_cookie
 from ..sansio.utils import host_is_trusted
-from ..security import gen_salt
 from ..utils import send_file
 from ..wrappers.request import Request
 from ..wrappers.response import Response
@@ -284,7 +284,7 @@ class DebuggedApplication:
         self.console_path = console_path
         self.console_init_func = console_init_func
         self.show_hidden_frames = show_hidden_frames
-        self.secret = gen_salt(20)
+        self.secret = secrets.token_urlsafe(20)
         self._failed_pin_auth = Value("B")
 
         self.pin_logging = pin_logging

--- a/src/werkzeug/security.py
+++ b/src/werkzeug/security.py
@@ -6,7 +6,6 @@ import os
 import posixpath
 import secrets
 
-SALT_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 DEFAULT_PBKDF2_ITERATIONS = 1_000_000
 
 _os_alt_seps: list[str] = list(
@@ -23,14 +22,6 @@ _windows_device_files = {
     "NUL",
     "PRN",
 }
-
-
-def gen_salt(length: int) -> str:
-    """Generate a random string of SALT_CHARS with specified ``length``."""
-    if length <= 0:
-        raise ValueError("Salt length must be at least 1.")
-
-    return "".join(secrets.choice(SALT_CHARS) for _ in range(length))
 
 
 def _hash_internal(method: str, salt: str, password: str) -> tuple[str, str]:
@@ -115,7 +106,10 @@ def generate_password_hash(
     .. versionchanged:: 2.3
         The default iterations for pbkdf2 was increased to 600,000.
     """
-    salt = gen_salt(salt_length)
+    if salt_length <= 0:
+        raise ValueError("Salt length must be at least 1.")
+
+    salt = secrets.token_urlsafe(salt_length)
     h, actual_method = _hash_internal(method, salt, password)
     return f"{actual_method}${salt}${h}"
 


### PR DESCRIPTION
https://docs.python.org/3/library/secrets.html has been around since Python 3.6. It generates random bytes and base64 encodes, rather than choosing ASCII.

`gen_salt` is removed, but it was never documented and I'm assuming no one's using it. Not worth going through deprecation.