### PR TITLE
AI junk

### DIFF
--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -201,13 +201,20 @@ class IntegerConverter(NumberConverter):
     regex = r"[0-9]+"
 
     def to_python(self, value: str) -> t.Any:
+        negative = value.startswith("-")
+        digits = value[1:] if negative else value
+
         if not self.fixed_digits:
             # Reject meaningless leading zeros ("007") so that each value
             # has exactly one canonical string representation. "0" itself
             # remains valid.
-            digits = value[1:] if value.startswith("-") else value
             if len(digits) > 1 and digits[0] == "0":
                 raise ValidationError()
+
+        # Reject negative zero ("-0"), which would otherwise decode to the
+        # same value as the canonical "0".
+        if negative and digits.strip("0") == "":
+            raise ValidationError()
 
         return super().to_python(value)
 
@@ -248,7 +255,8 @@ class FloatConverter(NumberConverter):
 
     def to_python(self, value: str) -> t.Any:
         int_part, _, frac_part = value.partition(".")
-        int_part = int_part[1:] if int_part.startswith("-") else int_part
+        negative = int_part.startswith("-")
+        int_part = int_part[1:] if negative else int_part
 
         # Reject meaningless leading zeros in the integer part ("00.5") and
         # meaningless trailing zeros in the fractional part ("0.50"), so
@@ -257,6 +265,11 @@ class FloatConverter(NumberConverter):
         if len(int_part) > 1 and int_part[0] == "0":
             raise ValidationError()
         if len(frac_part) > 1 and frac_part[-1] == "0":
+            raise ValidationError()
+
+        # Reject negative zero ("-0.0"), which would otherwise decode to
+        # the same value as the canonical "0.0".
+        if negative and int_part.strip("0") == "" and frac_part.strip("0") == "":
             raise ValidationError()
 
         value_num = super().to_python(value)

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 import typing as t
 import uuid
@@ -197,7 +198,18 @@ class IntegerConverter(NumberConverter):
         The ``signed`` parameter.
     """
 
-    regex = r"\d+"
+    regex = r"[0-9]+"
+
+    def to_python(self, value: str) -> t.Any:
+        if not self.fixed_digits:
+            # Reject meaningless leading zeros ("007") so that each value
+            # has exactly one canonical string representation. "0" itself
+            # remains valid.
+            digits = value[1:] if value.startswith("-") else value
+            if len(digits) > 1 and digits[0] == "0":
+                raise ValidationError()
+
+        return super().to_python(value)
 
 
 class FloatConverter(NumberConverter):
@@ -222,7 +234,7 @@ class FloatConverter(NumberConverter):
         The ``signed`` parameter.
     """
 
-    regex = r"\d+\.\d+"
+    regex = r"[0-9]+\.[0-9]+"
     num_convert = float
 
     def __init__(
@@ -233,6 +245,29 @@ class FloatConverter(NumberConverter):
         signed: bool = False,
     ) -> None:
         super().__init__(map, min=min, max=max, signed=signed)  # type: ignore
+
+    def to_python(self, value: str) -> t.Any:
+        int_part, _, frac_part = value.partition(".")
+        int_part = int_part[1:] if int_part.startswith("-") else int_part
+
+        # Reject meaningless leading zeros in the integer part ("00.5") and
+        # meaningless trailing zeros in the fractional part ("0.50"), so
+        # that each value has exactly one canonical string representation.
+        # "0" and a single trailing zero ("1.0") remain valid.
+        if len(int_part) > 1 and int_part[0] == "0":
+            raise ValidationError()
+        if len(frac_part) > 1 and frac_part[-1] == "0":
+            raise ValidationError()
+
+        value_num = super().to_python(value)
+
+        # float() silently overflows to inf instead of raising, which would
+        # otherwise accept an unbounded number of string representations
+        # for the same "inf" value.
+        if math.isinf(value_num):
+            raise ValidationError()
+
+        return value_num
 
     def to_url(self, value: t.Any) -> str:
         # f format ensures no scientific notation, but forces trailing zeroes

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -493,6 +493,8 @@ def test_number_canonical_form():
         [
             r.Rule("/int/<int:page>", endpoint="int"),
             r.Rule("/float/<float:page>", endpoint="float"),
+            r.Rule("/sint/<int(signed=True):page>", endpoint="sint"),
+            r.Rule("/sfloat/<float(signed=True):page>", endpoint="sfloat"),
         ]
     )
     adapter = map.bind("example.org", "/")
