### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Version 3.2.0
     -   ``OrderedMultiDict`` and ``ImmutableOrderedMultiDict are removed.
         The base ``MultiDict`` already retains order.
 
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve an empty username or password
+    when converting URLs. :issue:`3189`
 -   Minimum required version of MarkupSafe is 3.0.3.
 -   Minimum supported version of Watchdog is 6.0.
 -   The CSP ``prefetch_src``, ``navigate_to``, and ``plugin_types`` properties

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -21,6 +21,20 @@ def test_iri_support():
     )
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://@example.com/path",
+        "http://:pass@example.com/path",
+        "http://user:@example.com/path",
+        "http://:@example.com/path",
+    ],
+)
+def test_iri_support_empty_userinfo(value):
+    assert urls.uri_to_iri(value) == value
+    assert urls.iri_to_uri(value) == value
+
+
 def test_iri_safe_quoting():
     uri = "http://xn--f-1gaa.com/%2F%25?q=%C3%B6&x=%3D%25#%25"
     iri = "http://föö.com/%2F%25?q=ö&x=%3D%25#%25"


### PR DESCRIPTION
Fixes #3189

`uri_to_iri` and `iri_to_uri` now preserve an empty-but-present username or password when rebuilding URL userinfo. Missing userinfo is still omitted.

Tests:
- `PYTHONPATH=src uv run --frozen pytest tests/test_urls.py -q -k empty_userinfo`
- `PYTHONPATH=src uv run --frozen pytest tests/test_urls.py -q`
- `PYTHONPATH=src uv run --frozen pytest -q --basetemp=/tmp/werkzeug-pytest`
- `uv run --frozen ruff check src/werkzeug/urls.py tests/test_urls.py`
- `uv run --frozen ruff check`
- `git diff --check`