### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve an empty username or password
+    that is present in the URL, rather than dropping it. :issue:`3189`
 
 
 Version 3.1.8

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -68,6 +68,10 @@ def uri_to_iri(uri: str) -> str:
 
     :param uri: The URI to convert.
 
+    .. versionchanged:: 3.2
+        An empty username or password that is present in the URL is preserved
+        rather than dropped.
+
     .. versionchanged:: 3.0
         Passing a tuple or bytes, and the ``charset`` and ``errors`` parameters,
         are removed.
@@ -98,10 +102,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -118,6 +122,10 @@ def iri_to_uri(iri: str) -> str:
     'http://xn--n3h.net/p%C3%A5th?q=%C3%A8ry%DF'
 
     :param iri: The IRI to convert.
+
+    .. versionchanged:: 3.2
+        An empty username or password that is present in the URL is preserved
+        rather than dropped.
 
     .. versionchanged:: 3.0
         Passing a tuple or bytes, the ``charset`` and ``errors`` parameters,
@@ -153,10 +161,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -90,6 +90,21 @@ def test_uri_iri_normalization(value):
     assert urls.iri_to_uri(urls.iri_to_uri(value)) == uri
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://user:@example.com/path",
+        "http://:pass@example.com/path",
+        "http://:@example.com/path",
+    ],
+)
+def test_uri_iri_empty_userinfo(value):
+    # An empty username or password is present in the URL and must be
+    # preserved. Only a missing component (``None``) is dropped.
+    assert urls.uri_to_iri(value) == value
+    assert urls.iri_to_uri(value) == value
+
+
 def test_uri_to_iri_dont_unquote_space():
     assert urls.uri_to_iri("abc%20def") == "abc%20def"
 


### PR DESCRIPTION
`uri_to_iri()` and `iri_to_uri()` rebuild the userinfo part of a URL using a truthiness check on `username` and `password`. Because an empty string is falsy in Python, a present-but-empty component is silently dropped during what is meant to be a lossless normalization.

### The bug

```python
>>> from werkzeug.urls import uri_to_iri, iri_to_uri
>>> uri_to_iri("http://:pass@example.com/path")
'http://example.com/path'        # password dropped entirely
>>> uri_to_iri("http://user:@example.com/path")
'http://user@example.com/path'   # empty-password separator dropped
>>> iri_to_uri("http://:pass@example.com/path")
'http://example.com/path'
```

The first case is data loss: a non-empty password disappears when the username is empty.

### Root cause

`urllib.parse.urlsplit` distinguishes a present-but-empty component (`""`) from a missing one (`None`), and `urlunsplit` round-trips all of these correctly:

```python
>>> from urllib.parse import urlsplit, urlunsplit
>>> urlunsplit(urlsplit("http://:pass@example.com/path"))
'http://:pass@example.com/path'
```

The code used `if parts.username:` / `if parts.password:`, which treats `""` and `None` the same.

### Fix

Test `is not None` instead, so only an absent component is omitted while a present-but-empty one is preserved (`src/werkzeug/urls.py`, in both `uri_to_iri` and `iri_to_uri`).

### Tests

Added `tests/test_urls.py::test_uri_iri_empty_userinfo`, parametrized over `http://user:@...`, `http://:pass@...`, and `http://:@...`, asserting both functions preserve the value.

red -> green: on `main` the new test fails for every case, e.g.

```
>       assert urls.uri_to_iri(value) == value
E       AssertionError: assert 'http://example.com/path' == 'http://:@example.com/path'
```

With the fix all 3 cases pass and the full suite is green (994 passed, 1 skipped). `ruff check` and `ruff format --check` are clean.

Also added a `CHANGES.rst` entry and `.. versionchanged:: 3.2` notes in both docstrings.

fixes #3189