### PR TITLE
stricter int and float converters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,7 +83,16 @@ Version 3.2.0
     and ``upgrade_insecure_requests`` CSP directives. :pr:`3114`
 -   The development server does not send an extra ``100 Continue`` response, as
     Python's base server already sends it. :issue:`3138`
--   The float URL converter does not produce scientific notation. :issue:`3146`
+-   The ``int`` and ``float`` URL converters do not accept non-ASCII digits.
+     :issue:`3242`
+-   The ``int`` and ``float`` URL converters validate the value when building
+    URLs. :issue:`3242`
+-   The ``int`` URL converter does not count the negative sign for
+    ``fixed_digits``. :issue:`3242`
+-   The ``float`` URL converter does not accept values that are too large and
+    overflow to ``inf``. :issue:`3242`
+-   The ``float`` URL converter does not produce scientific notation, ``inf``,
+    or ``nan``. :issue:`3146`
 -   ``Request.if_range`` discards the header if it is an invalid weak ETag.
     :pr:`3163`
 -   Use SHA3-256 instead of SHA-1 for generating ETags and the debugger pin.

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import re
 import typing as t
 import uuid
@@ -124,14 +125,33 @@ class PathConverter(BaseConverter):
     weight = 200
 
 
-class NumberConverter(BaseConverter):
-    """Baseclass for `IntegerConverter` and `FloatConverter`.
+class IntegerConverter(BaseConverter):
+    """An :class:`int` value. Available as ``int`` in rules.
 
-    :internal:
+    Extraneous leading zeros are allowed. Negative zero is allowed. Therefore,
+    there is not a 1-to-1 unique mapping between URLs and parsed values.
+
+    Python limits the length of strings when parsing ints. A value greater than
+    :func:`sys.get_int_max_str_digits` will not match.
+
+    :param map: The map this rule is bound to.
+    :param fixed_digits: Require a fixed number of digits. For example, ``4``
+        will only match values like ``0001``. The negative sign is not counted,
+        ``-0004`` is considered 4 digits.
+    :param min: The minimum value, inclusive.
+    :param max: The maximum value, inclusive.
+    :param signed: Allow negative values.
+
+    .. versionchanged:: 3.2
+        Non-ASCII digits are not allowed. The negative sign is not counted for
+        ``fixed_digits``. ``to_url`` performs validation.
+
+    .. versionchanged:: 0.15
+        The ``signed`` parameter was added.
     """
 
     weight = 50
-    num_convert: t.Callable[[t.Any], t.Any] = int
+    regex = r"[0-9]+"
 
     def __init__(
         self,
@@ -141,89 +161,87 @@ class NumberConverter(BaseConverter):
         max: int | None = None,
         signed: bool = False,
     ) -> None:
-        if signed:
-            self.regex = self.signed_regex
         super().__init__(map)
-        self.fixed_digits = fixed_digits
         self.min = min
         self.max = max
+        self.fixed_digits = fixed_digits
         self.signed = signed
 
+        if signed:
+            self.regex = f"-?{self.regex}"
+
     def to_python(self, value: str) -> t.Any:
-        if self.fixed_digits and len(value) != self.fixed_digits:
-            raise ValidationError()
+        if self.fixed_digits and len(value.removeprefix("-")) != self.fixed_digits:
+            raise ValidationError(f"Must be {self.fixed_digits} digits.")
 
         try:
-            value_num = self.num_convert(value)
-        except ValueError as e:
+            value_num = int(value)
+        except ValueError as e:  # if > sys.get_int_max_str_digits()
             raise ValidationError() from e
 
         if (self.min is not None and value_num < self.min) or (
             self.max is not None and value_num > self.max
         ):
-            raise ValidationError()
+            raise ValidationError("Outside of allowed range.")
+
         return value_num
 
     def to_url(self, value: t.Any) -> str:
-        value_str = str(self.num_convert(value))
+        value = int(value)
+
+        if not self.signed and value < 0:
+            raise ValidationError("Negative values are not allowed.")
+
+        if (self.min is not None and value < self.min) or (
+            self.max is not None and value > self.max
+        ):
+            raise ValidationError("Outside of allowed range.")
+
+        value_str = str(value)
+
         if self.fixed_digits:
-            value_str = value_str.zfill(self.fixed_digits)
+            width = self.fixed_digits + (value < 0)
+            value_str = value_str.zfill(width)
+
+            if len(value_str) > width:
+                raise ValidationError(
+                    f"More than {self.fixed_digits} digits are not allowed."
+                )
+
         return value_str
 
-    @property
-    def signed_regex(self) -> str:
-        return f"-?{self.regex}"
 
+class FloatConverter(BaseConverter):
+    """A :class:`float` value. Available as ``float`` in rules.
 
