### PR TITLE
various minor string parsing improvements

### DIFF
--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -204,7 +204,7 @@ def _plain_int(value: str) -> int:
 
     Any leading or trailing whitespace is stripped
     """
-    value = value.strip()
+    value = value.strip(" \t")
     if _plain_int_re.fullmatch(value) is None:
         raise ValueError
 

--- a/src/werkzeug/datastructures/accept.py
+++ b/src/werkzeug/datastructures/accept.py
@@ -198,7 +198,7 @@ class Accept(ImmutableList[tuple[str, float]]):
         return None
 
 
-_mime_split_re = re.compile(r"/|(?:\s*;\s*)")
+_mime_split_re = re.compile(r"/|(?:[ \t]*;[ \t]*)")
 
 
 def _normalize_mime(value: str) -> list[str]:

--- a/src/werkzeug/datastructures/auth.py
+++ b/src/werkzeug/datastructures/auth.py
@@ -100,7 +100,7 @@ class Authorization:
 
         scheme, _, rest = value.partition(" ")
         scheme = scheme.lower()
-        rest = rest.strip()
+        rest = rest.strip(" \t")
 
         if scheme == "basic":
             try:
@@ -283,7 +283,7 @@ class WWWAuthenticate:
 
         scheme, _, rest = value.partition(" ")
         scheme = scheme.lower()
-        rest = rest.strip()
+        rest = rest.strip(" \t")
 
         if "=" in rest.rstrip("="):
             # = that is not trailing, this is parameters.

--- a/src/werkzeug/datastructures/file_storage.py
+++ b/src/werkzeug/datastructures/file_storage.py
@@ -42,7 +42,7 @@ class FileStorage:
             if filename is not None:
                 filename = fsdecode(filename)
 
-            if filename and filename[0] == "<" and filename[-1] == ">":
+            if filename and filename.startswith("<") and filename.endswith(">"):
                 filename = None
         else:
             filename = fsdecode(filename)

--- a/src/werkzeug/debug/__init__.py
+++ b/src/werkzeug/debug/__init__.py
@@ -450,7 +450,7 @@ class DebuggedApplication:
         val = parse_cookie(environ).get(self.pin_cookie_name)
         if not val or "|" not in val:
             return False
-        ts_str, pin_hash = val.split("|", 1)
+        ts_str, _, pin_hash = val.partition("|")
 
         try:
             ts = int(ts_str)

--- a/src/werkzeug/debug/repr.py
+++ b/src/werkzeug/debug/repr.py
@@ -156,7 +156,7 @@ class DebugReprGenerator:
         out = "".join(buf)
 
         # if the repr looks like a standard string, add subclass info if needed
-        if r[0] in "'\"" or (r[0] == "b" and r[1] in "'\""):
+        if r.startswith(("'", '"', 'b"', "b'")):
             return _add_subclass_info(out, obj, (bytes, str))
 
         # otherwise, assume the repr distinguishes the subclass already

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -356,7 +356,9 @@ def parse_list_header(value: str) -> list[str]:
 
     items.append(item)
     return [
-        unquote_header_value(item) for item in (item.strip() for item in items) if item
+        unquote_header_value(item)
+        for item in (item.strip(" \t") for item in items)
+        if item
     ]
 
 
@@ -399,7 +401,7 @@ def parse_dict_header(value: str) -> dict[str, str | None]:
 
     for item in parse_list_header(value):
         key, has_value, value = item.partition("=")
-        key = key.strip()
+        key = key.strip(" \t")
 
         if not key:
             # =value is not valid
@@ -409,7 +411,7 @@ def parse_dict_header(value: str) -> dict[str, str | None]:
             result[key] = None
             continue
 
-        value = value.strip()
+        value = value.strip(" \t")
         encoding: str | None = None
 
         if key.endswith("*"):
@@ -512,8 +514,8 @@ def parse_options_header(value: str | None) -> tuple[str, dict[str, str]]:
         return "", {}
 
     value, _, rest = value.partition(";")
-    value = value.strip()
-    rest = rest.strip()
+    value = value.strip(" \t")
+    rest = rest.strip(" \t")
 
     if not value or not rest:
         # empty (invalid) value, or value without options
@@ -671,7 +673,7 @@ def parse_accept_header(
 
         if "q" in options:
             # pop q, remaining options are reconstructed
-            q_str = options.pop("q").strip()
+            q_str = options.pop("q").strip(" \t")
 
             if _q_value_re.fullmatch(q_str) is None:
                 # ignore an invalid q
@@ -786,12 +788,12 @@ def parse_csp_header(
     items = []
 
     for policy in value.split(";"):
-        policy = policy.strip()
+        policy = policy.strip(" \t")
 
         # Ignore badly formatted policies (no space)
         if " " in policy:
-            directive, value = policy.strip().split(" ", 1)
-            items.append((directive.strip(), value.strip()))
+            directive, _, value = policy.strip(" \t").partition(" ")
+            items.append((directive.strip(" \t"), value.strip(" \t")))
 
     return cls(items, on_update)
 
@@ -863,10 +865,10 @@ def parse_range_header(
     ranges = []
     last_end = 0
     units, rng = value.split("=", 1)
-    units = units.strip().lower()
+    units = units.strip(" \t").lower()
 
     for item in rng.split(","):
-        item = item.strip()
+        item = item.strip(" \t")
         if "-" not in item:
             return None
         if item.startswith("-"):
@@ -880,8 +882,8 @@ def parse_range_header(
             last_end = -1
         elif "-" in item:
             begin_str, end_str = item.split("-", 1)
-            begin_str = begin_str.strip()
-            end_str = end_str.strip()
+            begin_str = begin_str.strip(" \t")
+            end_str = end_str.strip(" \t")
 
             try:
                 begin = _plain_int(begin_str)
@@ -924,7 +926,7 @@ def parse_content_range_header(
     if value is None:
         return None
     try:
-        units, rangedef = (value or "").strip().split(None, 1)
+        units, _, rangedef = (value or "").strip(" \t").partition(" ")
     except ValueError:
         return None
 

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -864,7 +864,7 @@ def parse_range_header(
 
     ranges = []
     last_end = 0
-    units, rng = value.split("=", 1)
+    units, _, rng = value.partition("=")
     units = units.strip(" \t").lower()
 
     for item in rng.split(","):
@@ -881,7 +881,7 @@ def parse_range_header(
             end = None
             last_end = -1
         elif "-" in item:
-            begin_str, end_str = item.split("-", 1)
+            begin_str, _, end_str = item.partition("-")
             begin_str = begin_str.strip(" \t")
             end_str = end_str.strip(" \t")
 
@@ -932,7 +932,7 @@ def parse_content_range_header(
 
     if "/" not in rangedef:
         return None
-    rng, length_str = rangedef.split("/", 1)
+    rng, _, length_str = rangedef.partition("/")
     if length_str == "*":
         length = None
     else:
@@ -949,7 +949,7 @@ def parse_content_range_header(
     elif "-" not in rng:
         return None
 
-    start_str, stop_str = rng.split("-", 1)
+    start_str, _, stop_str = rng.partition("-")
     try:
         start = _plain_int(start_str)
         stop = _plain_int(stop_str) + 1

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -186,7 +186,7 @@ def unquote_header_value(value: str) -> str:
     .. versionchanged:: 3.0
         The ``is_filename`` parameter is removed.
     """
