### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 Version 3.2.0
 -------------
 
+-   ``ContentRange.set`` raises ``ValueError`` instead of using ``assert`` for an
+    invalid range, so validation is not skipped under ``python -O``. :pr:`3183`
 -   Drop support for Python 3.9. :pr:`3098`
 -   Remove previous deprecated code: :pr:`3099`
 

--- a/src/werkzeug/datastructures/range.py
+++ b/src/werkzeug/datastructures/range.py
@@ -268,7 +268,8 @@ class ContentRange:
         units: str | None = "bytes",
     ) -> None:
         """Simple method to update the ranges."""
-        assert is_byte_range_valid(start, stop, length), "Bad range provided"
+        if not is_byte_range_valid(start, stop, length):
+            raise ValueError("Bad range provided")
         self._units: str | None = units
         self._start: int | None = start
         self._stop: int | None = stop

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -700,6 +700,16 @@ class TestRange:
         assert rv.length == 100
         assert rv.units == "bytes"
 
+    def test_content_range_set_rejects_invalid_range(self):
+        # set() validates a user-supplied range. It must raise ValueError (as
+        # the sibling Range class does) rather than a bare assert, which is
+        # stripped under python -O.
+        cr = ContentRange("bytes", 0, 100, 200)
+        with pytest.raises(ValueError):
+            cr.set(100, 50, 200)
+        with pytest.raises(ValueError):
+            ContentRange("bytes", 100, 50, 200)
+
 
 class TestRegression:
     def test_best_match_works(self):


### PR DESCRIPTION
`ContentRange.set()` is a public method (also called from `ContentRange.__init__`) that validates a user-supplied byte range with a bare `assert`:

```python
def set(self, start, stop, length=None, units="bytes"):
    """Simple method to update the ranges."""
    assert is_byte_range_valid(start, stop, length), "Bad range provided"
```

Two problems: `assert` is stripped under `python -O`, so an invalid range is accepted silently in optimized builds; and when it does fire it raises `AssertionError`, while the sibling `Range` class raises `ValueError` (and documents it) for the same kind of invalid range.

```python
ContentRange("bytes", 100, 50, 200)   # start > stop: AssertionError, or silently accepted under -O
Range("bytes", [(100, 50)])           # raises ValueError, as documented
```

This raises `ValueError` instead, matching `Range`. Added a regression test; `test_http.py` and `test_datastructures.py` pass.
