### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -100,6 +100,26 @@ def test_iri_to_uri_dont_quote_valid_code_points():
     assert urls.iri_to_uri("/path[bracket]?(paren)") == "/path%5Bbracket%5D?(paren)"
 
 
+def test_empty_username_password_uri_to_iri() -> None:
+    """Empty but present username/password should not be dropped."""
+    # Non-empty password with empty username
+    assert urls.uri_to_iri("http://:pass@example.com/path") == "http://:pass@example.com/path"
+    # Empty password with non-empty username
+    assert urls.uri_to_iri("http://user:@example.com/path") == "http://user:@example.com/path"
+    # Both empty
+    assert urls.uri_to_iri("http://:@example.com/path") == "http://:@example.com/path"
+    # No auth at all is unaffected
+    assert urls.uri_to_iri("http://example.com/path") == "http://example.com/path"
+
+
+def test_empty_username_password_iri_to_uri() -> None:
+    """Empty but present username/password should not be dropped."""
+    assert urls.iri_to_uri("http://:pass@example.com/path") == "http://:pass@example.com/path"
+    assert urls.iri_to_uri("http://user:@example.com/path") == "http://user:@example.com/path"
+    assert urls.iri_to_uri("http://:@example.com/path") == "http://:@example.com/path"
+    assert urls.iri_to_uri("http://example.com/path") == "http://example.com/path"
+
+
 # Python < 3.12
 def test_itms_services() -> None:
     url = "itms-services://?action=download-manifest&url=https://test.example/path"

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -103,9 +103,15 @@ def test_iri_to_uri_dont_quote_valid_code_points():
 def test_empty_username_password_uri_to_iri() -> None:
     """Empty but present username/password should not be dropped."""
     # Non-empty password with empty username
-    assert urls.uri_to_iri("http://:pass@example.com/path") == "http://:pass@example.com/path"
+    assert (
+        urls.uri_to_iri("http://:pass@example.com/path")
+        == "http://:pass@example.com/path"
+    )
     # Empty password with non-empty username
-    assert urls.uri_to_iri("http://user:@example.com/path") == "http://user:@example.com/path"
+    assert (
+        urls.uri_to_iri("http://user:@example.com/path")
+        == "http://user:@example.com/path"
+    )
     # Both empty
     assert urls.uri_to_iri("http://:@example.com/path") == "http://:@example.com/path"
     # No auth at all is unaffected
@@ -114,8 +120,14 @@ def test_empty_username_password_uri_to_iri() -> None:
 
 def test_empty_username_password_iri_to_uri() -> None:
     """Empty but present username/password should not be dropped."""
-    assert urls.iri_to_uri("http://:pass@example.com/path") == "http://:pass@example.com/path"
-    assert urls.iri_to_uri("http://user:@example.com/path") == "http://user:@example.com/path"
+    assert (
+        urls.iri_to_uri("http://:pass@example.com/path")
+        == "http://:pass@example.com/path"
+    )
+    assert (
+        urls.iri_to_uri("http://user:@example.com/path")
+        == "http://user:@example.com/path"
+    )
     assert urls.iri_to_uri("http://:@example.com/path") == "http://:@example.com/path"
     assert urls.iri_to_uri("http://example.com/path") == "http://example.com/path"
 


### PR DESCRIPTION
## Summary

uri_to_iri and iri_to_uri use truthiness checks on username/password, dropping empty-but-present values.

## Root cause

urlsplit returns empty string '' for a present-but-empty component and None for a missing one. The truthiness check treats both the same, so http://:pass@host/ (empty username, non-empty password) loses the password.

## Solution

Changed if username: to if username is not None: (same for password). Only a truly missing component is omitted.

## Test Plan

Added test_empty_username_password_uri_to_iri and test_empty_username_password_iri_to_uri. Full suite: 991 passed, 1 skipped.

## References

Fixes #3189