### PR TITLE
fix: correct docstring spelling

### DIFF
--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -73,7 +73,7 @@ def parse_form_data(
 
     :param environ: the WSGI environment to be used for parsing.
     :param stream_factory: An optional callable that returns a new read and
-                           writeable file descriptor.  This callable works
+                           writable file descriptor.  This callable works
                            the same as :meth:`Response._get_file_stream`.
     :param max_form_memory_size: the maximum number of bytes to be accepted for
                            in-memory stored form data.  If the data
@@ -136,7 +136,7 @@ class FormDataParser:
     object.
 
     :param stream_factory: An optional callable that returns a new read and
-                           writeable file descriptor.  This callable works
+                           writable file descriptor.  This callable works
                            the same as :meth:`Response._get_file_stream`.
     :param max_form_memory_size: the maximum number of bytes to be accepted for
                            in-memory stored form data.  If the data

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -205,7 +205,7 @@ class Request(_SansIORequest):
         """Called to get a stream for the file upload.
 
         This must provide a file-like class with `read()`, `readline()`
-        and `seek()` methods that is both writeable and readable.
+        and `seek()` methods that is both writable and readable.
 
         The default implementation returns a temporary file if the total
         content length is higher than 500KB.  Because many browsers do not


### PR DESCRIPTION
Fixes: writeable → writable in request.py and formparser.py docstrings