### PR TITLE
AI spam

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import getpass
 import hashlib
+import hmac
 import json
 import os
 import pkgutil
@@ -455,7 +456,7 @@ class DebuggedApplication:
         except ValueError:
             return False
 
-        if pin_hash != hash_pin(self.pin):
+        if not hmac.compare_digest(pin_hash, hash_pin(self.pin)):
             return None
         return (time.time() - PIN_TIME) < ts
 
@@ -501,7 +502,9 @@ class DebuggedApplication:
         else:
             entered_pin = request.args["pin"]
 
-            if entered_pin.strip().replace("-", "") == pin.replace("-", ""):
+            if hmac.compare_digest(
+                entered_pin.strip().replace("-", ""), pin.replace("-", "")
+            ):
                 self._failed_pin_auth.value = 0
                 auth = True
             else:
@@ -551,15 +554,24 @@ class DebuggedApplication:
             frame = self.frames.get(request.args.get("frm", type=int))  # type: ignore
             if cmd == "resource" and arg:
                 response = self.get_resource(request, arg)  # type: ignore
-            elif cmd == "pinauth" and secret == self.secret:
+            elif (
+                cmd == "pinauth"
+                and secret is not None
+                and hmac.compare_digest(secret, self.secret)
+            ):
                 response = self.pin_auth(request)  # type: ignore
-            elif cmd == "printpin" and secret == self.secret:
+            elif (
+                cmd == "printpin"
+                and secret is not None
+                and hmac.compare_digest(secret, self.secret)
+            ):
                 response = self.log_pin_request(request)  # type: ignore
             elif (
                 self.evalex
                 and cmd is not None
                 and frame is not None
-                and self.secret == secret
+                and secret is not None
+                and hmac.compare_digest(self.secret, secret)
                 and self.check_pin_trust(environ)
             ):
                 response = self.execute_command(request, cmd, frame)  # type: ignore


### PR DESCRIPTION
## Use constant-time comparison for debugger PIN and secret checks

The interactive debugger gates access to `eval`/`exec` behind a PIN and a
per-process secret. The comparisons that enforce this currently use plain
`==`/`!=`:

- `DebuggedApplication.check_pin_trust` compares the cookie's stored pin hash
  with `pin_hash != hash_pin(self.pin)`.
- `DebuggedApplication.pin_auth` compares the entered PIN with `==`.
- `DebuggedApplication.__call__` compares the request secret with
  `secret == self.secret` in three places (`pinauth`, `printpin`, and the
  `evalex` command dispatch).

`werkzeug.security` already uses `hmac.compare_digest` for password-hash
verification (`check_password_hash`), so the timing-safe primitive is the
established pattern in the codebase. This change applies it to the debugger's
auth comparisons for consistency and defense-in-depth, since these gate the
interactive console.

The PIN-entry path in `pin_auth` is rate-limited (a failure counter with a
sleep and a lockout at 10), so its practical exposure is low. The cookie hash
comparison in `check_pin_trust`, however, is reachable on the normal request
path without incrementing that counter, so a constant-time comparison is the
appropriate primitive there regardless.

No behavior change for valid input. `None` guards are added where the secret
comes from `request.args.get("s")` (which may be `None`) so `compare_digest`
is not called with a non-string.

`tests/test_debug.py` passes (23 passed); `ruff check` and `ruff format` are
clean.
