### PR TITLE
AI junk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 Version 3.2.0
 -------------
 
+-   :class:`~werkzeug.datastructures.ContentRange` no longer accepts a
+    ``Content-Range`` header whose ``complete-length`` is less than or equal to
+    the last-byte-position, as required by RFC 9110. :issue:`3227`
 -   Drop support for Python 3.9. :pr:`3098`
 -   Remove previous deprecated code: :pr:`3099`
 

--- a/src/werkzeug/datastructures/range.py
+++ b/src/werkzeug/datastructures/range.py
@@ -323,7 +323,14 @@ class ContentRange:
         except ValueError:
             return None
 
-        if is_byte_range_valid(start, stop, length):
+        # RFC 9110, section 14.4: a Content-Range is invalid if the
+        # complete-length is less than or equal to the last-byte-pos. The
+        # last-byte-pos is ``stop - 1``, so the value is only valid when
+        # ``stop <= length``. ``is_byte_range_valid`` cannot enforce this
+        # because ``Range.range_for_length`` relies on its lenient behaviour.
+        if is_byte_range_valid(start, stop, length) and (
+            length is None or stop <= length
+        ):
             return cls(units, start, stop, length)
 
         return None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -704,6 +704,34 @@ class TestRange:
         assert rv.length == 100
         assert rv.units == "bytes"
 
+    @pytest.mark.parametrize(
+        ("value",),
+        [
+            # RFC 9110, section 14.4: a Content-Range is invalid when the
+            # complete-length is less than or equal to the last-byte-pos.
+            # Here last-byte-pos is 99, so a complete-length of 100 is the
+            # minimum valid value.
+            ("bytes 0-100/100",),
+            ("bytes 0-499/100",),
+            ("bytes 50-100/100",),
+            ("bytes 0-99/99",),
+        ],
+    )
+    def test_content_range_invalid_complete_length(self, value):
+        assert ContentRange.from_header(value) is None
+
+    @pytest.mark.parametrize(
+        ("value",),
+        [
+            ("bytes 0-99/100",),
+            ("bytes 0-98/99",),
+            ("bytes */100",),
+            ("bytes 0-99/*",),
+        ],
+    )
+    def test_content_range_valid_complete_length(self, value):
+        assert ContentRange.from_header(value) is not None
+
 
 class TestRegression:
     def test_best_match_works(self):


### PR DESCRIPTION
## Summary

`ContentRange.from_header` accepted `Content-Range` headers that are invalid per [RFC 9110, section 14.4](https://www.rfc-editor.org/rfc/rfc9110#section-14.4).

RFC 9110 states a `Content-Range` is invalid when its `complete-length` is **less than or equal to** the `last-byte-pos`. The first condition (first-byte-pos > last-byte-pos) was already rejected, but the second was not, so values such as `bytes 0-100/100` (last-byte-pos `100`, complete-length `100`) and `bytes 0-499/100` (last-byte-pos `499`, complete-length `100`) were parsed into invalid `ContentRange` objects instead of returning `None`.

## Root cause

`is_byte_range_valid` ends with `return 0 <= start < length`, which never compares `stop` against `length`. That helper is also used by `Range.range_for_length`, which relies on its lenient behaviour, so the stricter check is applied only on the `ContentRange` parsing path (in `ContentRange.from_header`), leaving `Range` semantics unchanged.

## Fix

In `ContentRange.from_header`, reject the value when a `length` is present and `stop > length` (equivalently `complete-length <= last-byte-pos`).

## Behaviour

| Header | Before | After |
| --- | --- | --- |
| `bytes 0-499/100` | parsed (invalid) | `None` |
| `bytes 0-100/100` | parsed (invalid) | `None` |
| `bytes 0-99/100` | parsed (valid) | parsed (valid) |
| `bytes */100` | parsed (valid) | parsed (valid) |
| `bytes 0-99/*` | parsed (valid) | parsed (valid) |

## Verification

- Added regression tests (`tests/test_http.py::TestRange::test_content_range_invalid_complete_length` / `test_content_range_valid_complete_length`) covering both the invalid and still-valid cases.
- `pytest` (full suite): **1007 passed**.
- `ruff check` / `ruff format --check` and `mypy --strict` (the repo's lint gates) pass on the changed files.

Fixes #3227.
