### PR TITLE
validate host port

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
     port 0. :issue:`3189`
 -   Improve performance of ``parse_options_header``.
 -   Improve performance of ``parse_etags``.
+-   ``get_host`` also checks that the port is in the valid range.
 
 
 Version 3.1.8

--- a/src/werkzeug/sansio/utils.py
+++ b/src/werkzeug/sansio/utils.py
@@ -16,7 +16,7 @@ _host_re = re.compile(
     |
         \[[a-f0-9]*:[a-f0-9.:]+]  # ipv6
     )
-    (?::[0-9]+)?  # optional port
+    (?::([1-9][0-9]{,4}))?  # optional port
     """,
     flags=re.ASCII | re.IGNORECASE | re.VERBOSE,
 )
@@ -47,10 +47,13 @@ def host_is_trusted(
     if not hostname:
         return False
 
-    if _host_re.fullmatch(hostname) is None:
+    if (m := _host_re.fullmatch(hostname)) is None:
         return False
 
-    hostname = hostname.partition(":")[0]
+    hostname, port_str = m.groups()
+
+    if port_str and not (1 <= int(port_str) <= 65535):
+        return False
 
     if not trusted_list:
         return True

--- a/tests/sansio/test_utils.py
+++ b/tests/sansio/test_utils.py
@@ -45,7 +45,17 @@ def test_get_host_missing() -> None:
 
 
 @pytest.mark.parametrize(
-    "value", ["", "a.test:8080@b.test", "a.test:port", "[z:443]:8080"]
+    "value",
+    [
+        "",
+        "a.test:8080@b.test",
+        "a.test:port",
+        "[z:443]:8080",
+        "a.test:0",
+        "a.test:65536",
+        "a.test:0443",
+        "a.test:",
+    ],
 )
 def test_get_host_invalid(value: str | None) -> None:
     assert get_host("http", value, None) == ""


### PR DESCRIPTION
`host_is_trusted` validates that `1 <= port <= 65535`. 0 is a valid port, but not in the context of a host.

It also disallows leading zeros, for example `08443`. I couldn't find a definitive spec for whether this was allowed or not. Firefox will navigate to https://example.com:08443, but rewrites it as `8443` when clicking the link or entering it in the address bar, and the dev tools shows the request without leading zeros. HTTPWG says nothing about leading zeros. WhatWG URL standard https://url.spec.whatwg.org/#port-state specifies that it is a 16-bit unsigned integer "0 to 65535 inclusive". So I've taken that to mean that leading zeros are not allowed in the port, but that clients might normalize them. That ensures there's not multiple representations of the same value, not sure if that would matter or not.