### PR TITLE
sort converter matches numerically

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Unreleased
     ``max_form_memory_size``, only ``max_content_length``.
 -   ``LimitedStream.readinto`` does not resize the buffer when it reads less
     than the remaining size.
+-   Rules with 10 or more converters in a single part assign matched values
+    correctly.
 
 
 Version 3.1.8

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -137,13 +137,14 @@ class StateMachineMatcher:
                             remaining = [""]
 
                     converter_groups = sorted(
-                        match.groupdict().items(), key=lambda entry: entry[0]
+                        (
+                            item
+                            for item in match.groupdict().items()
+                            if item[0].startswith("__werkzeug_")
+                        ),
+                        key=lambda item: int(item[0][11:]),
                     )
-                    groups = [
-                        value
-                        for key, value in converter_groups
-                        if key.startswith("__werkzeug_")
-                    ]
+                    groups = [item[1] for item in converter_groups]
                     rv = _match(new_state, remaining, values + groups)
                     if rv is not None:
                         return rv

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -830,6 +830,17 @@ def test_nested_regex_groups():
     assert kwargs["end"] == "2023-02-16T23:46:36.266Z"
 
 
+def test_part_converter_order():
+    """Match groups within a single part are sorted numerically.
+
+    ``__werkzeug_2`` should sort before ``__werkzeug_10``.
+    """
+    m = r.Map([r.Rule(f"/{'-'.join(f'<int:a{i}>' for i in range(11))}", endpoint="a")])
+    a = m.bind("a.test")
+    _, args = a.match(f"/{'-'.join(str(i) for i in range(11))}")
+    assert args == {f"a{i}": i for i in range(11)}
+
+
 def test_anyconverter():
     m = r.Map(
         [


### PR DESCRIPTION
Converter matches were being sorted alphabetically instead of numerically. If there were 10 converters, `__werkzeug_10` would sort before `__werkzeug_2`, causing values to be assigned to incorrect keys.