### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -188,7 +188,9 @@ class StateMachineMatcher:
                             candidates.append(rv)
 
                 if candidates:
-                    return max(candidates, key=lambda item: _rule_match_preference(item[0]))
+                    return max(
+                        candidates, key=lambda item: _rule_match_preference(item[0])
+                    )
 
                 di = dj
 

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -31,10 +31,26 @@ class State:
     static: dict[str, State] = field(default_factory=dict)
 
 
+def _rule_match_preference(rule: Rule) -> tuple[int, int, int]:
+    """Score a fully matched rule when choosing among equal-weight dynamic peers.
+
+    Higher is better. Prefer rules with more static parts and fewer dynamic
+    parts (specificity), then earlier registration order (stable first-wins).
+
+    See https://github.com/pallets/werkzeug/issues/3156
+    """
+    static_count = sum(1 for part in rule._parts if part.static)
+    dynamic_count = sum(1 for part in rule._parts if not part.static)
+    # Earlier rules have smaller _match_order; invert so max() prefers them.
+    order = getattr(rule, "_match_order", 0)
+    return (static_count, -dynamic_count, -order)
+
+
 class StateMachineMatcher:
     def __init__(self, merge_slashes: bool) -> None:
         self._root = State()
         self.merge_slashes = merge_slashes
+        self._rule_order = 0
 
     def add(self, rule: Rule) -> None:
         state = self._root
@@ -56,6 +72,9 @@ class StateMachineMatcher:
             if rule.is_duplicate(existing):
                 raise DuplicateRuleError(existing, rule)
 
+        # Stable registration index for equal-weight dynamic peer selection.
+        rule._match_order = self._rule_order  # type: ignore[attr-defined]
+        self._rule_order += 1
         state.rules.append(rule)
 
     def update(self) -> None:
@@ -123,36 +142,55 @@ class StateMachineMatcher:
                 if rv is not None:
                     return rv
             # No match via the static transitions, so try the dynamic
-            # ones.
-            for test_part, new_state in state.dynamic:
-                target = part
-                remaining = parts[1:]
-                # A final part indicates a transition that always
-                # consumes the remaining parts i.e. transitions to a
-                # final state.
-                if test_part.final:
-                    target = "/".join(parts)
-                    remaining = []
-                match = re.compile(test_part.content).match(target)
-                if match is not None:
-                    if test_part.suffixed:
-                        # If a part_isolating=False part has a slash suffix, remove the
-                        # suffix from the match and check for the slash redirect next.
-                        suffix = match.groups()[-1]
-                        if suffix == "/":
-                            remaining = [""]
+            # ones. Dynamic transitions are sorted by weight; within the
+            # same weight, try every matching converter and pick the best
+            # rule. Returning the first successful transition alone lets
+            # an unrelated earlier rule reorder equal-weight peers when
+            # RuleParts are merged (pallets/werkzeug#3156).
+            dynamics = state.dynamic
+            di = 0
+            while di < len(dynamics):
+                weight = dynamics[di][0].weight
+                dj = di + 1
+                while dj < len(dynamics) and dynamics[dj][0].weight == weight:
+                    dj += 1
 
-                    converter_groups = sorted(
-                        match.groupdict().items(), key=lambda entry: entry[0]
-                    )
-                    groups = [
-                        value
-                        for key, value in converter_groups
-                        if key[:11] == "__werkzeug_"
-                    ]
-                    rv = _match(new_state, remaining, values + groups)
-                    if rv is not None:
-                        return rv
+                candidates: list[tuple[Rule, list[str]]] = []
+                for test_part, new_state in dynamics[di:dj]:
+                    target = part
+                    remaining = parts[1:]
+                    # A final part indicates a transition that always
+                    # consumes the remaining parts i.e. transitions to a
+                    # final state.
+                    if test_part.final:
+                        target = "/".join(parts)
+                        remaining = []
+                    match = re.compile(test_part.content).match(target)
+                    if match is not None:
+                        if test_part.suffixed:
+                            # If a part_isolating=False part has a slash
+                            # suffix, remove the suffix from the match and
+                            # check for the slash redirect next.
+                            suffix = match.groups()[-1]
+                            if suffix == "/":
+                                remaining = [""]
+
+                        converter_groups = sorted(
+                            match.groupdict().items(), key=lambda entry: entry[0]
+                        )
+                        groups = [
+                            value
+                            for key, value in converter_groups
+                            if key[:11] == "__werkzeug_"
+                        ]
+                        rv = _match(new_state, remaining, values + groups)
+                        if rv is not None:
+                            candidates.append(rv)
+
+                if candidates:
+                    return max(candidates, key=lambda item: _rule_match_preference(item[0]))
+
+                di = dj
 
             # If there is no match and the only part left is a
             # trailing slash ("") consider rules that aren't

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1747,6 +1747,70 @@ def test_weighting():
     )
 
 
