### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   The debugger compares the PIN hash cookie and the console secret using a
+    constant-time comparison to avoid a timing side channel.
 
 
 Version 3.1.8

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import getpass
 import hashlib
+import hmac
 import json
 import os
 import pkgutil
@@ -47,6 +48,19 @@ def hash_pin(pin: str) -> str:
     return hashlib.sha3_256(f"{pin} added salt".encode("utf-8", "replace")).hexdigest()[
         :12
     ]
+
+
+def _secret_eq(value: str | None, secret: str) -> bool:
+    """Compare a client-supplied value against a server secret in constant time
+    to avoid a timing side channel. ``value`` may be ``None`` or hold non-ASCII
+    characters; both compare unequal without raising.
+    """
+    if value is None:
+        return False
+
+    return hmac.compare_digest(
+        value.encode("utf-8", "replace"), secret.encode("utf-8", "replace")
+    )
 
 
 _machine_id: str | bytes | None = None
@@ -455,7 +469,7 @@ class DebuggedApplication:
         except ValueError:
             return False
 
-        if pin_hash != hash_pin(self.pin):
+        if not _secret_eq(pin_hash, hash_pin(self.pin)):
             return None
         return (time.time() - PIN_TIME) < ts
 
@@ -551,15 +565,15 @@ class DebuggedApplication:
             frame = self.frames.get(request.args.get("frm", type=int))  # type: ignore
             if cmd == "resource" and arg:
                 response = self.get_resource(request, arg)  # type: ignore
-            elif cmd == "pinauth" and secret == self.secret:
+            elif cmd == "pinauth" and _secret_eq(secret, self.secret):
                 response = self.pin_auth(request)  # type: ignore
-            elif cmd == "printpin" and secret == self.secret:
+            elif cmd == "printpin" and _secret_eq(secret, self.secret):
                 response = self.log_pin_request(request)  # type: ignore
             elif (
                 self.evalex
                 and cmd is not None
                 and frame is not None
-                and self.secret == secret
+                and _secret_eq(secret, self.secret)
                 and self.check_pin_trust(environ)
             ):
                 response = self.execute_command(request, cmd, frame)  # type: ignore

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -316,3 +316,27 @@ def test_debugged_application_pin_security_false():
     # This should not raise AttributeError
     debugged = DebuggedApplication(app, evalex=True, pin_security=False)
     assert debugged.pin is None
+
+
+def test_check_pin_trust_hash_comparison():
+    import time
+
+    from werkzeug.debug import _secret_eq
+    from werkzeug.debug import hash_pin
+    from werkzeug.test import create_environ
+
+    debugged = DebuggedApplication(lambda e, s: [b""], evalex=True)
+    pin = debugged.pin
+    name = debugged._pin_cookie
+    now = int(time.time())
+
+    good = create_environ(headers={"Cookie": f"{name}={now}|{hash_pin(pin)}"})
+    assert debugged.check_pin_trust(good) is True
+
+    wrong = create_environ(headers={"Cookie": f"{name}={now}|{'0' * 12}"})
+    assert debugged.check_pin_trust(wrong) is None
+
+    # A non-ASCII or missing secret compares unequal without raising.
+    assert _secret_eq(debugged.secret, debugged.secret) is True
+    assert _secret_eq(None, debugged.secret) is False
+    assert _secret_eq("café☃", debugged.secret) is False


### PR DESCRIPTION
The debugger authenticates the eval console and pin flow by comparing a client-supplied value against a server secret with plain `==`/`!=`: the console `s` parameter against `self.secret`, and the pin-hash cookie against `hash_pin(self.pin)` in `check_pin_trust`. Python string comparison short-circuits at the first differing byte, so both leak how much of the secret matched through response timing, and the `s` comparison runs before any pin lockout applies. Route them through `hmac.compare_digest` with a small `_secret_eq` helper that also treats `None` and non-ASCII input as unequal, the same constant-time approach already used in `check_password_hash`.