### PR TITLE
uri iri coversion preserves empty username, password, port 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 3.1.9
 Unreleased
 
 -   ``ProfilerMiddleware`` uses ``profiling.tracing`` on Python 3.15. :issue:`3207`
+-   ``uri_to_iri`` and ``iri_to_uri`` preserve empty username, password, and
+    port 0. :issue:`3189`
 
 
 Version 3.1.8

--- a/src/werkzeug/urls.py
+++ b/src/werkzeug/urls.py
@@ -68,6 +68,9 @@ def uri_to_iri(uri: str) -> str:
 
     :param uri: The URI to convert.
 
+    .. versionchanged:: 3.1.9
+        Empty username, password, and port 0 are preserved.
+
     .. versionchanged:: 3.0
         Passing a tuple or bytes, and the ``charset`` and ``errors`` parameters,
         are removed.
@@ -95,13 +98,13 @@ def uri_to_iri(uri: str) -> str:
     if ":" in netloc:
         netloc = f"[{netloc}]"
 
-    if parts.port:
+    if parts.port is not None:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = _unquote_user(parts.username)
 
-        if parts.password:
+        if parts.password is not None:
             password = _unquote_user(parts.password)
             auth = f"{auth}:{password}"
 
@@ -118,6 +121,9 @@ def iri_to_uri(iri: str) -> str:
     'http://xn--n3h.net/p%C3%A5th?q=%C3%A8ry%DF'
 
     :param iri: The IRI to convert.
+
+    .. versionchanged:: 3.1.9
+        Empty username, password, and port 0 are preserved.
 
     .. versionchanged:: 3.0
         Passing a tuple or bytes, the ``charset`` and ``errors`` parameters,
@@ -150,13 +156,13 @@ def iri_to_uri(iri: str) -> str:
     if ":" in netloc:
         netloc = f"[{netloc}]"
 
-    if parts.port:
+    if parts.port is not None:
         netloc = f"{netloc}:{parts.port}"
 
-    if parts.username:
+    if parts.username is not None:
         auth = quote(parts.username, safe="%!$&'()*+,;=")
 
-        if parts.password:
+        if parts.password is not None:
             password = quote(parts.password, safe="%!$&'()*+,;=")
             auth = f"{auth}:{password}"
 

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -104,3 +104,17 @@ def test_iri_to_uri_dont_quote_valid_code_points():
 def test_itms_services() -> None:
     url = "itms-services://?action=download-manifest&url=https://test.example/path"
     assert urls.iri_to_uri(url) == url
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["http://:p@d.test", "http://u:@d.test", "http://:@d.test", "http://u@d.test"],
+)
+def test_uri_empty_auth(value: str) -> None:
+    assert urls.uri_to_iri(value) == value
+    assert urls.iri_to_uri(value) == value
+
+
+def test_uri_port_0() -> None:
+    assert urls.uri_to_iri("http://d.test:0") == "http://d.test:0"
+    assert urls.iri_to_uri("http://d.test:0") == "http://d.test:0"


### PR DESCRIPTION
The username and password parts of a URL can be empty (`""`), rather than omitted (`None`). The functions now check specifically for `None` so that empty parts are not dropped. One or both parts can be empty, or a username can be given while omitting a password. Also noticed a similar thing would happen for port 0 (looks false).

fixes #3189 