### PR TITLE
disallow range -0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Unreleased
     than the remaining size.
 -   Rules with 10 or more converters in a single part assign matched values
     correctly.
+-   The invalid ``Range`` suffix length ``-0`` is no longer accepted.
 
 
 Version 3.1.8

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -878,6 +878,11 @@ def parse_range_header(
                 begin = _plain_int(item)
             except ValueError:
                 return None
+
+            # -0 will parse to 0, and is an invalid suffix length.
+            if begin == 0:
+                return None
+
             end = None
             last_end = -1
         elif "-" in item:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -687,6 +687,9 @@ class TestRange:
         rv = http.parse_range_header("bytes=52-99, bad")
         assert rv is None
 
+        rv = http.parse_range_header("bytes=-0")
+        assert rv is None
+
     def test_content_range_parsing(self):
         rv = http.parse_content_range_header("bytes 0-98/*")
         assert rv.units == "bytes"


### PR DESCRIPTION
When parsing `Range: bytes=-0`, `-0` gets recognized as a suffix length, but then Python parses `-0` to `0`. `-0` is an invalid suffix length, so return `None`