### PR TITLE
AI spam

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,8 @@ Version 3.2.0
     :pr:`3101`
 -   Raise a ``DuplicateRuleError`` when attempting to add a rule to a map with
     an equal rule. :issue:`3037`
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve empty usernames and passwords in
+    URLs. :issue:`3189`
 -   Add ``Request.sec_fetch_site``, ``sec_fetch_mode``, ``sec_fetch_user``, and
     ``sec_fetch_dest`` header properties. :pr:`3082`
 -   ``Response.make_conditional`` sets the ``Accept-Ranges`` header even if it

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -70,6 +70,19 @@ def test_uri_to_iri_to_uri():
 
 
 @pytest.mark.parametrize(
+    "url",
+    [
+        "http://:pass@example.com/path",
+        "http://user:@example.com/path",
+        "http://@example.com/path",
+    ],
+)
+def test_empty_userinfo_is_preserved(url):
+    assert urls.uri_to_iri(url) == url
+    assert urls.iri_to_uri(url) == url
+
+
+@pytest.mark.parametrize(
     "value",
     [
         "http://föñ.com/\N{BALLOT BOX}/fred?utf8=\u2713",


### PR DESCRIPTION
`uri_to_iri()` and `iri_to_uri()` currently check `SplitResult.username` and `.password` by truthiness when reconstructing userinfo. `urlsplit()` uses `None` for a missing component and `""` for a present-but-empty component, so empty usernames or passwords are dropped.

This changes those checks to `is not None`, preserving empty userinfo components while still omitting missing ones. It also adds regression coverage for empty username, empty password, and empty userinfo round-trips.

fixes #3189

Tests:

- `python -m pytest tests\\test_urls.py -q`
- `python -m ruff check src\\werkzeug\\urls.py tests\\test_urls.py`
- `python -m ruff format --check src\\werkzeug\\urls.py tests\\test_urls.py`
- `python -m mypy src\\werkzeug\\urls.py`
- `git diff --check`