+def test_consistent_relative_priority_with_unrelated_rule():
+    """Equal-weight dynamic converters keep registration order even when an
+    unrelated earlier rule shares a RulePart with a later peer (#3156).
+    """
+    rule_1 = r.Rule("/<any(foo, bar):value>", endpoint="rule_1")
+    rule_2 = r.Rule("/<string:value>", endpoint="rule_2")
+    map_ = r.Map([rule_1, rule_2])
+    adapter = map_.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+    map_ = r.Map(
+        [
+            r.Rule("/<string:unrelated>/no_match", endpoint="no_match"),
+            rule_1.empty(),
+            rule_2.empty(),
+        ]
+    )
+    adapter = map_.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+
+def test_consistent_relative_priority_custom_converter():
+    """Same as above with a custom converter of default weight (#3156)."""
+    rule_1 = r.Rule("/<dummy:value>", endpoint="rule_1")
+    rule_2 = r.Rule("/<string:value>", endpoint="rule_2")
+    map_ = r.Map([rule_1, rule_2], converters={"dummy": r.BaseConverter})
+    adapter = map_.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+    map_ = r.Map(
+        [
+            r.Rule("/<string:value>/no_match", endpoint="no_match"),
+            rule_1.empty(),
+            rule_2.empty(),
+        ],
+        converters={"dummy": r.BaseConverter},
+    )
+    adapter = map_.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+
+def test_cross_converter_static_more_specific():
+    """A static segment after a different equal-weight converter still wins
+    over a path catch-all on a shared prefix (#3156 related).
+    """
+    map_ = r.Map(
+        [
+            r.Rule("/<string:value>/<path:path>", endpoint="less_specific"),
+            r.Rule("/<string:value>/bar", endpoint="more_specific"),
+        ]
+    )
+    adapter = map_.bind("example.org", "/")
+    assert adapter.match("/foo/bar") == ("more_specific", {"value": "foo"})
+
+    map_ = r.Map(
+        [
+            r.Rule("/<string:value>/<path:path>", endpoint="less_specific"),
+            r.Rule("/<any(foo):value>/bar", endpoint="more_specific"),
+        ]
+    )
+    adapter = map_.bind("example.org", "/")
+    assert adapter.match("/foo/bar") == ("more_specific", {"value": "foo"})
+
+
 def test_strict_slashes_false():
     map = r.Map(
         [


### PR DESCRIPTION
## Description

Fixes #3156: relative priority of routing rules could change when an unrelated earlier rule shared a dynamic `RulePart` with a later peer of equal converter weight.

### Cause

`StateMachineMatcher` merges identical dynamic `RulePart`s into one transition. After `update()`, equal-weight dynamics keep insertion order. Matching returned the **first** successful dynamic transition, so an earlier unrelated rule that established a `string` transition made a later `string` rule win over an earlier equal-weight `any`/`custom` rule.

### Fix

Within each equal weight group of dynamic transitions, try **all** matching converters and select the best complete match:

1. Prefer more static / fewer dynamic parts (specificity)
2. Prefer earlier registration order (stable first-wins)

Also assign a stable `_match_order` when rules are added.

### Tests

- `test_consistent_relative_priority_with_unrelated_rule` (AnyConverter repro from the issue)
- `test_consistent_relative_priority_custom_converter` (BaseConverter default weight)
- `test_cross_converter_static_more_specific` (related specificity across converters)

### Checklist

- [x] Unit tests added
- [x] `tests/test_routing.py` green (153 passed locally with `PYTHONPATH=src`)
- [ ] Please run full suite in CI
