### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,13 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    # Distinguish missing (None) from present-but-empty ("") userinfo parts.
+    # Truthiness checks drop empty username/password and can lose a password
+    # when only the password is present (http://:pass@host). See #3189.
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +156,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -94,6 +94,16 @@ def test_uri_to_iri_dont_unquote_space():
     assert urls.uri_to_iri("abc%20def") == "abc%20def"
 
 
+def test_uri_to_iri_preserves_empty_userinfo():
+    """Empty-but-present username/password must not be dropped (#3189)."""
+    assert urls.uri_to_iri("http://:pass@example.com/path") == "http://:pass@example.com/path"
+    assert urls.uri_to_iri("http://user:@example.com/path") == "http://user:@example.com/path"
+    assert urls.iri_to_uri("http://:pass@example.com/path") == "http://:pass@example.com/path"
+    assert urls.iri_to_uri("http://user:@example.com/path") == "http://user:@example.com/path"
+    # Missing auth still omitted
+    assert urls.uri_to_iri("http://example.com/path") == "http://example.com/path"
+
+
 def test_iri_to_uri_dont_quote_valid_code_points():
     # [] are not valid URL code points according to WhatWG URL Standard
     # https://url.spec.whatwg.org/#url-code-points


### PR DESCRIPTION
## Summary

Fixes #3189.

\uri_to_iri\ / \iri_to_uri\ rebuilt userinfo with truthiness checks on username/password. Empty strings are falsy, so empty-but-present components were dropped (including dropping a non-empty password when the username was empty).

### Change
Use \is not None\ checks so present-but-empty userinfo is preserved.

## Test plan
- [x] Manual asserts for empty-user / empty-password cases
- [x] pytest tests/test_urls.py::test_uri_to_iri_preserves_empty_userinfo --noconftest -q
