### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -35,9 +35,12 @@ class StateMachineMatcher:
     def __init__(self, merge_slashes: bool) -> None:
         self._root = State()
         self.merge_slashes = merge_slashes
+        self._rule_count = 0
 
     def add(self, rule: Rule) -> None:
         state = self._root
+        rule._insertion_index = self._rule_count
+        self._rule_count += 1
         for part in rule._parts:
             if part.static:
                 state.static.setdefault(part.content, State())
@@ -60,11 +63,30 @@ class StateMachineMatcher:
 
     def update(self) -> None:
         # For every state the dynamic transitions should be sorted by
-        # the weight of the transition
+        # the weight of the transition, then by the minimum insertion
+        # index of any rule that terminates directly at the destination
+        # state.  Using only the direct rules (state.rules) rather than
+        # the full subtree prevents unrelated rules that merely share a
+        # dynamic path prefix from inflating a branch's apparent priority.
+        # When no rule terminates at a state (e.g. an intermediate state
+        # on a longer path), the sentinel self._rule_count causes that
+        # transition to sort after all rule-terminating transitions with
+        # the same weight, preserving stable insertion order between them.
         state = self._root
 
         def _update_state(state: State) -> None:
-            state.dynamic.sort(key=lambda entry: entry[0].weight)
+            state.dynamic.sort(
+                key=lambda entry: (
+                    entry[0].weight,
+                    min(
+                        (
+                            r._insertion_index  # type: ignore[attr-defined]
+                            for r in entry[1].rules
+                        ),
+                        default=self._rule_count,
+                    ),
+                )
+            )
             for new_state in state.static.values():
                 _update_state(new_state)
             for _, new_state in state.dynamic:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1820,3 +1820,34 @@ def test_bind_untrusted_host() -> None:
 
     with pytest.raises(SecurityError):
         r.Map().bind_to_environ(req)
+
+
+def test_consistent_relative_priority_with_unrelated_rule() -> None:
+    """Registering an unrelated rule that shares a dynamic segment with a later
+    rule must not change the relative priority between earlier-registered rules.
+
+    Regression test for https://github.com/pallets/werkzeug/issues/3156.
+    """
+    rule_1 = r.Rule("/<dummy:value>", endpoint="rule_1")
+    rule_2 = r.Rule("/<string:value>", endpoint="rule_2")
+
+    # Baseline: rule_1 registered first should win when weights are equal.
+    map1 = r.Map(
+        [rule_1, rule_2],
+        converters={"dummy": r.BaseConverter},
+    )
+    adapter = map1.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+    # Adding an unrelated rule (/<string:value>/no_match) before rule_1 and
+    # rule_2 must NOT change which of those two wins for /foo.
+    map2 = r.Map(
+        [
+            r.Rule("/<string:value>/no_match", endpoint="no_match"),
+            rule_1.empty(),
+            rule_2.empty(),
+        ],
+        converters={"dummy": r.BaseConverter},
+    )
+    adapter2 = map2.bind("example.org", "/")
+    assert adapter2.match("/foo") == ("rule_1", {"value": "foo"})


### PR DESCRIPTION
Fixes #3156.

## Summary

When two dynamic converter parts have the same weight (e.g. a custom converter subclassing `BaseConverter` at weight=100 vs the built-in `string` converter also at weight=100), `StateMachineMatcher.update()` sorts `state.dynamic` by weight alone. Because Python's sort is stable, the result preserves `state.dynamic` insertion order — but that order reflects which rule **first created** a path transition, not which rule was **registered first**.

An unrelated rule that merely *shares* a dynamic prefix (e.g. `/<string:value>/no_match`) can create the `string` transition before `/<dummy:value>` is registered, placing `string` ahead of `dummy` in `state.dynamic`. A later `/<string:value>` rule then reuses that same transition, meaning the order of two competing rules (`/<dummy:value>` vs `/<string:value>`) is controlled by a third rule that has nothing to do with either of them.

## Fix

1. **`StateMachineMatcher.__init__`**: add `self._rule_count = 0`
2. **`StateMachineMatcher.add`**: stamp each rule with `rule._insertion_index = self._rule_count` before incrementing
3. **`StateMachineMatcher.update`**: sort key becomes `(weight, min_direct_rule_insertion_index)` where "direct" means only `state.rules` (rules that terminate at the destination state, not rules that merely transit through it)

The sentinel `default=self._rule_count` ensures intermediate states (no terminating rules) sort after terminal states of equal weight, with stable ordering among intermediates.

## Regression test

`test_consistent_relative_priority_with_unrelated_rule` registers `/<dummy:value>` (rule_1) before `/<string:value>` (rule_2) and verifies that inserting an unrelated `/<string:value>/no_match` rule before them does not change which of rule_1/rule_2 wins for `/foo`.