@@ -519,6 +521,13 @@ def test_number_canonical_form():
     # A float that overflows to infinity is rejected rather than silently
     # matching as "inf".
     pytest.raises(NotFound, lambda: adapter.match(f"/float/{'1' + '0' * 400}.0"))
+
+    # Negative zero is rejected because it decodes to the same value as
+    # the canonical "0" / "0.0" forms.
+    assert adapter.match("/sint/0") == ("sint", {"page": 0})
+    assert adapter.match("/sfloat/0.0") == ("sfloat", {"page": 0.0})
+    pytest.raises(NotFound, lambda: adapter.match("/sint/-0"))
+    pytest.raises(NotFound, lambda: adapter.match("/sfloat/-0.0"))
 
 
 def test_float_no_scientific():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -488,6 +488,39 @@ def test_negative():
     pytest.raises(NotFound, lambda: adapter.match("/bar/-2.0"))
 
 
+def test_number_canonical_form():
+    map = r.Map(
+        [
+            r.Rule("/int/<int:page>", endpoint="int"),
+            r.Rule("/float/<float:page>", endpoint="float"),
+        ]
+    )
+    adapter = map.bind("example.org", "/")
+
+    # Canonical values still match as before.
+    assert adapter.match("/int/0") == ("int", {"page": 0})
+    assert adapter.match("/int/123") == ("int", {"page": 123})
+    assert adapter.match("/float/0.5") == ("float", {"page": 0.5})
+    assert adapter.match("/float/1.5") == ("float", {"page": 1.5})
+    assert adapter.match("/float/1.0") == ("float", {"page": 1.0})
+
+    # Non-ASCII digits that decode to the same value are rejected, not
+    # silently accepted as equivalent to their ASCII counterparts.
+    pytest.raises(NotFound, lambda: adapter.match("/int/١٢٣"))
+    pytest.raises(NotFound, lambda: adapter.match("/float/١.٥"))
+
+    # Meaningless leading zeros are rejected.
+    pytest.raises(NotFound, lambda: adapter.match("/int/007"))
+    pytest.raises(NotFound, lambda: adapter.match("/float/00.5"))
+
+    # Meaningless trailing zeros in the fractional part are rejected.
+    pytest.raises(NotFound, lambda: adapter.match("/float/1.50"))
+
+    # A float that overflows to infinity is rejected rather than silently
+    # matching as "inf".
+    pytest.raises(NotFound, lambda: adapter.match(f"/float/{'1' + '0' * 400}.0"))
+
+
 def test_float_no_scientific():
     map = r.Map([r.Rule("/<float:v>", endpoint="a")])
     adapter = map.bind("test.example")


### PR DESCRIPTION
## Summary
In IntegerConverter.to_python, after stripping an optional leading '-', if the value is negative and the remaining digits are all zero, raise ValidationError. In FloatConverter.to_python, after splitting into int_part/frac_part and stripping the sign, if negative and both int_part and frac_part consist only of zeros, raise ValidationError. This rejects '-0', '-00' (fixed_digits), '-0.0', '-0.00', etc., while leaving '0', '0.0', and legitimate negative values like '-1', '-0.5' unaffected.

## Problem
pallets/werkzeug issue reference: pallets/werkzeug#3237

## Root Cause
This addresses the specific gap flagged by the reviewer on top of the already-accepted fix: NumberConverter.to_python (and the Integer/Float overrides) validated leading/trailing zeros and inf-overflow but did not check for a negative sign applied to an all-zero magnitude ('-0', '-0.0'), which decodes equal to the unsigned canonical form.

## Testing
PASS - tests/test_routing.py: 152 passed. Full suite minus test_debug.py: 984 passed, 1 skipped, 1 failed (tests/test_security.py::test_safe_join[b\\c-None], a pre-existing Windows-path-handling failure unrelated to this change, present before this fix and outside routing/converters code).

## Related Issue
pallets/werkzeug#3237
