### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve explicitly empty usernames and
+    passwords in URL userinfo. :issue:`3189`
 
 
 Version 3.1.8

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,10 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
-        auth = _unquote_user(parts.username)
+    if parts.username is not None or parts.password is not None:
+        auth = _unquote_user(parts.username or "")
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +153,10 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
-        auth = quote(parts.username, safe="%!$&'()*+,;=")
+    if parts.username is not None or parts.password is not None:
+        auth = quote(parts.username or "", safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -100,6 +100,19 @@ def test_iri_to_uri_dont_quote_valid_code_points():
     assert urls.iri_to_uri("/path[bracket]?(paren)") == "/path%5Bbracket%5D?(paren)"
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://:pass@example.com/path",
+        "http://user:@example.com/path",
+        "http://@example.com/path",
+    ],
+)
+def test_userinfo_preserves_empty_components(url):
+    assert urls.uri_to_iri(url) == url
+    assert urls.iri_to_uri(url) == url
+
+
 # Python < 3.12
 def test_itms_services() -> None:
     url = "itms-services://?action=download-manifest&url=https://test.example/path"


### PR DESCRIPTION
## Summary

- preserve explicitly empty usernames and passwords when converting between URI and IRI forms
- distinguish an absent userinfo component (None) from an explicitly empty component (empty string)
- add regression coverage for empty username, empty password, and both components

This prevents URL normalization from silently dropping credentials or the userinfo delimiter.

## Validation

- python -m pytest tests/test_urls.py -q (20 passed)
- python -m ruff check src/werkzeug/urls.py tests/test_urls.py
- python -m compileall -q src/werkzeug/urls.py tests/test_urls.py
- git diff --check

Closes #3189