### PR TITLE
clearer docs about about where request limits apply

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
     is longer than ``sys.get_int_max_str_digits()``. :issue:`3237`
 -   Improve debugger PIN generation from cgroup data inside Podman. :issue:`3245`
 -   ``Authorization`` parsing ``basic`` auth disallows non-base64 characters.
+-   ``application/x-www-form-urlencoded`` form data is no longer limited to
+    ``max_form_memory_size``, only ``max_content_length``.
 
 
 Version 3.1.8

--- a/docs/request_data.rst
+++ b/docs/request_data.rst
@@ -76,25 +76,32 @@ Limiting Request Data
 The :class:`Request` class provides a few attributes to control how much data is
 processed from the request body. This can help mitigate DoS attacks that craft the
 request in such a way that the server uses too many resources to handle it. Each of
-these limits will raise a :exc:`~werkzeug.exceptions.RequestEntityTooLarge` if they are
-exceeded.
+these limits will raise a :exc:`.RequestEntityTooLarge` if they are exceeded.
 
--   :attr:`~Request.max_content_length` - Stop reading request data after this number
-    of bytes. It's better to configure this in the WSGI server or HTTP server, rather
-    than the WSGI application.
--   :attr:`~Request.max_form_memory_size` - Stop reading request data if any
-    non-file form field is larger than this number of bytes. While file parts
-    can be moved to disk, regular form field data is stored in memory only and
-    could fill up memory. The default is 500kB.
--   :attr:`~Request.max_form_parts` Stop reading request data if more than this number
-    of parts are sent in multipart form data. This is useful to stop a very large number
-    of very small parts, especially file parts. The default is 1000.
+-   :attr:`~Request.max_content_length` - Stop reading data after this many
+    bytes. This amount of memory, plus additional object overhead, could be used
+    during one request. It's better to configure this in the WSGI server or HTTP
+    server, rather than the WSGI application, which is why it's not set by
+    default. Not setting it anywhere would be an issue with that application,
+    not with Werkzeug.
+-   :attr:`~Request.max_form_memory_size` - Stop parsing ``multipart/form-data``
+    if any non-file part is larger than this number of bytes. File parts can
+    be larger, they are moved to disk at this limit. The default is 500kB. This
+    is an additional check, it does not replace ``max_content_length``.
+-   :attr:`~Request.max_form_parts` - Stop parsing ``multipart/form-data`` if
+    more than this number of parts are received. This is useful to stop a very
+    large number of very small fields, especially files. The default is 1000.
+    This is an additional check, it does not replace ``max_content_length``.
 
 Each of these values can be set on the ``Request`` class to affect the default
 for all requests, or on a ``request`` instance to change the behavior for a
 specific request. For example, a small limit can be set by default, and a large
 limit can be set on an endpoint that accepts video uploads. These values should
 be tuned to the specific needs of your application and endpoints.
+
+If not using ``Request``, use :func:`.get_input_stream` to apply
+``max_content_length``, and :class:`.FormDataParser` to apply
+``max_form_memory_size`` and ``max_form_parts``.
 
 Using Werkzeug to set these limits is only one layer of protection. WSGI servers
 and HTTPS servers should set their own limits on size and timeouts. The operating system

