### PR TITLE
Add Client.query() test shortcut for the QUERY HTTP method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   Add ``Client.query`` shortcut for making test requests with the ``QUERY``
+    HTTP method (:rfc:`10008`). :issue:`3193`
 
 
 Version 3.1.8

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -63,7 +63,8 @@ def parse_form_data(
 ) -> t_parse_result:
     """Parse the form data in the environ and return it as tuple in the form
     ``(stream, form, files)``.  You should only call this method if the
-    transport method is `POST`, `PUT`, or `PATCH`.
+    transport method carries a body, such as `POST`, `PUT`, `PATCH`, or
+    `QUERY`.
 
     If the mimetype of the data transmitted is `multipart/form-data` the
     files multidict will be filled with `FileStorage` objects.  If the

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -1175,6 +1175,17 @@ class Client:
         kw["method"] = "PATCH"
         return self.open(*args, **kw)
 
+    def query(self, *args: t.Any, **kw: t.Any) -> TestResponse:
+        """Call :meth:`open` with ``method`` set to ``QUERY``.
+
+        The ``QUERY`` method is a safe, idempotent request method that
+        carries content in the request body, defined in :rfc:`10008`.
+
+        .. versionadded:: 3.2
+        """
+        kw["method"] = "QUERY"
+        return self.open(*args, **kw)
+
     def options(self, *args: t.Any, **kw: t.Any) -> TestResponse:
         """Call :meth:`open` with ``method`` set to ``OPTIONS``."""
         kw["method"] = "OPTIONS"

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -119,6 +119,16 @@ def test_cookie_for_different_path():
     assert response.text == "test=test"
 
 
+def test_client_query_method():
+    @Request.application
+    def app(request):
+        return Response(f"{request.method}:{request.form.get('q', '')}")
+
+    c = Client(app)
+    response = c.query("/", data={"q": "select"})
+    assert response.text == "QUERY:select"
+
+
 def test_cookie_default_path() -> None:
     """When no path is set for a cookie, the default uses everything up to but not
     including the first slash.


### PR DESCRIPTION
## Description

[RFC 10008](https://www.rfc-editor.org/info/rfc10008/) (June 2026) standardizes
the `QUERY` HTTP method: a safe, idempotent request method that carries content
in the request body.

Werkzeug already handles `QUERY` end to end — routing accepts arbitrary methods
(the only method restriction is for WebSocket rules), and form parsing is
mimetype-driven rather than method-gated, so `request.form` and
`request.get_data()` already work for `QUERY` requests. The one gap is the test
client: `Client` has shortcuts for `get`/`post`/`put`/`delete`/`patch`/
`options`/`head`/`trace`, but not `query`, so a `QUERY` test request currently
requires `client.open("/", method="QUERY")`.

This PR adds the missing shortcut to mirror the existing ones:

- `Client.query()` calls `open()` with `method="QUERY"`.
- `parse_form_data` docstring updated to note `QUERY` also carries a body.

fixes #3193

## Checklist

- [x] Tests added that fail without the change (`test_client_query_method`
      calls `client.query()`, which raises `AttributeError` without it).
- [x] Code docs updated (`Client.query()` docstring with `.. versionadded:: 3.2`);
      the method is surfaced via the `Client` autoclass, so no manual `docs/`
      change is needed.
- [x] `CHANGES.rst` entry added, linking to the issue.
- [x] `.. versionadded::` added (new method, so `versionadded` rather than
      `versionchanged`).
