### PR TITLE
Disable fallback on deprecated profile module

### DIFF
--- a/src/werkzeug/middleware/profiler.py
+++ b/src/werkzeug/middleware/profiler.py
@@ -18,12 +18,10 @@ import os.path
 import sys
 import time
 import typing as t
+from cProfile import (
+    Profile,  # no longer use profile as fallback, as it was deprecated in Python 3.15
+)
 from pstats import Stats
-
-try:
-    from cProfile import Profile
-except ImportError:
-    from profile import Profile  # type: ignore
 
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse


### PR DESCRIPTION
The profile module was deprecated in Python 3.15 (https://docs.python.org/3.15/whatsnew/3.15.html#pep-799-a-dedicated-profiling-package).
This PR removes the fallback on the profile module.This should fix the test error originating in from the  DeprecationWarning

fixes #3207 
