### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Version 3.2.0
     ``Sequence``. These were previously overridable to allow ordered data
     structures when needed, but Python's ``dict`` now guarantees order. This
     improves static typing. :pr:`3169`
+-   ``Headers`` no longer allows newlines in header keys, matching the existing
+    behavior for header values. Previously only values were checked, so a key
+    containing ``\r\n`` could inject extra headers. :pr:`3230`
 -   ``HTTP_STATUS_CODES`` is deprecated. Use Python's built-in
     ``http.HTTPStatus`` instead. Reason phrases use the more common title case
     rather than upper case. :pr:`3139`

--- a/src/werkzeug/datastructures/headers.py
+++ b/src/werkzeug/datastructures/headers.py
@@ -359,7 +359,7 @@ class Headers:
             value = _options_header_vkw(value, kwargs)
 
         value_str = _str_header_value(value)
-        self._list.append((key, value_str))
+        self._list.append((_str_header_key(key), value_str))
 
     def add_header(self, key: str, value: t.Any, /, **kwargs: t.Any) -> None:
         """Add a new header tuple to the list.
@@ -391,6 +391,7 @@ class Headers:
         if kwargs:
             value = _options_header_vkw(value, kwargs)
 
+        key = _str_header_key(key)
         value_str = _str_header_value(value)
 
         if not self._list:
@@ -483,9 +484,11 @@ class Headers:
         if isinstance(key, str):
             self.set(key, value)
         elif isinstance(key, int):
-            self._list[key] = value[0], _str_header_value(value[1])  # type: ignore[index]
+            self._list[key] = _str_header_key(value[0]), _str_header_value(value[1])  # type: ignore[index]
         else:
-            self._list[key] = [(k, _str_header_value(v)) for k, v in value]  # type: ignore[str-unpack]
+            self._list[key] = [  # type: ignore[str-unpack]
+                (_str_header_key(k), _str_header_value(v)) for k, v in value
+            ]
 
     def update(
         self,
@@ -589,6 +592,13 @@ def _options_header_vkw(value: str, kw: dict[str, t.Any]) -> str:
 
 
 _newline_re = re.compile(r"[\r\n]")
+
+
+def _str_header_key(key: str) -> str:
+    if _newline_re.search(key) is not None:
+        raise ValueError("Header keys must not contain newline characters.")
+
+    return key
 
 
 def _str_header_value(value: t.Any) -> str:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -579,6 +579,25 @@ class TestHeaders:
             with pytest.raises(ValueError):
                 h.set("foo", "test", option=variation)
 
+    def test_reject_newlines_in_keys(self):
+        h = self.storage_class()
+
+        for variation in "foo\nbar", "foo\r\nbar", "foo\rbar":
+            with pytest.raises(ValueError):
+                h[variation] = "test"
+            with pytest.raises(ValueError):
+                h.add(variation, "test")
+            with pytest.raises(ValueError):
+                h.set(variation, "test")
+            with pytest.raises(ValueError):
+                h.setdefault(variation, "test")
+            with pytest.raises(ValueError):
+                h.setlist(variation, ["test"])
+            with pytest.raises(ValueError):
+                h.extend([(variation, "test")])
+            with pytest.raises(ValueError):
+                self.storage_class([(variation, "test")])
+
     def test_slicing(self):
         h = self.storage_class()
         h.set("X-Foo-Meh", "bleh")


### PR DESCRIPTION
Makes `Headers` reject CR and LF in header keys, matching the behaviour it has had for header values since 0.8.

fixes #3229

## What the change does

`_str_header_value()` has rejected newlines in values since 0.8, recorded in CHANGES.rst as "Headers datastructure no longer allows newlines in values to avoid header injection attacks". Because that helper only ever receives the value half of the pair, keys reached `self._list` unvalidated through every write path.

This adds `_str_header_key()` next to `_str_header_value()`, reusing the same `_newline_re` and raising the same `ValueError`. It is applied at the two chokepoints that every string-key public API funnels through, `add` and `set`, plus the two positional `__setitem__` branches. That covers `setdefault`, `setlist`, `setlistdefault`, `extend`, `update` and the constructor without touching each one separately.

It also lines the class up with its own constructor docstring, which already says the values passed to it "are validated the same way values added later are".

## Before and after

```python
from werkzeug.datastructures import Headers

Headers()["X-A"] = "1\r\nX-Injected: yes"   # ValueError, as documented
Headers()["X-A\r\nX-Injected: yes"] = "1"   # accepted before this change
```

On `main` the second line stores the key verbatim, and the werkzeug dev server writes it to the wire through `BaseHTTPRequestHandler`, producing a second attacker authored response on the same connection. Full reproduction including the raw bytes is in #3229.

With this change both lines raise `ValueError`, which is the same fail closed behaviour already chosen for values.

## Tests

`tests/test_datastructures.py::TestHeaders::test_reject_newlines_in_keys` mirrors the existing `test_reject_newlines`, covering `__setitem__`, `add`, `set`, `setdefault`, `setlist`, `extend` and the constructor across `\n`, `\r\n` and `\r`.

It fails on `main`:

```
$ python -m pytest tests/test_datastructures.py -k reject_newlines_in_keys
E           Failed: DID NOT RAISE ValueError
1 failed, 108 deselected
```

and passes with the change applied.

## Checks run

```
$ python -m pytest tests/
1000 passed

$ ruff check src/werkzeug/datastructures/headers.py tests/test_datastructures.py
All checks passed!

$ ruff format --check src/werkzeug/datastructures/headers.py tests/test_datastructures.py
2 files already formatted

$ mypy src/werkzeug/datastructures/headers.py
Success: no issues found in 1 source file
```

## Notes

No behaviour change for keys that do not contain newlines, so this should not affect existing applications. A CHANGES.rst entry is included.

I raised this as a regular issue rather than a private report because the security policy excludes insecure code in a project using the library. If you would rather treat it as a security issue I am happy to withdraw this and report it privately instead.