-class IntegerConverter(NumberConverter):
-    """This converter only accepts integer values::
+    Values must have an integer and decimal part, ``4.`` and ``.4`` are not
+    allowed. Scientific notation, ``inf``, and ``nan`` are not allowed.
 
-        Rule("/page/<int:page>")
+    Values that are too large to fit in a float are not allowed; Python would
+    convert them to ``inf``. Values that are too tiny are allowed; Python
+    converts them to ``0.0``.
 
-    By default it only accepts unsigned, positive values. The ``signed``
-    parameter will enable signed, negative values. ::
+    Extraneous leading and trailing zeros are allowed. Many values, such as
+    ``0.1``, are not exactly expressible as a float and are converted to the
+    nearest expressible value. Therefore, there is not a 1-to-1 unique mapping
+    between URLs and parsed values.
 
-        Rule("/page/<int(signed=True):page>")
-
-    :param map: The :class:`Map`.
-    :param fixed_digits: The number of fixed digits in the URL. If you
-        set this to ``4`` for example, the rule will only match if the
-        URL looks like ``/0001/``. The default is variable length.
-    :param min: The minimal value.
-    :param max: The maximal value.
-    :param signed: Allow signed (negative) values.
-
-    .. versionadded:: 0.15
-        The ``signed`` parameter.
-    """
-
-    regex = r"\d+"
-
-
-class FloatConverter(NumberConverter):
-    """This converter only accepts floating point values::
-
-        Rule("/probability/<float:probability>")
-
-    By default it only accepts unsigned, positive values. The ``signed``
-    parameter will enable signed, negative values. ::
-
-        Rule("/offset/<float(signed=True):offset>")
-
-    :param map: The :class:`Map`.
-    :param min: The minimal value.
-    :param max: The maximal value.
-    :param signed: Allow signed (negative) values.
+    :param map: The map this rule is bound to.
+    :param min: The minimum value, inclusive.
+    :param max: The maximum value, inclusive.
+    :param signed: Allow negative values.
 
     .. versionchanged:: 3.2
-        Does not produce scientific notation.
+        Non-ASCII digits are not allowed. Values that are too large and overflow
+        to ``inf`` are not allowed. ``to_url`` performs validation and does not
+        produce scientific notation.
 
-    .. versionadded:: 0.15
-        The ``signed`` parameter.
+    .. versionchanged:: 0.15
+        The ``signed`` parameter was added.
     """
 
-    regex = r"\d+\.\d+"
-    num_convert = float
+    weight = 50
+    regex = r"[0-9]+\.[0-9]+"
 
     def __init__(
         self,
@@ -232,11 +250,56 @@ class FloatConverter(NumberConverter):
         max: float | None = None,
         signed: bool = False,
     ) -> None:
-        super().__init__(map, min=min, max=max, signed=signed)  # type: ignore
+        super().__init__(map)
+        self.min = min
+        self.max = max
+        self.signed = signed
+
+        if signed:
+            self.regex = f"-?{self.regex}"
+
+    def to_python(self, value: str) -> t.Any:
+        value_num: float = float(value)
+        # will convert too tiny to 0.0, too large to inf
+
+        if math.isinf(value_num):
+            raise ValidationError("Too large.")
+
+        if (self.min is not None and value_num < self.min) or (
+            self.max is not None and value_num > self.max
+        ):
+            raise ValidationError("Outside of allowed range.")
+
+        return value_num
 
     def to_url(self, value: t.Any) -> str:
