### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -19,6 +19,10 @@ def test_iri_support():
         urls.iri_to_uri("http://föö.com:8080/bam/baz")
         == "http://xn--f-1gaa.com:8080/bam/baz"
     )
+    assert urls.uri_to_iri("http://:pass@example.com/") == "http://:pass@example.com/"
+    assert urls.uri_to_iri("http://user:@example.com/") == "http://user:@example.com/"
+    assert urls.iri_to_uri("http://:pass@example.com/") == "http://:pass@example.com/"
+    assert urls.iri_to_uri("http://user:@example.com/") == "http://user:@example.com/"
 
 
 def test_iri_safe_quoting():


### PR DESCRIPTION
When `uri_to_iri` and `iri_to_uri` reconstruct the userinfo portion of a URL, they check `parts.username` and `parts.password` for truthiness. However, an empty username or password string (such as in `http://:pass@example.com` or `http://user:@example.com`) is falsy, causing it to be dropped.

Checking against `None` instead of truthiness ensures present-but-empty components are correctly retained in the output URL.