### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 Version 3.2.0
 -------------
 
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve empty username and password
+    components. :issue:`3189`
 -   Drop support for Python 3.9. :pr:`3098`
 -   Remove previous deprecated code: :pr:`3099`
 

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -21,6 +21,20 @@ def test_iri_support():
     )
 
 
+@pytest.mark.parametrize("convert", [urls.uri_to_iri, urls.iri_to_uri])
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://@example.com/",
+        "http://:password@example.com/",
+        "http://user:@example.com/",
+        "http://:@example.com/",
+    ],
+)
+def test_iri_preserves_empty_userinfo(convert, value):
+    assert convert(value) == value
+
+
 def test_iri_safe_quoting():
     uri = "http://xn--f-1gaa.com/%2F%25?q=%C3%B6&x=%3D%25#%25"
     iri = "http://föö.com/%2F%25?q=ö&x=%3D%25#%25"


### PR DESCRIPTION
## Summary

- preserve present-but-empty username and password components in `uri_to_iri` and `iri_to_uri`
- distinguish a missing userinfo component (`None`) from an empty one (`""`)
- add coverage for empty usernames, passwords, and both components, and document the fix in the changelog

Fixes #3189.

## Validation

- `python -m pytest tests/test_urls.py -q`
- `python -m ruff check src/werkzeug/urls.py tests/test_urls.py`
- `git diff --check`
