### PR TITLE
improve performance of cookie parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
     port 0. :issue:`3189`
 -   Improve performance of ``parse_options_header``.
 -   Improve performance of ``parse_etags``.
+-   Improve performance of ``parse_cookie``.
 -   ``get_host`` also checks that the port is in the valid range.
 -   The ``int`` URL converter returns a 404 instead of 500 error when the value
     is longer than ``sys.get_int_max_str_digits()``. :issue:`3237`

--- a/src/werkzeug/sansio/http.py
+++ b/src/werkzeug/sansio/http.py
@@ -93,15 +93,17 @@ def is_resource_modified(
 
 _cookie_re = re.compile(
     r"""
-    ([^=;]*)
-    (?:\s*=\s*
-      (
-        "(?:[^\\"]|\\.)*"
-      |
-        .*?
-      )
+    [ \t]*  # ignore leading space
+    ([^ \t=";]+)  # key
+    (?:[ \t]*=[ \t]*  # optional =value, ignoring invalid space
+        (
+            "(?:[^\\"]|\\.)*"  # quoted value with backslash escapes
+        |
+            [^ \t";]*  # token value
+        )
     )?
-    \s*;\s*
+    [ \t]*  # ignore trailing space
+    (?:;|\Z)  # only if followed by semicolon or end
     """,
     flags=re.ASCII | re.VERBOSE,
 )
@@ -143,17 +145,24 @@ def parse_cookie(
     if not cookie:
         return cls()
 
-    cookie = f"{cookie};"
     out = []
+    pos = 0
 
-    for ck, cv in _cookie_re.findall(cookie):
-        ck = ck.strip()
-        cv = cv.strip()
+    while True:
+        if (m := _cookie_re.match(cookie, pos)) is None:
+            # Skip invalid chars until the next semicolon.
+            if (pos := cookie.find(";", pos) + 1) == 0:
+                break
 
-        if not ck:
             continue
 
-        if len(cv) >= 2 and cv[0] == cv[-1] == '"':
+        ck, cv = m.groups()
+        pos = m.end()
+
+        if cv is None:
+            cv = ""
+
+        if cv.startswith('"') and cv.endswith('"'):
             # Work with bytes here, since a UTF-8 character could be multiple bytes.
             cv = _cookie_unslash_re.sub(
                 _cookie_unslash_replace, cv[1:-1].encode()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -500,7 +500,6 @@ class TestHTTPUtility:
             "b": '";',
             "fo234{": "bar",
             "blub": "Blah",
-            '"__Secure-c"': "d",
             "__Host-eq": "good",
         }
 


### PR DESCRIPTION
Been going over the regex parsers again. `findall`/`finditer` seem to be a little slower than a while loop and incrementing position, especially if they need to account for proper delimiters and skip invalid sections. Only space and tab are considered space in the spec. Make key a little stricter, disallow `"`. Make token a little stricter, disallow space, tab, `"`, and `;`. Avoid string slicing where possible.