### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   ``uri_to_iri`` and ``iri_to_uri`` keep an empty but present username or
+    password rather than dropping it. Only a missing component is omitted.
+    :issue:`3189`
 
 
 Version 3.1.8

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -68,6 +68,10 @@ def uri_to_iri(uri: str) -> str:
 
     :param uri: The URI to convert.
 
+    .. versionchanged:: 3.2
+        An empty but present username or password is preserved. Only a
+        missing component is omitted.
+
     .. versionchanged:: 3.0
         Passing a tuple or bytes, and the ``charset`` and ``errors`` parameters,
         are removed.
@@ -98,10 +102,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -118,6 +122,10 @@ def iri_to_uri(iri: str) -> str:
     'http://xn--n3h.net/p%C3%A5th?q=%C3%A8ry%DF'
 
     :param iri: The IRI to convert.
+
+    .. versionchanged:: 3.2
+        An empty but present username or password is preserved. Only a
+        missing component is omitted.
 
     .. versionchanged:: 3.0
         Passing a tuple or bytes, the ``charset`` and ``errors`` parameters,
@@ -153,10 +161,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -104,3 +104,40 @@ def test_iri_to_uri_dont_quote_valid_code_points():
 def test_itms_services() -> None:
     url = "itms-services://?action=download-manifest&url=https://test.example/path"
     assert urls.iri_to_uri(url) == url
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # an empty username with a password must keep the password
+        ("http://:pass@example.com/path", "http://:pass@example.com/path"),
+        # an empty password that is present must keep the separator
+        ("http://user:@example.com/path", "http://user:@example.com/path"),
+        # a present non-empty userinfo is unchanged
+        ("http://user:pass@example.com/path", "http://user:pass@example.com/path"),
+        # a username without a password is unchanged
+        ("http://user@example.com/path", "http://user@example.com/path"),
+        # a missing userinfo is still omitted
+        ("http://example.com/path", "http://example.com/path"),
+    ],
+)
+def test_uri_to_iri_keeps_empty_userinfo(value, expected):
+    # https://github.com/pallets/werkzeug/issues/3189
+    # urlsplit distinguishes a present-but-empty component ("") from a
+    # missing one (None), so an empty username or password must be kept.
+    assert urls.uri_to_iri(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("http://:pass@example.com/path", "http://:pass@example.com/path"),
+        ("http://user:@example.com/path", "http://user:@example.com/path"),
+        ("http://user:pass@example.com/path", "http://user:pass@example.com/path"),
+        ("http://user@example.com/path", "http://user@example.com/path"),
+        ("http://example.com/path", "http://example.com/path"),
+    ],
+)
+def test_iri_to_uri_keeps_empty_userinfo(value, expected):
+    # https://github.com/pallets/werkzeug/issues/3189
+    assert urls.iri_to_uri(value) == expected


### PR DESCRIPTION
`uri_to_iri()` and `iri_to_uri()` rebuild the userinfo part of a URL using a
truthiness check on the username and password. `urllib.parse.urlsplit`
distinguishes a present-but-empty component (`""`) from a missing one (`None`),
but because an empty string is falsy, an empty-but-present username or password
was silently dropped. The most severe case is a non-empty password being
dropped entirely when the username is empty, which is data loss during what
should be a lossless normalization:

```pycon
>>> from werkzeug.urls import uri_to_iri
>>> uri_to_iri("http://:pass@example.com/path")
'http://example.com/path'        # before: password silently dropped
'http://:pass@example.com/path'  # after
>>> uri_to_iri("http://user:@example.com/path")
'http://user@example.com/path'   # before: empty password separator dropped
'http://user:@example.com/path'  # after
```

This replaces the truthiness checks with explicit `is not None` checks so that
an empty but present username or password is preserved, and only a missing
component is omitted. The behavior now matches the stdlib round-trip
(`urlunsplit(urlsplit(...))`).

Added parametrized regression tests for both functions covering empty username,
empty password, non-empty userinfo, a username without a password, and a
missing userinfo. The tests fail without the change. Added a CHANGES.rst entry
and `.. versionchanged::` notes in the docstrings.

fixes #3189

This change was written with the assistance of Claude. I have reviewed it and
take full responsibility for its correctness.
