### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 


### PR DESCRIPTION
Fixes #3189

## Problem

`uri_to_iri()` and `iri_to_uri()` use truthiness checks (`if parts.username:`, `if parts.password:`) to decide whether to include credentials in the reconstructed URL. Since empty string is falsy, an empty-but-present username or password is silently dropped:

```python
>>> from werkzeug.urls import uri_to_iri, iri_to_uri
>>> uri_to_iri("http://:pass@example.com/path")
'http://example.com/path'        # password silently dropped
>>> uri_to_iri("http://user:@example.com/path")
'http://user@example.com/path'   # empty password separator dropped
```

The stdlib preserves these correctly:

```python
>>> from urllib.parse import urlsplit, urlunsplit
>>> urlunsplit(urlsplit("http://:pass@example.com/path"))
'http://:pass@example.com/path'
```

## Fix

Replace truthiness checks with `is not None` checks in both `uri_to_iri` and `iri_to_uri`. `urlsplit` returns `None` when a component is absent and `""` when it is present but empty, so `is not None` is the correct sentinel:

```python
# before
if parts.username:
    ...
    if parts.password:

# after
if parts.username is not None:
    ...
    if parts.password is not None:
```

Normal (non-empty) credentials are unaffected.