### PR TITLE
parse plain int in a few more inputs

### DIFF
--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -193,19 +193,20 @@ class _DictAccessorProperty(t.Generic[_TAccessorValue]):
         return f"<{type(self).__name__} {self.name}>"
 
 
-_plain_int_re = re.compile(r"-?\d+", re.ASCII)
+_plain_int_re = re.compile(r"-?[a-z0-9]+", re.ASCII | re.IGNORECASE)
 
 
-def _plain_int(value: str) -> int:
-    """Parse an int only if it is only ASCII digits and ``-``.
+def _plain_int(value: str, base: int = 10) -> int:
+    """Parse an int only if it is ASCII digits and ``-``.
 
-    This disallows ``+``, ``_``, and non-ASCII digits, which are accepted by ``int`` but
-    are not allowed in HTTP header values.
+    This disallows ``+``, ``_``, and non-ASCII digits, which are accepted by
+    ``int`` but are not allowed in HTTP header values.
 
-    Any leading or trailing whitespace is stripped
+    Any surrounding whitespace is stripped.
     """
     value = value.strip()
+
     if _plain_int_re.fullmatch(value) is None:
         raise ValueError
 
-    return int(value)
+    return int(value, base)

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -21,6 +21,7 @@ from os.path import join
 from zlib import adler32
 
 from .._internal import _log
+from .._internal import _plain_int
 from ..exceptions import NotFound
 from ..exceptions import SecurityError
 from ..http import parse_cookie
@@ -450,7 +451,7 @@ class DebuggedApplication:
         ts_str, pin_hash = val.split("|", 1)
 
         try:
-            ts = int(ts_str)
+            ts = _plain_int(ts_str)
         except ValueError:
             return False
 

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -18,6 +18,7 @@ from urllib.parse import quote
 from urllib.parse import unquote
 
 from ._internal import _dt_as_utc
+from ._internal import _plain_int
 
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import WSGIEnvironment
@@ -1147,7 +1148,7 @@ def parse_age(value: str | None = None) -> timedelta | None:
     if not value:
         return None
     try:
-        seconds = int(value)
+        seconds = _plain_int(value)
     except ValueError:
         return None
     if seconds < 0:
@@ -1167,10 +1168,9 @@ def dump_age(age: timedelta | int | None = None) -> str | None:
     """
     if age is None:
         return None
+
     if isinstance(age, timedelta):
         age = int(age.total_seconds())
-    else:
-        age = int(age)
 
     if age < 0:
         raise ValueError("age cannot be negative")

--- a/src/werkzeug/middleware/shared_data.py
+++ b/src/werkzeug/middleware/shared_data.py
@@ -151,7 +151,7 @@ class SharedDataMiddleware:
         return lambda: (
             open(filename, "rb"),
             datetime.fromtimestamp(os.path.getmtime(filename), tz=timezone.utc),
-            int(os.path.getsize(filename)),
+            os.path.getsize(filename),
         )
 
     def get_file_loader(self, filename: str) -> _TLoader:

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -31,6 +31,7 @@ from urllib.parse import unquote
 from urllib.parse import urlsplit
 
 from ._internal import _log
+from ._internal import _plain_int
 from ._internal import _wsgi_encoding_dance
 from .datastructures import HeaderSet
 from .exceptions import InternalServerError
@@ -108,7 +109,7 @@ class DechunkedInput(io.RawIOBase):
     def read_chunk_len(self) -> int:
         try:
             line = self._rfile.readline().decode("latin1")
-            _len = int(line.strip(), 16)
+            _len = _plain_int(line, 16)
         except ValueError as e:
             raise OSError("Invalid chunk header") from e
         if _len < 0:

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,3 +1,6 @@
+import pytest
+
+from werkzeug._internal import _plain_int
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 from werkzeug.wrappers import Response
@@ -28,3 +31,25 @@ def test_wrapper_internals():
     response = Response(["Hällo Wörld".encode()])
     headers = response.get_wsgi_headers(create_environ())
     assert "Content-Length" in headers
+
+
+@pytest.mark.parametrize(
+    ("value", "base", "expect"),
+    [
+        ("123", 10, 123),
+        ("-123", 10, -123),
+        ("1_23", 10, None),
+        ("+123", 10, None),
+        ("𝟙𝟚𝟛", 10, None),
+        ("7B", 10, None),
+        ("7B", 16, 123),
+        ("-7B", 16, -123),
+        ("7b", 16, 123),
+    ],
+)
+def test_plain_int(value: str, base: int, expect: int | None) -> None:
+    if expect is None:
+        with pytest.raises(ValueError):
+            _plain_int(value, base)
+    else:
+        assert _plain_int(value, base) == expect


### PR DESCRIPTION
A few other minor uses of `int` where only plain ints (not Python's extended syntax) are expected. There are some other uses of `int` and `float`, but they're all preceded by format checks already.