### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   The multipart parser does not append a stray ``\r`` to a part when a partial
+    closing boundary is split across chunks. :pr:`3202`
 
 
 Version 3.1.8

--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -273,8 +273,9 @@ class MultipartDecoder:
         # could be present in the data. This will be the earliest
         # position of a LF or a CR, unless that position is more
         # than a complete boundary from the end in which case there
-        # is no partial boundary.
-        complete_boundary_index = len(data) - len(b"\r\n--" + self.boundary)
+        # is no partial boundary. The closing boundary "--" suffix is
+        # included so a partial closing boundary is not treated as data.
+        complete_boundary_index = len(data) - len(b"\r\n--" + self.boundary + b"--")
         try:
             last_nl = data.rindex(b"\n")
         except ValueError:

--- a/tests/sansio/test_multipart.py
+++ b/tests/sansio/test_multipart.py
@@ -131,6 +131,33 @@ def test_chunked_boundaries() -> None:
     assert isinstance(decoder.next_event(), Epilogue)
 
 
+def test_chunked_does_not_leak_closing_boundary_cr() -> None:
+    # The closing delimiter "\r\n--foo--" is two bytes longer than the
+    # opening one, so when it is delivered a byte at a time the decoder
+    # would briefly hold "\r\n--foo-" and emit the leading "\r" as part
+    # data, corrupting the last part with a trailing "\r".
+    boundary = b"foo"
+    payload = b"some content"
+    data = (
+        b"--foo\r\n"
+        b'Content-Disposition: form-data; name="test"\r\n\r\n'
+        + payload
+        + b"\r\n--foo--\r\n"
+    )
+    decoder = MultipartDecoder(boundary)
+    received = bytearray()
+    for i in range(len(data)):
+        decoder.receive_data(data[i : i + 1])
+        while True:
+            event = decoder.next_event()
+            if isinstance(event, NeedData):
+                break
+            if isinstance(event, Data):
+                received += event.data
+    decoder.receive_data(None)
+    assert bytes(received) == payload
+
+
 def test_empty_field() -> None:
     boundary = b"foo"
     decoder = MultipartDecoder(boundary)


### PR DESCRIPTION
`_last_partial_boundary_index` sizes the boundary window with the opening delimiter, but the closing delimiter `\r\n--boundary--` is two bytes longer, so when a body is fragmented such that the buffer briefly holds `\r\n--boundary-` the leading CR is treated as content and a stray `\r` is appended to the last part. Because the chunk edges are set by the network, the same upload can decode differently between runs, and saved file contents pick up the extra byte too. Including the closing `--` when computing the window holds the partial closing boundary back until the rest arrives.