### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   ``HeaderSet.remove`` removes members case insensitively, matching the
+    documented behavior of the class. Previously removing a member by its
+    original upper or mixed case left it in the header list. :pr:`3211`
 
 
 Version 3.1.8

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -790,8 +790,8 @@ class HeaderSet(cabc.MutableSet[str]):
         if key not in self._set:
             raise KeyError(header)
         self._set.remove(key)
-        for idx, key in enumerate(self._headers):
-            if key.lower() == header:
+        for idx, item in enumerate(self._headers):
+            if item.lower() == key:
                 del self._headers[idx]
                 break
         if self._on_update is not None:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -744,6 +744,22 @@ class TestHeaderSet:
         hs.clear()
         assert not hs
 
+    def test_remove_is_case_insensitive(self):
+        # HeaderSet is documented as case insensitive. Removing a member
+        # using its original (upper or mixed) case must drop it from both
+        # the internal set and the ordered header list, e.g. an ``Allow``
+        # header whose methods are upper case.
+        hs = self.storage_class(["GET", "POST", "HEAD"])
+        hs.remove("GET")
+        assert "GET" not in hs
+        assert len(hs) == 2
+        assert list(hs) == ["POST", "HEAD"]
+        assert hs.to_header() == "POST, HEAD"
+
+        # Removing using a different case than stored also works.
+        hs.discard("head")
+        assert list(hs) == ["POST"]
+
 
 class TestImmutableList:
     storage_class = ds.ImmutableList


### PR DESCRIPTION
`HeaderSet` is documented as case insensitive ("Unlike `ETags` this is case insensitive and used for vary, allow, and content-language headers") and keeps two parallel stores that must stay in sync:

- `_set` — lowercased keys, used for membership and `len()`
- `_headers` — original casing, order preserving, used for iteration and `to_header()`

`HeaderSet.remove` removed the lowercased key from `_set` correctly, but when scanning `_headers` it compared the stored header's lowercased form against the **un-lowercased** `header` argument:

```python
self._set.remove(key)
for idx, key in enumerate(self._headers):
    if key.lower() == header:   # compares lower(stored) to raw argument
        del self._headers[idx]
        break
```

That equality only holds when `header` is already all-lowercase. Removing a member by its original upper/mixed case leaves it in `_headers` while dropping it from `_set`, permanently desynchronizing the two stores. This affects real headers whose members are upper/mixed case, e.g. the methods in `Allow`, or entries in `Vary` / `Content-Language`.

```python
>>> from werkzeug.datastructures import HeaderSet
>>> hs = HeaderSet(["GET", "POST", "HEAD"])
>>> hs.discard("GET")
>>> "GET" in hs        # from _set
False
>>> len(hs)            # from _set
2
>>> hs.to_header()     # from _headers -- GET is still here
'GET, POST, HEAD'
>>> list(hs)
['GET', 'POST', 'HEAD']
```

The sibling `HeaderSet.find` already does this correctly (it lowercases the argument first, then compares `item.lower() == header`). This change compares against the lowercased `key` the same way, and renames the loop variable so it no longer shadows `key`.

A regression test is added covering removal by upper/mixed case; it fails before this change and passes after.