### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve an empty but present username or
+    password in the userinfo component instead of silently dropping it.
+    :issue:`3189`
 
 
 Version 3.1.8

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -98,10 +98,12 @@ def uri_to_iri(uri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    # An empty-but-present username or password must be preserved. Only a
+    # missing component (``None``) is omitted, matching urlsplit/urlunsplit.
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -153,10 +155,12 @@ def iri_to_uri(iri: str) -> str:
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    # An empty-but-present username or password must be preserved. Only a
+    # missing component (``None``) is omitted, matching urlsplit/urlunsplit.
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -100,6 +100,32 @@ def test_iri_to_uri_dont_quote_valid_code_points():
     assert urls.iri_to_uri("/path[bracket]?(paren)") == "/path%5Bbracket%5D?(paren)"
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://user:pass@example.com/path",
+        "http://user@example.com/path",
+        # An empty-but-present username or password must be preserved rather
+        # than silently dropped. See issue #3189.
+        "http://:pass@example.com/path",
+        "http://user:@example.com/path",
+        "http://:@example.com/path",
+        "http://@example.com/path",
+        "http://example.com/path",
+    ],
+)
+def test_uri_iri_preserve_empty_userinfo(value):
+    # A present-but-empty username/password (``""``) differs from a missing
+    # one (``None``); only the missing component may be dropped. The stdlib
+    # urlsplit/urlunsplit round-trip is the correctness oracle.
+    from urllib.parse import urlsplit
+    from urllib.parse import urlunsplit
+
+    expected = urlunsplit(urlsplit(value))
+    assert urls.uri_to_iri(value) == expected
+    assert urls.iri_to_uri(value) == expected
+
+
 # Python < 3.12
 def test_itms_services() -> None:
     url = "itms-services://?action=download-manifest&url=https://test.example/path"


### PR DESCRIPTION
Fixes #3189.

### Problem

`uri_to_iri` and `iri_to_uri` silently drop a present-but-empty username or
password in the userinfo component, which is data loss in a normalization that
should round-trip losslessly:

```python
>>> uri_to_iri("http://:pass@example.com/path")
'http://example.com/path'          # the password `pass` is gone
```

`urllib.parse.urlsplit`/`urlunsplit` round-trips these correctly, so the
normalization is dropping information the standard library preserves.

### Root cause

The userinfo reconstruction uses truthiness checks (`if parts.username:` /
`if parts.password:`). `urlsplit` represents a present-but-empty component as
`""` (never `None`), so an empty string is falsy and gets treated as absent.

### Fix

Use presence checks (`is not None`) instead. Since `urlsplit` yields
`username=""` whenever an `@` is present, `username is not None` means "userinfo
present," and `password is not None` decides whether to emit the `:password`
segment. This reproduces stdlib formatting for all shapes
(`user:pass@`, `user@`, `:pass@`, `user:@`, `:@`, `@`) and omits userinfo only
when it is truly absent. Applied to both `uri_to_iri` and `iri_to_uri`.

### Tests

Adds `test_uri_iri_preserve_empty_userinfo` (parametrized over the userinfo
shapes), which fails without the change and passes with it. Full `test_urls.py`
suite passes; percent-encoding and IDNA/host handling are untouched.