-        # f format ensures no scientific notation, but forces trailing zeroes
-        return f"{self.num_convert(value):f}".rstrip("0")
+        value = float(value)
+
+        if not math.isfinite(value):
+            raise ValidationError("Infinity or NaN are not allowed.")
+
+        if not self.signed and value < 0:
+            raise ValidationError("Negative values are not allowed.")
+
+        if (self.min is not None and value < self.min) or (
+            self.max is not None and value > self.max
+        ):
+            raise ValidationError("Outside of allowed range.")
+
+        # Use `str(value)` if it doesn't produce scientific notation.
+        if "e" not in (value_str := str(value)):
+            return value_str
+
+        sig, _, exp_str = value_str.partition("e")
+        left, _, right = sig.partition(".")
+        exp = int(exp_str)
+
+        # A big number. Expand trailing zeros in the integer part.
+        if exp > 0:
+            return f"{left}{right}{'0' * (exp - len(right))}.0"
+
+        # A small number. Expand leading zeros in the fraction part.
+        return f"0.{'0' * (-exp - len(left))}{left}{right}"
 
 
 class UUIDConverter(BaseConverter):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -465,35 +465,6 @@ def test_defaults():
     assert adapter.build("foo", {"page": 2}) == "/foo/2"
 
 
-def test_negative():
-    map = r.Map(
-        [
-            r.Rule("/foos/<int(signed=True):page>", endpoint="foos"),
-            r.Rule("/bars/<float(signed=True):page>", endpoint="bars"),
-            r.Rule("/foo/<int:page>", endpoint="foo"),
-            r.Rule("/bar/<float:page>", endpoint="bar"),
-        ]
-    )
-    adapter = map.bind("example.org", "/")
-
-    assert adapter.match("/foos/-2") == ("foos", {"page": -2})
-    assert adapter.match("/foos/-50") == ("foos", {"page": -50})
-    assert adapter.match("/bars/-2.0") == ("bars", {"page": -2.0})
-    assert adapter.match("/bars/-0.185") == ("bars", {"page": -0.185})
-
-    # Make sure signed values are rejected in unsigned mode
-    pytest.raises(NotFound, lambda: adapter.match("/foo/-2"))
-    pytest.raises(NotFound, lambda: adapter.match("/foo/-50"))
-    pytest.raises(NotFound, lambda: adapter.match("/bar/-0.185"))
-    pytest.raises(NotFound, lambda: adapter.match("/bar/-2.0"))
-
-
-def test_float_no_scientific():
-    map = r.Map([r.Rule("/<float:v>", endpoint="a")])
-    adapter = map.bind("test.example")
-    assert "e" not in adapter.build("a", {"v": 0.00001})
-
-
 def test_greedy():
     map = r.Map(
         [
@@ -867,18 +838,97 @@ def test_default_converters():
     assert "foo" not in r.Map.default_converters
 
 
+_converter_match_params = {
+    "int": {
+        "positive": ({}, "123", 123),
+        "unsigned negative": ({}, "-123", None),
+        "Unicode digits": ({}, "١٢٣", None),
+        "max digits": ({}, "1" * (sys.get_int_max_str_digits() + 1), None),
+        "negative max digits": (
+            {"signed": True},
+            "-" + "1" * (sys.get_int_max_str_digits() + 1),
+            None,
+        ),
+        "negative": ({"signed": True}, "-123", -123),
+        "fixed positive": ({"fixed_digits": 4}, "0123", 123),
+        "fixed unsigned negative": ({"fixed_digits": 4}, "-0123", None),
+        "fixed short": ({"fixed_digits": 4}, "123", None),
+        "fixed short negative": ({"fixed_digits": 4}, "-123", None),
+        "fixed long": ({"fixed_digits": 4}, "10000", None),
+        "fixed negative": ({"fixed_digits": 4, "signed": True}, "-0123", -123),
+        "range": ({"min": 100, "max": 900}, "500", 500),
+        "range min": ({"min": 100, "max": 900}, "50", None),
+        "range max": ({"min": 100, "max": 900}, "950", None),
+        "fixed range": ({"min": 100, "max": 900, "fixed_digits": 4}, "0500", 500),
+        "fixed range min": ({"min": 100, "max": 900, "fixed_digits": 4}, "0050", None),
+        "fixed range max": ({"min": 100, "max": 900, "fixed_digits": 4}, "0950", None),
+        "build unsigned negative": ({}, None, -123),
+        "build range": ({"min": 100}, None, 50),
+        "build fixed too large": ({"fixed_digits": 4}, None, 12345),
+    },
+    "float": {
+        "positive": ({}, "1.23", 1.23),
+        "unsigned negative": ({}, "-1.23", None),
+        "no integer part": ({}, ".4", None),
+        "no fraction part": ({}, "4.", None),
+        "Unicode digits": ({}, "١٢٣.0", None),
+        "overflow": ({}, "1" * 400, None),
+        "negative": ({"signed": True}, "-1.23", -1.23),
+        "negative zero": ({"signed": True}, "-0.0", -0.0),
+        "range": ({"min": 1.5, "max": 6.2}, "5.0", 5.0),
+        "range min": ({"min": 1.5, "max": 6.2}, "1.4", None),
+        "range max": ({"min": 1.5, "max": 6.2}, "6.25", None),
+        "no exp small": ({}, "0.00001", 0.00001),
+        "no exp large": ({}, "10000000000000000.0", 10000000000000000.0),
+        "build inf": ({}, None, float("inf")),
+        "build nan": ({}, None, float("nan")),
+        "build unsigned negative": ({}, None, -123.0),
+        "build range": ({"min": 1.5}, None, 1.0),
+    },
+}
+
+
 @pytest.mark.parametrize(
-    "value",
+    ("name", "kwargs", "url", "value"),
     [
-        pytest.param("1" * (sys.get_int_max_str_digits() + 1), id="int_max_str_digits"),
+        pytest.param(name, *params, id=f"{name} {message}")
+        for name, param_map in _converter_match_params.items()
+        for message, params in param_map.items()
     ],
 )
-def test_int_converter_404(value: str) -> None:
-    m = r.Map([r.Rule("/<int:a>", endpoint="a")])
-    a = m.bind("a.test")
+def test_converter(
+    name: str,
+    kwargs: dict[str, t.Any],
+    url: str | None,
+    value: t.Any | None,
+) -> None:
+    """Test how a configured converter matches and builds.
 
-    with pytest.raises(NotFound):
-        a.match(f"/{value}")
+    :param name: Name of the converter.
+    :param kwargs: Arguments to pass to the converter.
+    :param url: URL value to match into ``value``. If ``None``, test that
+        building ``value`` fails.
+    :param value: Value to build into ``url``. If ``None``, test that
+        matching ``url`` fails.
+    """
+    kwargs_str = ", ".join(f"{k}={v}" for k, v in kwargs.items())
+    url_map = r.Map([r.Rule(f"/<{name}({kwargs_str}):a>", endpoint="a")])
+    bound_map = url_map.bind("a.test")
+    path = f"/{url}"
+
+    if url is not None:
+        if value is not None:
+            assert bound_map.match(path)[1]["a"] == value
+        else:
+            with pytest.raises(NotFound):
+                bound_map.match()
+
+    if value is not None:
+        if url is not None:
+            assert bound_map.build("a", {"a": value}) == path
+        else:
+            with pytest.raises(r.BuildError):
+                bound_map.build("a", {"a": value})
 
 
 def test_uuid_converter():


### PR DESCRIPTION
- Remove the private `NumberConverter` base class. This was making it more complicated than it needed to be to handle the different behaviors.
- Non-ASCII digits are not accepted.
- Value is validated when building.
- `int` `fixed_digits` does not count the negative sign as one of the digits.
- `float`
  - Overflow values (too large to fit in float) are not allowed. Otherwise they would become `inf`.
  - `inf` and `nan` are not allowed when building.
  - Improve string conversion. #3147 used `.06f` to avoid scientific notation, but this cuts off a huge range of legitimate fraction values. Instead, rely on Python's `str(value)` to pick its "simplest" representation, then expand the value if it produced scientific notation.
- A lot of tests.
- Document that these converters do not produce 1-to-1 unique mapping between URLs and values.

fixes #3242 