### PR TITLE
validate base64 in basic auth parser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 -   The ``int`` URL converter returns a 404 instead of 500 error when the value
     is longer than ``sys.get_int_max_str_digits()``. :issue:`3237`
 -   Improve debugger PIN generation from cgroup data inside Podman. :issue:`3245`
+-   ``Authorization`` parsing ``basic`` auth disallows non-base64 characters.
 
 
 Version 3.1.8

--- a/src/werkzeug/datastructures/auth.py
+++ b/src/werkzeug/datastructures/auth.py
@@ -104,7 +104,9 @@ class Authorization:
 
         if scheme == "basic":
             try:
-                username, _, password = base64.b64decode(rest).decode().partition(":")
+                username, _, password = (
+                    base64.b64decode(rest, validate=True).decode().partition(":")
+                )
             except (binascii.Error, UnicodeError):
                 return None
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -240,6 +240,11 @@ class TestHTTPUtility:
         content = base64.b64encode(b"\xffser:pass").decode()
         assert Authorization.from_header(f"Basic {content}") is None
 
+    def test_authorization_basic_validate(self):
+        """Non-alphabet characters are rejected."""
+        content = "!".join(base64.b64encode(b"test").decode())
+        assert Authorization.from_header(f"Basic {content}") is None
+
     def test_authorization_eq(self):
         basic1 = Authorization.from_header("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
         basic2 = Authorization(


### PR DESCRIPTION
`b64decode(validate=True)` rejects any non-base64 characters rather than ignoring them.