-    if len(value) >= 2 and value[0] == value[-1] == '"':
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
         return _unslash_re.sub(r"\g<1>", value[1:-1])
 
     return value
@@ -230,7 +230,7 @@ def dump_options_header(header: str | None, options: t.Mapping[str, t.Any]) -> s
         if value is None:
             continue
 
-        if key[-1] == "*":
+        if key.endswith("*"):
             segments.append(f"{key}={value}")
         else:
             segments.append(f"{key}={quote_header_value(value)}")
@@ -276,7 +276,7 @@ def dump_header(iterable: dict[str, t.Any] | t.Iterable[t.Any]) -> str:
         for key, value in iterable.items():
             if value is None:
                 items.append(key)
-            elif key[-1] == "*":
+            elif key.endswith("*"):
                 items.append(f"{key}={value}")
             else:
                 items.append(f"{key}={quote_header_value(value)}")

--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -300,7 +300,7 @@ class Map:
         wsgi_server_name = get_host(env).lower()
         scheme = env["wsgi.url_scheme"]
         upgrade = any(
-            v.strip() == "upgrade"
+            v.strip(" \t") == "upgrade"
             for v in env.get("HTTP_CONNECTION", "").lower().split(",")
         )
 

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -142,7 +142,7 @@ class StateMachineMatcher:
                     groups = [
                         value
                         for key, value in converter_groups
-                        if key[:11] == "__werkzeug_"
+                        if key.startswith("__werkzeug_")
                     ]
                     rv = _match(new_state, remaining, values + groups)
                     if rv is not None:

--- a/src/werkzeug/routing/rules.py
+++ b/src/werkzeug/routing/rules.py
@@ -670,7 +670,7 @@ class Rule(RuleFactory):
             pos = match.end()
 
         suffixed = False
-        if final and content[-1] == "/":
+        if final and content.endswith("/"):
             # If a converter is part_isolating=False (matches slashes) and ends with a
             # slash, augment the regex to support slash redirects.
             suffixed = True

--- a/src/werkzeug/sansio/multipart.py
+++ b/src/werkzeug/sansio/multipart.py
@@ -228,11 +228,11 @@ class MultipartDecoder:
         data = HEADER_CONTINUATION_RE.sub(b" ", data)
         # Now there is one header per line
         for line in data.splitlines():
-            line = line.strip()
+            line = line.strip(b" \t")
 
             if line != b"":
                 name, _, value = line.decode().partition(":")