--- a/src/werkzeug/formparser.py
+++ b/src/werkzeug/formparser.py
@@ -91,21 +91,27 @@ def parse_form_data(
     :param stream_factory: An optional callable that returns a new read and
                            writeable file descriptor.  This callable works
                            the same as :meth:`Response._get_file_stream`.
-    :param max_form_memory_size: the maximum number of bytes to be accepted for
-                           in-memory stored form data.  If the data
-                           exceeds the value specified an
-                           :exc:`~exceptions.RequestEntityTooLarge`
-                           exception is raised.
-    :param max_content_length: If this is provided and the transmitted data
-                               is longer than this value an
-                               :exc:`~exceptions.RequestEntityTooLarge`
-                               exception is raised.
+    :param max_content_length: If the data is larger than this many bytes, raise
+        :exc:`.RequestEntityTooLarge`. This is used by :meth:`parse_from_environ`
+        to set up a limited stream. When using :meth:`parse`, you must get a
+        limited stream with :func:`.get_input_stream`.
+    :param max_form_memory_size: If a ``multipart/form-data`` text part is larger
+        than this many bytes, raise :exc:`~exceptions.RequestEntityTooLarge`.
+        File parts are written to disk after this size. This is an additional
+        check, it does not replace using a limited stream and
+        ``max_content_length``.
+    :param max_form_parts: If more than this number of ``multipart/form-data``
+        parts are received, raise :exc:`.RequestEntityTooLarge`. This is an
+        additional check, it does not replace using a limited stream and
+        ``max_content_length``.
     :param cls: an optional dict class to use.  If this is not specified
                        or `None` the default :class:`MultiDict` is used.
     :param silent: If set to False parsing errors will not be caught.
-    :param max_form_parts: The maximum number of multipart parts to be parsed. If this
-        is exceeded, a :exc:`~exceptions.RequestEntityTooLarge` exception is raised.
     :return: A tuple in the form ``(stream, form, files)``.
+
+    .. versionchanged:: 3.1.9
+        ``max_form_memory_size`` is not applied to
+        ``application/x-www-form-urlencoded``.
 
     .. versionchanged:: 3.0
         The ``charset`` and ``errors`` parameters were removed.
@@ -140,20 +146,22 @@ class FormDataParser:
     :param stream_factory: An optional callable that returns a new read and
                            writeable file descriptor.  This callable works
                            the same as :meth:`Response._get_file_stream`.
-    :param max_form_memory_size: the maximum number of bytes to be accepted for
-                           in-memory stored form data.  If the data
-                           exceeds the value specified an
-                           :exc:`~exceptions.RequestEntityTooLarge`
-                           exception is raised.
-    :param max_content_length: If this is provided and the transmitted data
-                               is longer than this value an
-                               :exc:`~exceptions.RequestEntityTooLarge`
-                               exception is raised.
+    :param max_content_length: If the data is larger than this many bytes, raise
+        :exc:`.RequestEntityTooLarge`. This is used by :meth:`parse_from_environ`
+        to set up a limited stream. When using :meth:`parse`, you must get a
+        limited stream with :func:`.get_input_stream`.
+    :param max_form_memory_size: If a ``multipart/form-data`` text part is larger
+        than this many bytes, raise :exc:`~exceptions.RequestEntityTooLarge`.
+        File parts are written to disk after this size. This is an additional
+        check, it does not replace using a limited stream and
+        ``max_content_length``.
+    :param max_form_parts: If more than this number of ``multipart/form-data``
+        parts are received, raise :exc:`.RequestEntityTooLarge`. This is an
+        additional check, it does not replace using a limited stream and
+        ``max_content_length``.
     :param cls: an optional dict class to use.  If this is not specified
                        or `None` the default :class:`MultiDict` is used.
     :param silent: If set to False parsing errors will not be caught.
-    :param max_form_parts: The maximum number of multipart parts to be parsed. If this
-        is exceeded, a :exc:`~exceptions.RequestEntityTooLarge` exception is raised.
 
     .. versionchanged:: 3.0
         The ``charset`` and ``errors`` parameters were removed.
@@ -181,8 +189,8 @@ class FormDataParser:
             stream_factory = default_stream_factory
 
         self.stream_factory = stream_factory
-        self.max_form_memory_size = max_form_memory_size
         self.max_content_length = max_content_length
+        self.max_form_memory_size = max_form_memory_size
         self.max_form_parts = max_form_parts
 
         if cls is None:
@@ -217,8 +225,10 @@ class FormDataParser:
         """Parses the information from the given stream, mimetype,
         content length and mimetype parameters.
 
-        :param stream: an input stream
-        :param mimetype: the mimetype of the data
+        :param stream: A limited input stream, from :meth:`.get_input_stream`.
+        :param mimetype: The mimetype used to choose how to parse the form.
+            ``multipart/form-data`` and ``application/x-www-form-urlencoded``
+            are supported.
         :param content_length: the content length of the incoming data
         :param options: optional mimetype parameters (used for
                         the multipart boundary for instance)
@@ -274,13 +284,12 @@ class FormDataParser:
         content_length: int | None,
         options: dict[str, str],
     ) -> t_parse_result:
-        if (
-            self.max_form_memory_size is not None
-            and content_length is not None
-            and content_length > self.max_form_memory_size
-        ):
-            raise RequestEntityTooLarge()
-
+        # The stream must already be limited to max_content_length.
+        # max_form_memory_size can't apply, since the entire stream is read at
+        # once instead of incrementally parsed.
+        # max_form_parts could be applied here, but doesn't impose a useful
+        # limit given the previous points and because the parser is much simpler
+        # and faster already.
         items = parse_qsl(
             stream.read().decode(),
             keep_blank_values=True,

--- a/src/werkzeug/wrappers/request.py
+++ b/src/werkzeug/wrappers/request.py
@@ -69,33 +69,45 @@ class Request(_SansIORequest):
         Read-only mode is enforced with immutable classes for all data.
     """
 
-    #: the maximum content length.  This is forwarded to the form data
-    #: parsing function (:func:`parse_form_data`).  When set and the
-    #: :attr:`form` or :attr:`files` attribute is accessed and the
-    #: parsing fails because more than the specified value is transmitted
-    #: a :exc:`~werkzeug.exceptions.RequestEntityTooLarge` exception is raised.
-    #:
-    #: .. versionadded:: 0.5
     max_content_length: int | None = None
+    """Stop reading data after this many bytes and raise
+    :exc:`.RequestEntityTooLarge`. This amount of memory, plus additional object
+    overhead, could be used during one request.
 
-    #: the maximum form field size.  This is forwarded to the form data
-    #: parsing function (:func:`parse_form_data`).  When set and the
-    #: :attr:`form` or :attr:`files` attribute is accessed and the
-    #: data in memory for post data is longer than the specified value a
-    #: :exc:`~werkzeug.exceptions.RequestEntityTooLarge` exception is raised.
-    #:
-    #: .. versionchanged:: 3.1
-    #:     Defaults to 500kB instead of unlimited.
-    #:
-    #: .. versionadded:: 0.5
+    It's better to configure this in the WSGI server or HTTP server, rather than
+    the WSGI application, which is why it's not set by default. Not setting it
+    anywhere would be an issue with that application, not with Werkzeug.
+
+    This is applied to :attr:`stream` and anything that reads it such as
+    :attr:`data` and :meth:`parse_form_data`.
+
+    .. versionadded:: 0.5
+    """
+
     max_form_memory_size: int | None = 500_000
+    """Stop parsing ``multipart/form-data`` if any non-file part is larger than
+    this number of bytes, and raise :exc:`.RequestEntityTooLarge`. File parts
+    can be larger, they are moved to disk at this limit. The default is 500kB.
+    This is an additional check, it does not replace :attr:`max_content_length`.
 
-    #: The maximum number of multipart parts to parse, passed to
-    #: :attr:`form_data_parser_class`. Parsing form data with more than this
-    #: many parts will raise :exc:`~.RequestEntityTooLarge`.
-    #:
-    #: .. versionadded:: 2.2.3
+    .. versionchanged:: 3.1.9
+        This is not applied to ``application/x-www-form-urlencoded``.
+
+    .. versionchanged:: 3.1
+        Defaults to 500kb instead of unlimited.
+
+    .. versionadded:: 0.5
+    """
+
     max_form_parts = 1000
+    """Stop parsing ``multipart/form-data`` if more than this number of parts
+    are received, and raise :exc:`.RequestEntityTooLarge`. This is useful to
+    stop a very large number of very small fields, especially files. The
+    default is 1000. This is an additional check, it does not replace
+    :attr:`max_content_length`.
+
+    .. versionadded:: 2.2.3
+    """
 
     #: The form data parser that should be used.  Can be replaced to customize
     #: the form date parsing.

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -145,8 +145,10 @@ def get_input_stream(
     safe_fallback: bool = True,
     max_content_length: int | None = None,
 ) -> t.IO[bytes]:
-    """Return the WSGI input stream, wrapped so that it may be read safely without going
-    past the ``Content-Length`` header value or ``max_content_length``.
+    """Return the WSGI input stream, wrapped so that it may be read safely
+    without going past the ``Content-Length`` header value or
+    ``max_content_length``. This must be used to pass a safe stream to other
+    functions, which are not responsible for enforcing this limit.
 
     If ``Content-Length`` exceeds ``max_content_length``, a
     :exc:`RequestEntityTooLarge`` ``413 Content Too Large`` error is raised.

--- a/tests/test_formparser.py
+++ b/tests/test_formparser.py
@@ -51,24 +51,6 @@ class TestFormParser:
         req.max_content_length = 400
         assert req.form["foo"] == "Hello World"
 
-        req = Request.from_values(
-            input_stream=io.BytesIO(data),
-            content_length=len(data),
-            content_type="application/x-www-form-urlencoded",
-            method="POST",
-        )
-        req.max_form_memory_size = 7
-        pytest.raises(RequestEntityTooLarge, lambda: req.form["foo"])
-
-        req = Request.from_values(
-            input_stream=io.BytesIO(data),
-            content_length=len(data),
-            content_type="application/x-www-form-urlencoded",
-            method="POST",
-        )
-        req.max_form_memory_size = 400
-        assert req.form["foo"] == "Hello World"
-
         input_stream = io.BytesIO(b"foo=123456")
         req = Request.from_values(
             input_stream=input_stream,


### PR DESCRIPTION
Add more docs to address the constant stream of invalid security reports about the form parser and max content length.

- The stream must be limited by using `FormDataParser.parse_from_environ` or `get_input_stream`.
- `max_form_memory_size` and `max_form_parts` are additional checks, they do not replace a limited stream and `max_content_length`.
- Update docs, `Request` attr docstrings, and `FormDataParser` docstrings.
- Add a comment to `_parse_urlencoded` explaining why it doesn't use `max_form_memory_size` or `max_form_parts`.

`_parse_urlencoded` actually _did_ enforce `content_length <= max_form_memory_size`, which was where a lot of the invalid reports were coming from since they only looked at that and nothing else. That check seems to have been there forever, but it seems to be incorrect. `max_form_memory_size` is for `multipart/form-data` (and is already dubiously useful for text parts, since they will still all take up memory in the end, which should be limited with `max_content_length`). The check here was applied to the entire body as if it was `max_content_length`. We also decided that enforcing `max_form_parts` there didn't make sense. I removed the check.