### PR TITLE
int URL 404s when longer than max_int_str_digits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Unreleased
 -   Improve performance of ``parse_options_header``.
 -   Improve performance of ``parse_etags``.
 -   ``get_host`` also checks that the port is in the valid range.
+-   The ``int`` URL converter returns a 404 instead of 500 error when the value
+    is longer than ``sys.get_int_max_str_digits()``. :issue:`3237`
 
 
 Version 3.1.8

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -152,7 +152,12 @@ class NumberConverter(BaseConverter):
     def to_python(self, value: str) -> t.Any:
         if self.fixed_digits and len(value) != self.fixed_digits:
             raise ValidationError()
-        value_num = self.num_convert(value)
+
+        try:
+            value_num = self.num_convert(value)
+        except ValueError as e:
+            raise ValidationError() from e
+
         if (self.min is not None and value_num < self.min) or (
             self.max is not None and value_num > self.max
         ):

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -188,8 +188,8 @@ class StateMachineMatcher:
             for name, value in zip(rule._converters.keys(), values):
                 try:
                     value = rule._converters[name].to_python(value)
-                except ValidationError:
-                    raise NoMatch(have_match_for, websocket_mismatch) from None
+                except ValidationError as e:
+                    raise NoMatch(have_match_for, websocket_mismatch) from e
                 result[str(name)] = value
             if rule.defaults:
                 result.update(rule.defaults)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import typing as t
 import uuid
 
@@ -749,6 +750,20 @@ def test_default_converters():
     assert a.match("/b/2") == ("b", {"b": "2"})
     assert a.match("/c/3") == ("c", {"c": "3"})
     assert "foo" not in r.Map.default_converters
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("1" * (sys.get_int_max_str_digits() + 1), id="int_max_str_digits"),
+    ],
+)
+def test_int_converter_404(value: str) -> None:
+    m = r.Map([r.Rule("/<int:a>", endpoint="a")])
+    a = m.bind("a.test")
+
+    with pytest.raises(NotFound):
+        a.match(f"/{value}")
 
 
 def test_uuid_converter():


### PR DESCRIPTION
Python defaults to 4300 digits for int/str conversion, and it can be changed at runtime. This is unlikely in the first place, since many clients and servers reject very long URLs already. In this case, `int(value)` raises a `ValueError`, which results in a 500 error. Only a `ValidationError` results in a 404.

I considered having the matcher catch `ValueError` instead of only `ValidationError`. After all, `ValidationError` is a subclass of `ValueError`, so perhaps that was intended. In the end, I kept the documented behavior of only handling `ValidationError`, since it seems better to encourage devs to understand the custom converters they're writing and exactly how they can fail.

fixes part of #3237 