### PR TITLE
improve header parsing and performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 -   ``uri_to_iri`` and ``iri_to_uri`` preserve empty username, password, and
     port 0. :issue:`3189`
 -   Improve performance of ``parse_options_header``.
+-   Improve performance of ``parse_etags``.
 
 
 Version 3.1.8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 -   ``ProfilerMiddleware`` uses ``profiling.tracing`` on Python 3.15. :issue:`3207`
 -   ``uri_to_iri`` and ``iri_to_uri`` preserve empty username, password, and
     port 0. :issue:`3189`
+-   Improve performance of ``parse_options_header``.
 
 
 Version 3.1.8

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -413,15 +413,14 @@ def parse_dict_header(value: str) -> dict[str, str | None]:
         value = value.strip()
         encoding: str | None = None
 
-        if key[-1] == "*":
+        if key.endswith("*"):
             # key*=charset''value becomes key=value, where value is percent encoded
             # adapted from parse_options_header, without the continuation handling
             key = key[:-1]
-            match = _charset_value_re.match(value)
 
-            if match:
+            if (m_charset := _charset_value_re.match(value)) is not None:
                 # If there is a charset marker in the value, split it off.
-                encoding, value = match.groups()
+                encoding, value = m_charset.groups()
                 encoding = encoding.lower()
 
             # A safe list of encodings. Modern clients should only send ASCII or UTF-8.
@@ -438,18 +437,19 @@ def parse_dict_header(value: str) -> dict[str, str | None]:
 
 # https://httpwg.org/specs/rfc9110.html#parameter
 _parameter_key_re = re.compile(r"([\w!#$%&'*+\-.^`|~]+)=", flags=re.ASCII)
+# https://www.rfc-editor.org/rfc/rfc2231#section-3
+_parameter_mark_re = re.compile(r"(?:\*(\d+))?(\*)?$", flags=re.ASCII)
 _parameter_token_value_re = re.compile(r"[\w!#$%&'*+\-.^`|~]+", flags=re.ASCII)
 # https://www.rfc-editor.org/rfc/rfc2231#section-4
 _charset_value_re = re.compile(
     r"""
     ([\w!#$%&*+\-.^`|~]*)'  # charset part, could be empty
     [\w!#$%&*+\-.^`|~]*'  # don't care about language part, usually empty
-    ([\w!#$%&'*+\-.^`|~]+)  # one or more token chars with percent encoding
+    ([\w!#$%&'*+\-.^`|~]+)$  # one or more token chars with percent encoding
     """,
     re.ASCII | re.VERBOSE,
 )
-# https://www.rfc-editor.org/rfc/rfc2231#section-3
-_continuation_re = re.compile(r"\*(\d+)$", re.ASCII)
+_parameter_delimiter_re = re.compile(r";[ \t]*")
 
 
 def parse_options_header(value: str | None) -> tuple[str, dict[str, str]]:
@@ -522,88 +522,108 @@ def parse_options_header(value: str | None) -> tuple[str, dict[str, str]]:
 
     # Collect all valid key=value parts without processing the value.
     parts: list[tuple[str, str]] = []
+    scan_pos = 0
+    length = len(rest)
 
-    while True:
-        if (m := _parameter_key_re.match(rest)) is not None:
-            pk = m.group(1).lower()
-            rest = rest[m.end() :]
+    while scan_pos < length:
+        if (m_key := _parameter_key_re.match(rest, scan_pos)) is not None:
+            pk = m_key.group(1).lower()
+            scan_pos = m_key.end()
 
             # Value may be a token.
-            if (m := _parameter_token_value_re.match(rest)) is not None:
-                parts.append((pk, m.group()))
+            if (m_value := _parameter_token_value_re.match(rest, scan_pos)) is not None:
+                parts.append((pk, m_value.group()))
 
             # Value may be a quoted string, find the closing quote.
