### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -94,11 +94,11 @@ def uri_to_iri(uri: str) -> str:
 
     if ":" in netloc:
         netloc = f"[{netloc}]"
-
+        
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
-
-   if parts.username is not None:
+        
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
         if parts.password is not None:
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+   if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -94,10 +94,10 @@ def uri_to_iri(uri: str) -> str:
 
     if ":" in netloc:
         netloc = f"[{netloc}]"
-        
+
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
-        
+
     if parts.username is not None:
         auth = _unquote_user(parts.username)
 


### PR DESCRIPTION
Fixes #3189

`uri_to_iri()` and `iri_to_uri()` used a truthiness check on `username`
and `password`. An empty string `""` is falsy, so an empty-but-present
username or password was silently dropped.

Changed `if username:` → `if username is not None:` and same for password,
so only a truly missing (`None`) component is omitted.

Before:
>>> uri_to_iri("http://:pass@example.com/")
**'http://example.com/'**  

After:
>>> uri_to_iri("http://:pass@example.com/")
**'http://:pass@example.com/'**  