### PR TITLE
use `profiling.tracing` on Python 3.15

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Version 3.1.9
 
 Unreleased
 
+-   ``ProfilerMiddleware`` uses ``profiling.tracing`` on Python 3.15. :issue:`3207`
+
 
 Version 3.1.8
 -------------

--- a/src/werkzeug/middleware/profiler.py
+++ b/src/werkzeug/middleware/profiler.py
@@ -20,10 +20,13 @@ import time
 import typing as t
 from pstats import Stats
 
-try:
-    from cProfile import Profile
-except ImportError:
-    from profile import Profile  # type: ignore
+if sys.version_info >= (3, 15):
+    from profiling.tracing import Profile
+else:
+    try:
+        from cProfile import Profile
+    except ImportError:
+        from profile import Profile  # type: ignore[assignment]
 
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse


### PR DESCRIPTION
Python 3.15 adds `profiling.tracing`. `cProfile` is still an alias to it, but `profile` is deprecated.

closes #3207 