### PR TITLE
make plain int parsing even stricter

### DIFF
--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -193,20 +193,23 @@ class _DictAccessorProperty(t.Generic[_TAccessorValue]):
         return f"<{type(self).__name__} {self.name}>"
 
 
-_plain_int_re = re.compile(r"-?[a-z0-9]+", re.ASCII | re.IGNORECASE)
+_plain_int_re = {
+    10: re.compile(r"-?[0-9]+", re.ASCII),
+    16: re.compile(r"-?[0-9a-f]+", re.ASCII | re.IGNORECASE),
+}
 
 
-def _plain_int(value: str, base: int = 10) -> int:
-    """Parse an int only if it is ASCII digits and ``-``.
+def _plain_int(value: str, base: t.Literal[10, 16] = 10) -> int:
+    """Parse an int only if it valid ASCII characters for the base.
 
-    This disallows ``+``, ``_``, and non-ASCII digits, which are accepted by
-    ``int`` but are not allowed in HTTP header values.
+    This disallows ``+``, ``_``, ``0x``, and non-ASCII digits, which are
+    accepted by ``int`` but are not allowed in HTTP header values.
 
-    Any surrounding whitespace is stripped.
+    Any surrounding spaces and tabs are stripped.
     """
-    value = value.strip()
+    value = value.strip(" \t")
 
-    if _plain_int_re.fullmatch(value) is None:
+    if _plain_int_re[base].fullmatch(value) is None:
         raise ValueError
 
     return int(value, base)

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -108,7 +108,7 @@ class DechunkedInput(io.RawIOBase):
 
     def read_chunk_len(self) -> int:
         try:
-            line = self._rfile.readline().decode("latin1")
+            line = self._rfile.readline().decode("latin1").removesuffix("\r\n")
             _len = _plain_int(line, 16)
         except ValueError as e:
             raise OSError("Invalid chunk header") from e

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -45,6 +45,10 @@ def test_wrapper_internals():
         ("7B", 16, 123),
         ("-7B", 16, -123),
         ("7b", 16, 123),
+        ("0x7B", 16, None),
+        (" 123", 10, 123),
+        ("\t123", 10, 123),
+        ("\N{PARAGRAPH SEPARATOR}123", 10, None),
     ],
 )
 def test_plain_int(value: str, base: int, expect: int | None) -> None:


### PR DESCRIPTION
Only handle base 10 and 16, and check for the specific digit characters for each. This disallows `0x` prefix for base 16. Only strip space and tab, not other unexpected Unicode space characters. Change chunked encoding to remove trailing newline when reading chunk number.