-            elif rest[:1] == '"':
-                pos = 1
-                length = len(rest)
+            elif rest.startswith('"', scan_pos):
+                quote_pos = scan_pos + 1
 
-                while pos < length:
-                    if rest[pos : pos + 2] in {"\\\\", '\\"'}:
+                while quote_pos < length:
+                    if rest.startswith(("\\\\", '\\"'), quote_pos):
                         # Consume escaped slashes and quotes.
-                        pos += 2
-                    elif rest[pos] == '"':
+                        quote_pos += 2
+                    elif rest.startswith('"', quote_pos):
                         # Stop at an unescaped quote.
-                        parts.append((pk, rest[: pos + 1]))
-                        rest = rest[pos + 1 :]
+                        quote_pos += 1
+                        parts.append((pk, rest[scan_pos:quote_pos]))
+                        scan_pos = quote_pos
                         break
                     else:
                         # Consume any other character.
-                        pos += 1
+                        quote_pos += 1
 
-        # Find the next section delimited by `;`, if any.
-        if (end := rest.find(";")) == -1:
+        # Continue to the next delimited part, skipping spaces.
+        if m_delim := _parameter_delimiter_re.search(rest, scan_pos):
+            scan_pos = m_delim.end()
+        else:
             break
 
-        rest = rest[end + 1 :].lstrip()
-
     options: dict[str, str] = {}
-    encoding: str | None = None
-    continued_encoding: str | None = None
+    continuations: dict[str, list[str]] = {}
+    continuation_encodings: dict[str, str] = {}
 
     # For each collected part, process optional charset and continuation,
     # unquote quoted values.
     for pk, pv in parts:
-        if pk[-1] == "*":
-            # key*=charset''value becomes key=value, where value is percent encoded
-            pk = pk[:-1]
-            match = _charset_value_re.match(pv)
+        encoding: str | None = None
+        has_continuation = has_charset = False
 
-            if match:
+        # Check for and remove markers at end of key.
+        if (
+            m_mark := _parameter_mark_re.search(pk)
+        ) is not None and m_mark.end() - m_mark.start() > 0:
+            has_continuation = m_mark.group(1) is not None
+            has_charset = m_mark.group(2) is not None
+            pk = pk[: m_mark.start()]
+
+        # key*=charset''value becomes key=value, where value is percent encoded
+        if has_charset:
+            if (m_charset := _charset_value_re.match(pv)) is not None:
                 # If there is a valid charset marker in the value, split it off.
-                encoding, pv = match.groups()
+                encoding, pv = m_charset.groups()
                 # This might be the empty string, handled next.
                 encoding = encoding.lower()
 
-            # No charset marker, or marker with empty charset value.
-            if not encoding:
-                encoding = continued_encoding
+            # Use the prior continuation encoding if not set on this part.
+            if not encoding and has_continuation:
+                encoding = continuation_encodings.get(pk)
 
             # A safe list of encodings. Modern clients should only send ASCII or UTF-8.
             # This list will not be extended further. An invalid encoding will leave the
             # value quoted.
             if encoding in {"ascii", "us-ascii", "utf-8", "iso-8859-1"}:
-                # Continuation parts don't require their own charset marker. This is
-                # looser than the RFC, it will persist across different keys and allows
-                # changing the charset during a continuation. But this implementation is
-                # much simpler than tracking the full state.
-                continued_encoding = encoding
                 # invalid bytes are replaced during unquoting
                 pv = unquote(pv, encoding=encoding)
-
-        # Remove quotes. At this point the value cannot be empty or a single quote.
-        if pv[0] == pv[-1] == '"':
-            # HTTP headers use slash, multipart form data uses percent
-            pv = pv[1:-1].replace("\\\\", "\\").replace('\\"', '"').replace("%22", '"')
-
-        match = _continuation_re.search(pk)
-
-        if match:
-            # key*0=a; key*1=b becomes key=ab
-            pk = pk[: match.start()]
-            options[pk] = options.get(pk, "") + pv
         else:
+            # Remove quotes, replace header slash escapes, replace multipart
+            # percent-encoded quotes.
+            pv = unquote_header_value(pv).replace("%22", '"')
+
+        # key*0=a; key*1=b becomes key=ab
+        if has_continuation:
+            # Remove prior normal option.
+            if pk in options:
+                del options[pk]
+
+            # For simplicity, this uses the scan order rather than enforcing
+            # sequential numbering.
+            if pk in continuations:
+                continuations[pk].append(pv)
+            else:
+                continuations[pk] = [pv]
+
+            # Further parts don't require their own charset marker.
+            if encoding:
+                continuation_encodings[pk] = encoding
+        else:
+            # Remove prior continuation option.
+            if pk in continuations:
+                del continuations[pk]
+                continuation_encodings.pop(pk, None)
+
             options[pk] = pv
 
+    options.update({pk: "".join(pv) for pk, pv in continuations.items()})
     return value, options
 
 

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -25,7 +25,6 @@ if t.TYPE_CHECKING:
 _token_chars = frozenset(
     "!#$%&'*+-.0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ^_`abcdefghijklmnopqrstuvwxyz|~"
 )
-_etag_re = re.compile(r'([Ww]/)?(?:"(.*?)"|(.*?))(?:\s*,\s*|$)')
 _entity_headers = frozenset(
     [
         "allow",
@@ -966,10 +965,11 @@ def quote_etag(etag: str, weak: bool = False) -> str:
     """
     if '"' in etag:
         raise ValueError("invalid etag")
-    etag = f'"{etag}"'
+
     if weak:
-        etag = f"W/{etag}"
-    return etag
+        return f'W/"{etag}"'
+
+    return f'"{etag}"'
 
 
 @t.overload
@@ -991,14 +991,24 @@ def unquote_etag(
     """
     if not etag:
         return None, None
-    etag = etag.strip()
+
     weak = False
+    start = 0
+
     if etag.startswith(("W/", "w/")):
         weak = True
-        etag = etag[2:]
-    if etag[:1] == etag[-1:] == '"':
-        etag = etag[1:-1]
-    return etag, weak
+        start = 2
+
+    if etag.startswith('"', start) and etag.endswith('"', start):
+        return etag[start + 1 : -1], weak
+
+    # invalid unquoted
+    return etag[start:], weak
+
+
+_etag_re = re.compile(
+    r'([Ww]/)?(?:"([^"]*)"|([^" \t,]+))(?:[ \t]*,[ \t]*)?', flags=re.ASCII
+)
 
 
 def parse_etags(value: str | None) -> ds.ETags:
@@ -1009,24 +1019,21 @@ def parse_etags(value: str | None) -> ds.ETags:
     """
     if not value:
         return ds.ETags()
+
+    if value == "*":
+        return ds.ETags(star_tag=True)
+
     strong = []
     weak = []
-    end = len(value)
-    pos = 0
-    while pos < end:
-        match = _etag_re.match(value, pos)
-        if match is None:
-            break
-        is_weak, quoted, raw = match.groups()
-        if raw == "*":
-            return ds.ETags(star_tag=True)
-        elif quoted:
-            raw = quoted
+
+    for match in _etag_re.findall(value):
+        is_weak, tag, invalid_unquoted = match
+
         if is_weak:
-            weak.append(raw)
+            weak.append(tag or invalid_unquoted)
         else:
-            strong.append(raw)
-        pos = match.end()
+            strong.append(tag or invalid_unquoted)
+
     return ds.ETags(strong, weak)
 
 

--- a/src/werkzeug/middleware/shared_data.py
+++ b/src/werkzeug/middleware/shared_data.py
@@ -25,6 +25,7 @@ from zlib import adler32
 
 from ..http import http_date
 from ..http import is_resource_modified
+from ..http import quote_etag
 from ..security import safe_join
 from ..utils import get_content_type
 from ..wsgi import get_path_info
@@ -257,9 +258,9 @@ class SharedDataMiddleware:
 
         if self.cache:
             timeout = self.cache_timeout
-            etag = self.generate_etag(mtime, file_size, real_filename)  # type: ignore
+            etag = quote_etag(self.generate_etag(mtime, file_size, real_filename))  # type: ignore
             headers += [
-                ("Etag", f'"{etag}"'),
+                ("Etag", etag),
                 ("Cache-Control", f"max-age={timeout}, public"),
             ]
 

--- a/src/werkzeug/sansio/http.py
+++ b/src/werkzeug/sansio/http.py
@@ -9,6 +9,7 @@ from ..http import generate_etag
 from ..http import parse_date
 from ..http import parse_etags
 from ..http import parse_if_range_header
+from ..http import quote_etag
 from ..http import unquote_etag
 
 _etag_re = re.compile(r'([Ww]/)?(?:"(.*?)"|(.*?))(?:\s*,\s*|$)')
@@ -42,7 +43,7 @@ def is_resource_modified(
     .. versionadded:: 2.2
     """
     if etag is None and data is not None:
-        etag = generate_etag(data)
+        etag = quote_etag(generate_etag(data))
     elif data is not None:
         raise TypeError("both data and etag given")
 
@@ -74,7 +75,7 @@ def is_resource_modified(
         etag, _ = unquote_etag(etag)
 
         if if_range is not None and if_range.etag is not None:
-            unmodified = parse_etags(if_range.etag).contains(etag)
+            unmodified = if_range.etag == etag
         else:
             if_none_match = parse_etags(http_if_none_match)
             if if_none_match:

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -640,16 +640,15 @@ class Response(_SansIOResponse):
         """Return ``True`` if `Range` header is present and if underlying
         resource is considered unchanged when compared with `If-Range` header.
         """
-        return (
+        return "HTTP_RANGE" in environ and (
             "HTTP_IF_RANGE" not in environ
             or not is_resource_modified(
                 environ,
-                self.headers.get("etag"),
-                None,
-                self.headers.get("last-modified"),
+                self.headers.get("ETag"),
+                last_modified=self.headers.get("Last-Modified"),
                 ignore_if_range=False,
             )
-        ) and "HTTP_RANGE" in environ
+        )
 
     def _process_range_request(
         self,
@@ -765,9 +764,8 @@ class Response(_SansIOResponse):
             is206 = self._process_range_request(environ, complete_length, accept_ranges)
             if not is206 and not is_resource_modified(
                 environ,
-                self.headers.get("etag"),
-                None,
-                self.headers.get("last-modified"),
+                self.headers.get("ETag"),
+                last_modified=self.headers.get("Last-Modified"),
             ):
                 if parse_etags(environ.get("HTTP_IF_MATCH")):
                     self.status_code = 412

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -429,12 +429,16 @@ class TestHTTPUtility:
 
         # any method is allowed
         env["REQUEST_METHOD"] = "POST"
-        assert http.is_resource_modified(env, etag="testing")
+        assert http.is_resource_modified(env)
         env["REQUEST_METHOD"] = "GET"
 
-        # etagify from data
-        pytest.raises(TypeError, http.is_resource_modified, env, data="42", etag="23")
-        env["HTTP_IF_NONE_MATCH"] = http.generate_etag(b"awesome")
+        # only one of etag or data
+        with pytest.raises(TypeError):
+            http.is_resource_modified(env, data=b"42", etag='"23"')
+
+        etag = http.quote_etag(http.generate_etag(b"awesome"))
+        env["HTTP_IF_NONE_MATCH"] = etag
+        assert not http.is_resource_modified(env, etag=etag)
         assert not http.is_resource_modified(env, data=b"awesome")
 
         env["HTTP_IF_MODIFIED_SINCE"] = http.http_date(datetime(2008, 1, 1, 12, 30))
@@ -449,7 +453,7 @@ class TestHTTPUtility:
         env = create_environ()
 
         env["HTTP_IF_MODIFIED_SINCE"] = http.http_date(datetime(2008, 1, 1, 12, 30))
-        env["HTTP_IF_RANGE"] = http.generate_etag(b"awesome_if_range")
+        env["HTTP_IF_RANGE"] = http.quote_etag(http.generate_etag(b"awesome_if_range"))
         # Range header not present, so If-Range should be ignored
         assert not http.is_resource_modified(
             env,
@@ -619,10 +623,10 @@ class TestRange:
         assert rv.to_header() == '"Test"'
 
         # broken etags are supported too
-        rv = http.parse_if_range_header("bullshit")
-        assert rv.etag == "bullshit"
+        rv = http.parse_if_range_header("invalid_unquoted")
+        assert rv.etag == "invalid_unquoted"
         assert rv.date is None
-        assert rv.to_header() == '"bullshit"'
+        assert rv.to_header() == '"invalid_unquoted"'
 
         rv = http.parse_if_range_header("Thu, 01 Jan 1970 00:00:00 GMT")
         assert rv.etag is None

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -527,7 +527,9 @@ def test_etag_response():
 
     assert "date" not in response.headers
     env = create_environ()
-    env.update({"REQUEST_METHOD": "GET", "HTTP_IF_NONE_MATCH": response.get_etag()[0]})
+    env.update(
+        {"REQUEST_METHOD": "GET", "HTTP_IF_NONE_MATCH": response.headers["ETag"]}
+    )
     response.make_conditional(env)
     assert "date" in response.headers
 
@@ -568,9 +570,7 @@ def test_etag_response_412():
 
     assert "date" not in response.headers
     env = create_environ()
-    env.update(
-        {"REQUEST_METHOD": "GET", "HTTP_IF_MATCH": f"{response.get_etag()[0]}xyz"}
-    )
+    env.update({"REQUEST_METHOD": "GET", "HTTP_IF_MATCH": '"xyz"'})
     response.make_conditional(env)
     assert "date" in response.headers
 


### PR DESCRIPTION
- `parse_options_header`
    - Was doing a lot of string slicing. Replaced that with keeping track of the position in the full string and starting new matches from that position.
    - Replaced uses of `str[-1] == ""` with `startswith` and `endswith`, which are fast C calls that presumably don't create new strings.
    - Charset regex ensures the entire value is captured, rather than accepting up to an invalid token char.
    - Continuation charsets are tracked per key.
    - Slashs and quotes are not removed for charset values, as they are required to be token chars only. This also removes an ambiguity where unquoting could produce unexpected results if it was done before or after percent decoding.
    - A key specified without a continuation does not contribute to a continuation.
    - A continuation after a non-continuation key replaces it, and vice versa. This means the last value wins, as it would for multiple non-continuation items.
    - Continuations are accumulated and joined, rather than repeatedly concatenated. This probably doesn't matter, I'm pretty sure string concatenation is optimized in modern Python.
- `quote_etag` does not create intermediate strings
- `unquote_etag` does not use intermediate slicing.
- `parse_etags`
    - Looks for `*` alone first, rather than accepting it within a list of other tags.
    - Still accepts invalid unquoted values, but requires at least one char and excludes `*`, `"`, space, and tab since those are part of valid parts or delimiters.
- `if_modified_since`
    - Is always passed a valid quoted etag, and generates one when passed `data`.
    - `if_range.etag` is an unquoted value, and only ever one value, so it can be compared with `==` rather than `in` at the point it's used.
    - It currently accepts invalid unquoted etags, but in 3.2 we should ignore invalid unquoted etags rather than keep them. It's not clear why they were ever accepted, but no client should produce them.