### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Version 3.2.0
 -------------
 
 -   Drop support for Python 3.9. :pr:`3098`
+-   ``ContentRange.from_header`` rejects a value whose complete-length is
+    not greater than the last-byte-pos, such as ``bytes 0-499/100``.
+    :issue:`3227`
 -   Remove previous deprecated code: :pr:`3099`
 
     -   ``OrderedMultiDict`` and ``ImmutableOrderedMultiDict are removed.

--- a/src/werkzeug/datastructures/range.py
+++ b/src/werkzeug/datastructures/range.py
@@ -323,10 +323,17 @@ class ContentRange:
         except ValueError:
             return None
 
-        if is_byte_range_valid(start, stop, length):
-            return cls(units, start, stop, length)
+        if not is_byte_range_valid(start, stop, length):
+            return None
 
-        return None
+        # RFC 9110 section 14.4 additionally makes a complete-length that is
+        # not greater than the last-byte-pos invalid. ``is_byte_range_valid``
+        # is shared with ``Range``, where a range extending past the length is
+        # merely unsatisfiable and gets clamped, so check that here instead.
+        if length is not None and stop > length:
+            return None
+
+        return cls(units, start, stop, length)
 
     def to_header(self) -> str:
         """Convert to a ``Content-Range`` header value."""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -700,6 +700,21 @@ class TestRange:
         assert rv.length == 100
         assert rv.units == "bytes"
 
+    @pytest.mark.parametrize(
+        "value", ["bytes 0-499/100", "bytes 0-100/100", "bytes 100-100/100"]
+    )
+    def test_content_range_length_not_past_last_byte(self, value):
+        """RFC 9110 section 14.4 makes a complete-length that is not greater
+        than the last-byte-pos invalid."""
+        assert ContentRange.from_header(value) is None
+
+    def test_content_range_length_equal_to_stop(self):
+        """The last byte of the representation is still valid."""
+        rv = ContentRange.from_header("bytes 0-99/100")
+        assert rv is not None
+        assert rv.stop == 100
+        assert rv.length == 100
+
 
 class TestRegression:
     def test_best_match_works(self):


### PR DESCRIPTION
RFC 9110 section 14.4 makes a Content-Range invalid when the complete-length is less than or equal to the last-byte-pos, but ``bytes 0-499/100`` and ``bytes 0-100/100`` were both accepted:

```python
>>> from werkzeug.datastructures import ContentRange
>>> ContentRange.from_header("bytes 0-499/100")
<ContentRange 'bytes 0-499/100'>     # now None
>>> ContentRange.from_header("bytes 0-100/100")
<ContentRange 'bytes 0-100/100'>     # now None
```

The check goes in `ContentRange.from_header` rather than in `is_byte_range_valid`, because that helper is shared with `Range`, where a range extending past the length is merely unsatisfiable and is clamped by `range_for_length` instead of being rejected. Tightening the shared helper would turn `Range: bytes=0-499` against a 100 byte resource into a 416 instead of the correct `(0, 100)`; the existing test covering that clamping still passes.

`ContentRange.set` still uses its existing `assert`, which I left alone to keep this change to the parsing path.

fixes #3227

- Added `test_content_range_length_not_past_last_byte` covering `bytes 0-499/100`, `bytes 0-100/100`, and `bytes 100-100/100`, plus `test_content_range_length_equal_to_stop` confirming `bytes 0-99/100` still parses. The first two cases fail without the change.
- Added a CHANGES.rst entry linking the issue.
- No docs changes; this corrects existing validation rather than changing a documented API, so no `.. versionchanged::` entry seemed warranted. Happy to add one if you would prefer it noted.