### PR TITLE
fix boolean logic for external url

### DIFF
--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -960,13 +960,10 @@ class MapAdapter:
 
         # Return a plain path if neither host or subdomain matching is enabled,
         # or if they are enabled and the current host matches.
-        if (
-            not force_external
-            and (self.map.subdomain_matching or self.map.host_matching)
-            and (
-                (self.map.subdomain_matching and domain_part == self.subdomain)
-                or (self.map.host_matching and host == self.server_name)
-            )
+        if not force_external and (
+            not (self.map.subdomain_matching or self.map.host_matching)
+            or (self.map.subdomain_matching and domain_part == self.subdomain)
+            or (self.map.host_matching and host == self.server_name)
         ):
             return f"{self.script_name.rstrip('/')}/{path.lstrip('/')}"
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1433,6 +1433,16 @@ class TestNoDomainMatching(_Routing):
     def test_match_ignore_subdomain(self) -> None:
         assert self._match(base_url="static.app.test") == ("index", {})
 
+    def test_build_relative(self) -> None:
+        assert self._build("index") == "/"
+
+    def test_build_external(self) -> None:
+        """server_name is used over host"""
+        assert (
+            self._build("index", base_url="untrusted.test", external=True)
+            == "http://app.test/"
+        )
+
 
 def test_server_name_casing():
     m = r.Map([r.Rule("/", endpoint="index", subdomain="foo")])


### PR DESCRIPTION
The check for disabled matching was backwards, meaning `build` would always create external URLs. Adds a test to verify that `external` prefers `server_name` over `host`, since `host` can be arbitrary in that case.