### PR TITLE
add `client.query` method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,7 @@ Version 3.2.0
     ETag will be different. :pr:`3164`
 -   ``generate_password_hash`` uses ``secrets.token_urlsafe`` to generate salt.
     The private ``gen_salt`` method is removed. :pr:`3167`
+-   The test ``Client`` has a ``query`` method for the ``QUERY`` request method.
 
 
 Version 3.1.9

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -61,9 +61,8 @@ def parse_form_data(
     max_form_parts: int | None = None,
     **kwargs: t.Any,
 ) -> t_parse_result:
-    """Parse the form data in the environ and return it as tuple in the form
-    ``(stream, form, files)``.  You should only call this method if the
-    transport method is `POST`, `PUT`, or `PATCH`.
+    """Parse the form data from the request body and return it as a
+    tuple ``(stream, form, files)``.
 
     If the mimetype of the data transmitted is `multipart/form-data` the
     files multidict will be filled with `FileStorage` objects.  If the

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -1155,6 +1155,14 @@ class Client:
         kw["method"] = "GET"
         return self.open(*args, **kw)
 
+    def query(self, *args: t.Any, **kw: t.Any) -> TestResponse:
+        """Call :meth:`open` with ``method`` set to ``QUERY``.
+
+        .. versionadded:: 3.2
+        """
+        kw["method"] = "QUERY"
+        return self.open(*args, **kw)
+
     def post(self, *args: t.Any, **kw: t.Any) -> TestResponse:
         """Call :meth:`open` with ``method`` set to ``POST``."""
         kw["method"] = "POST"


### PR DESCRIPTION
[RFC 10008](https://datatracker.ietf.org/doc/html/rfc10008) isn't accepted yet, but it's been kicking around for years and looks like it will pass. I'm adding it now so I don't have to watch it anymore.

closes #3193 