### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve empty usernames and passwords in
+    URL userinfo. :issue:`3189`
 
 
 Version 3.1.8

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -21,6 +21,32 @@ def test_iri_support():
     )
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://:pass@example.com/path",
+        "http://user:@example.com/path",
+        "http://@example.com/path",
+        "http://:@example.com/path",
+    ],
+)
+def test_uri_to_iri_preserves_empty_userinfo(url):
+    assert urls.uri_to_iri(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://:pass@example.com/path",
+        "http://user:@example.com/path",
+        "http://@example.com/path",
+        "http://:@example.com/path",
+    ],
+)
+def test_iri_to_uri_preserves_empty_userinfo(url):
+    assert urls.iri_to_uri(url) == url
+
+
 def test_iri_safe_quoting():
     uri = "http://xn--f-1gaa.com/%2F%25?q=%C3%B6&x=%3D%25#%25"
     iri = "http://föö.com/%2F%25?q=ö&x=%3D%25#%25"


### PR DESCRIPTION
Fixes #3189

## Summary
- Preserve empty-but-present usernames and passwords when rebuilding URLs in `uri_to_iri` and `iri_to_uri`.
- Add regression tests for empty username, empty password, empty username with password, and empty username with empty password.
- Add a changelog entry for the fix.

## Root cause
`urlsplit` represents missing userinfo as `None`, but present empty userinfo as an empty string. The URL conversion helpers used truthiness checks, so empty-but-present components were treated as missing and dropped from the rebuilt netloc.

## Checks
- `.venv/bin/python -m pytest tests/test_urls.py -q`
- `.venv/bin/python -m ruff check src/werkzeug/urls.py tests/test_urls.py`
- `.venv/bin/python -m ruff format --check src/werkzeug/urls.py tests/test_urls.py`
- `.venv/bin/python -m mypy src/werkzeug/urls.py`