### PR TITLE
avoid resizing buffer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Unreleased
 -   ``Authorization`` parsing ``basic`` auth disallows non-base64 characters.
 -   ``application/x-www-form-urlencoded`` form data is no longer limited to
     ``max_form_memory_size``, only ``max_content_length``.
+-   ``LimitedStream.readinto`` does not resize the buffer when it reads less
+    than the remaining size.
 
 
 Version 3.1.8

--- a/src/werkzeug/wsgi.py
+++ b/src/werkzeug/wsgi.py
@@ -561,7 +561,11 @@ class LimitedStream(io.RawIOBase):
                     return 0
 
                 if out_size:
-                    b[:out_size] = temp_b
+                    # Need to slice both sides. Math here is complicated.
+                    # size=10, remaining=5, out_size=3, remaining > out_size
+                    # Without slicing temp_b (b[:s] = tb), would try to
+                    # put 5 bytes into 3 bytes, causing b to resize to 12.
+                    b[:out_size] = temp_b[:out_size]
         else:
             # WSGI requires that stream.read is available.
             try:


### PR DESCRIPTION
There's some weird behavior with Python bytearray slice assignment. If you assign more bytes than the size of the slice, the assigned-to buffer is resized to accommodate.

```python
b = bytearray(10)  # LimitedStream.readinto(target)
remaining = 5  # 5 remaining bytes to read, smaller than target
temp_b = bytearray(5)  # buffer that only fits remaining bytes
out_size = 3  # internal stream.readinto(temp) only read 3 bytes instead of the remaining 5

b[:out_size] = temp_b  # assigning 5 byte buffer to 3 byte slice
# b is now 12 bytes to accommodate the 2 extra bytes

# fix:
b[:out_size] = temp_b[:out_size]  # assign same number of bytes as target slice
```

I doubt _anyone_ is using `readinto(bytearray)`, and I'm not even sure it matters if the array grows, but might as well be absolutely correct.