-                headers.append((name.strip(), value.strip()))
+                headers.append((name.strip(" \t"), value.strip(" \t")))
         return Headers(headers)
 
     def _parse_data(

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -300,7 +300,7 @@ class Response:
         ct = self.headers.get("content-type")
 
         if ct:
-            return ct.split(";")[0].strip()
+            return ct.partition(";")[0].strip()
         else:
             return None
 

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -450,17 +450,17 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
         msg = msg.translate(self._control_char_table)
         code = str(code)
 
-        if code[0] == "1":  # 1xx - Informational
+        if code.startswith("1"):  # 1xx - Informational
             msg = _ansi_style(msg, "bold")
         elif code == "200":  # 2xx - Success
             pass
         elif code == "304":  # 304 - Resource Not Modified
             msg = _ansi_style(msg, "cyan")
-        elif code[0] == "3":  # 3xx - Redirection
+        elif code.startswith("3"):  # 3xx - Redirection
             msg = _ansi_style(msg, "green")
         elif code == "404":  # 404 - Resource Not Found
             msg = _ansi_style(msg, "yellow")
-        elif code[0] == "4":  # 4xx - Client Error
+        elif code.startswith("4"):  # 4xx - Client Error
             msg = _ansi_style(msg, "bold", "red")
         else:  # 5xx, or any other response
             msg = _ansi_style(msg, "bold", "magenta")

--- a/src/werkzeug/serving.py
+++ b/src/werkzeug/serving.py
@@ -108,7 +108,7 @@ class DechunkedInput(io.RawIOBase):
     def read_chunk_len(self) -> int:
         try:
             line = self._rfile.readline().decode("latin1")
-            _len = int(line.strip(), 16)
+            _len = int(line.strip(" \t\r\n"), 16)
         except ValueError as e:
             raise OSError("Invalid chunk header") from e
         if _len < 0:
@@ -247,7 +247,7 @@ class WSGIRequestHandler(BaseHTTPRequestHandler):
         return environ
 
     def run_wsgi(self) -> None:
-        if self.headers.get("Expect", "").lower().strip() == "100-continue":
+        if self.headers.get("Expect", "").lower().strip(" \t") == "100-continue":
             self.wfile.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
         self.environ = environ = self.make_environ()

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -1436,11 +1436,11 @@ class Cookie:
 
         for item in parameters_str.split(";"):
             k, sep, v = item.partition("=")
-            params[k.strip().lower()] = v.strip() if sep else None
+            params[k.strip(" \t").lower()] = v.strip(" \t") if sep else None
 
         return cls(
-            key=key.strip(),
-            value=value.strip(),
+            key=key.strip(" \t"),
+            value=value.strip(" \t"),
             decoded_key=decoded_key,
             decoded_value=decoded_value,
             expires=parse_date(params.get("expires")),

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -491,7 +491,7 @@ class EnvironBuilder:
         .. versionadded:: 0.14
         """
         ct = self.content_type
-        return ct.split(";")[0].strip() if ct else None
+        return ct.partition(";")[0].strip() if ct else None
 
     @mimetype.setter
     def mimetype(self, value: str) -> None:
@@ -623,16 +623,16 @@ class EnvironBuilder:
     @property
     def server_name(self) -> str:
         """The server name (read-only, use :attr:`host` to set)"""
-        return self.host.split(":", 1)[0]
+        return self.host.partition(":")[0]
 
     @property
     def server_port(self) -> int:
         """The server port as integer (read-only, use :attr:`host` to set)"""
-        pieces = self.host.split(":", 1)
+        _, sep, port = self.host.partition(":")
 
-        if len(pieces) == 2:
+        if sep:
             try:
-                return int(pieces[1])
+                return int(port)
             except ValueError:
                 pass
 
@@ -1005,7 +1005,7 @@ class Client:
             response.request.environ, path=path, query_string=qs
         )
 
-        to_name_parts = netloc.split(":", 1)[0].split(".")
+        to_name_parts = netloc.partition(":")[0].split(".")
         from_name_parts = builder.server_name.split(".")
 
         if to_name_parts != [""]:


### PR DESCRIPTION
All of these are pretty minor, but I kept doing them as I was working on individual things, figured I'd apply it consistently.

* `strip(" \t")` instead of `strip()`, only removes space and tab, not other invalid ASCII/Unicode space characters. Parsers are still lenient, this means the invalid data might be considered part of a key or value instead of silently omitted, but no valid client would be producing that. This feels more accurate and visible. Probably also a slight performance improvement to search for fewer characters.
* `[ \t]` instead of `\s` in regex, same as above.
* `partition(sep)` instead of `split(sep, 1)`, doesn't create a list, always returns a 3-tuple to unpack
* `startswith`/`endswith` instead of `v[-1] == c` slicing, doesn't create intermediate strings, fast C method, can handle multiple checks at once.

Didn't use `removeprefix`/`removesuffix` instead of `v[len(p):]` slicing, since every place with it already knows the prefix is there. Slicing directly is faster in that case and creates a string either way.