### PR TITLE
include the entire cgroup line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
 -   ``get_host`` also checks that the port is in the valid range.
 -   The ``int`` URL converter returns a 404 instead of 500 error when the value
     is longer than ``sys.get_int_max_str_digits()``. :issue:`3237`
+-   Improve debugger PIN generation from cgroup data inside Podman. :issue:`3245`
 
 
 Version 3.1.8

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -74,7 +74,7 @@ def get_machine_id() -> str | bytes | None:
         # relatively stable across boots.
         try:
             with open("/proc/self/cgroup", "rb") as f:
-                linux += f.readline().strip().rpartition(b"/")[2]
+                linux += f.readline().strip()
         except OSError:
             pass
 


### PR DESCRIPTION
Just include the whole line, the rest of it seems static anyway so shouldn't affect anything.

fixes #3245 