### PR TITLE
AI spam

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -100,6 +100,46 @@ def test_iri_to_uri_dont_quote_valid_code_points():
     assert urls.iri_to_uri("/path[bracket]?(paren)") == "/path%5Bbracket%5D?(paren)"
 
 
+def test_uri_to_iri_preserves_empty_username():
+    """Empty username (password-only auth) should be preserved, not dropped.
+
+    Regression test for https://github.com/pallets/werkzeug/issues/3189
+    """
+    result = urls.uri_to_iri("http://:pass@example.com/path")
+    assert ":pass@" in result
+    # Also verify round-trip
+    assert ":pass@" in urls.iri_to_uri(result)
+
+
+def test_uri_to_iri_preserves_empty_password():
+    """Empty password (username with colon but no password) should be preserved.
+
+    Regression test for https://github.com/pallets/werkzeug/issues/3189
+    """
+    result = urls.uri_to_iri("http://user:@example.com/path")
+    assert "user:@" in result
+    # Also verify round-trip
+    assert "user:@" in urls.iri_to_uri(result)
+
+
+def test_iri_to_uri_preserves_empty_username():
+    """Empty username should be preserved in iri_to_uri.
+
+    Regression test for https://github.com/pallets/werkzeug/issues/3189
+    """
+    result = urls.iri_to_uri("http://:pass@example.com/path")
+    assert ":pass@" in result
+
+
+def test_iri_to_uri_preserves_empty_password():
+    """Empty password should be preserved in iri_to_uri.
+
+    Regression test for https://github.com/pallets/werkzeug/issues/3189
+    """
+    result = urls.iri_to_uri("http://user:@example.com/path")
+    assert "user:@" in result
+
+
 # Python < 3.12
 def test_itms_services() -> None:
     url = "itms-services://?action=download-manifest&url=https://test.example/path"


### PR DESCRIPTION
## Fix: Preserve empty username and password in uri_to_iri and iri_to_uri

Fixes #3189

### Problem

When a URL contains an empty-but-present username (e.g., `http://:pass@example.com/path`) or empty password (e.g., `http://user:@example.com/path`), `uri_to_iri()` and `iri_to_uri()` silently drop these components. This is data loss during what should be a lossless normalization.

```python
>>> uri_to_iri("http://:pass@example.com/path")
"http://example.com/path"        # password silently dropped!
>>> uri_to_iri("http://user:@example.com/path")
"http://user@example.com/path"   # empty password separator dropped!
```

### Root Cause

The code uses truthiness checks (`if username:`, `if password:`) which treat `""` as falsy. `urllib.parse.urlsplit` correctly returns `""` for present-but-empty and `None` for missing, but the truthiness check conflates the two.

### Fix

Change truthiness checks to explicit `None` checks:
- `if username:` → `if username is not None:`
- `if password:` → `if password is not None:`

This is a minimal, targeted fix in both `uri_to_iri()` and `iri_to_uri()` — 4 lines changed total.

### After fix

```python
>>> uri_to_iri("http://:pass@example.com/path")
"http://:pass@example.com/path"      # ✓ preserved
>>> uri_to_iri("http://user:@example.com/path")
"http://user:@example.com/path"     # ✓ preserved
```

### Tests

Added 4 new test cases covering:
- `uri_to_iri` with empty username
- `uri_to_iri` with empty password
- `iri_to_uri` with empty username
- `iri_to_uri` with empty password

All existing tests continue to pass.