### PR TITLE
Simplify pincode formatting logic

### DIFF
--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -211,15 +211,7 @@ def get_pin_and_cookie_name(
     # Format the pincode in groups of digits for easier remembering if
     # we don't have a result yet.
     if rv is None:
-        for group_size in 5, 4, 3:
-            if len(num) % group_size == 0:
-                rv = "-".join(
-                    num[x : x + group_size].rjust(group_size, "0")
-                    for x in range(0, len(num), group_size)
-                )
-                break
-        else:
-            rv = num
+        rv = f"{num[:3]}-{num[3:6]}-{num[6:]}"
 
     return rv, cookie_name
 


### PR DESCRIPTION
num = f"{int(h.hexdigest(), 16):09d}"[:9]

this expression will always make the 9 character long string so checking group size does not make sense since 3 is only the factor of 9, from the group list of 5, 4, 3.