### PR TITLE
[rejected AI] Keep equal-weight URL rules in registration order when matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,7 +109,8 @@ Version 3.1.9
 
 Unreleased
 
--   ``ProfilerMiddleware`` uses ``profiling.tracing`` on Python 3.15. :issue:`3207`
+-   Matching two rules of equal priority is no longer affected by an earlier
+    unrelated rule that shares a converter. :issue:`3156`
 -   ``uri_to_iri`` and ``iri_to_uri`` preserve empty username, password, and
     port 0. :issue:`3189`
 -   Improve performance of ``parse_options_header``.

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -35,8 +35,12 @@ class StateMachineMatcher:
     def __init__(self, merge_slashes: bool) -> None:
         self._root = State()
         self.merge_slashes = merge_slashes
+        self._rule_index: dict[int, int] = {}
+        self._next_index = 0
 
     def add(self, rule: Rule) -> None:
+        self._rule_index[id(rule)] = self._next_index
+        self._next_index += 1
         state = self._root
         for part in rule._parts:
             if part.static:
@@ -123,37 +127,58 @@ class StateMachineMatcher:
                 if rv is not None:
                     return rv
             # No match via the static transitions, so try the dynamic
-            # ones.
-            for test_part, new_state in state.dynamic:
-                target = part
-                remaining = parts[1:]
-                # A final part indicates a transition that always
-                # consumes the remaining parts i.e. transitions to a
-                # final state.
-                if test_part.final:
-                    target = "/".join(parts)
-                    remaining = []
-                match = re.compile(test_part.content).match(target)
-                if match is not None:
-                    if test_part.suffixed:
-                        # If a part_isolating=False part has a slash suffix, remove the
-                        # suffix from the match and check for the slash redirect next.
-                        suffix = match.groups()[-1]
-                        if suffix == "/":
-                            remaining = [""]
+            # ones. Transitions are grouped by weight. Within a weight
+            # class, every matching transition is tried and the
+            # earliest-registered rule wins. Otherwise an earlier
+            # unrelated rule that shares a converter can change which
+            # of two equal-priority rules matches.
+            dyn = state.dynamic
+            weight_start = 0
+            while weight_start < len(dyn):
+                weight = dyn[weight_start][0].weight
+                weight_end = weight_start + 1
+                while (
+                    weight_end < len(dyn) and dyn[weight_end][0].weight == weight
+                ):
+                    weight_end += 1
 
-                    converter_groups = sorted(
-                        (
-                            item
-                            for item in match.groupdict().items()
-                            if item[0].startswith("__werkzeug_")
-                        ),
-                        key=lambda item: int(item[0][11:]),
+                matches: list[tuple[Rule, list[str]]] = []
+                for test_part, new_state in dyn[weight_start:weight_end]:
+                    target = part
+                    remaining = parts[1:]
+                    # A final part indicates a transition that always
+                    # consumes the remaining parts i.e. transitions to a
+                    # final state.
+                    if test_part.final:
+                        target = "/".join(parts)
+                        remaining = []
+                    match = re.compile(test_part.content).match(target)
+                    if match is not None:
+                        if test_part.suffixed:
+                            # If a part_isolating=False part has a slash suffix, remove the
+                            # suffix from the match and check for the slash redirect next.
+                            suffix = match.groups()[-1]
+                            if suffix == "/":
+                                remaining = [""]
+
+                        converter_groups = sorted(
+                            (
+                                item
+                                for item in match.groupdict().items()
+                                if item[0].startswith("__werkzeug_")
+                            ),
+                            key=lambda item: int(item[0][11:]),
+                        )
+                        groups = [item[1] for item in converter_groups]
+                        rv = _match(new_state, remaining, values + groups)
+                        if rv is not None:
+                            matches.append(rv)
+                if matches:
+                    return min(
+                        matches,
+                        key=lambda item: self._rule_index.get(id(item[0]), 0),
                     )
-                    groups = [item[1] for item in converter_groups]
-                    rv = _match(new_state, remaining, values + groups)
-                    if rv is not None:
-                        return rv
+                weight_start = weight_end
 
             # If there is no match and the only part left is a
             # trailing slash ("") consider rules that aren't

--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -137,9 +137,7 @@ class StateMachineMatcher:
             while weight_start < len(dyn):
                 weight = dyn[weight_start][0].weight
                 weight_end = weight_start + 1
-                while (
-                    weight_end < len(dyn) and dyn[weight_end][0].weight == weight
-                ):
+                while weight_end < len(dyn) and dyn[weight_end][0].weight == weight:
                     weight_end += 1
 
                 matches: list[tuple[Rule, list[str]]] = []
@@ -155,8 +153,9 @@ class StateMachineMatcher:
                     match = re.compile(test_part.content).match(target)
                     if match is not None:
                         if test_part.suffixed:
-                            # If a part_isolating=False part has a slash suffix, remove the
-                            # suffix from the match and check for the slash redirect next.
+                            # If a part_isolating=False part has a slash suffix,
+                            # remove the suffix from the match and check for
+                            # the slash redirect next.
                             suffix = match.groups()[-1]
                             if suffix == "/":
                                 remaining = [""]

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -938,6 +938,31 @@ def test_uuid_converter():
     assert type(kwargs["a_uuid"]) == uuid.UUID  # noqa: E721
 
 
+def test_equal_weight_rules_keep_registration_order():
+    """An unrelated earlier rule must not change which of two equal-priority
+    rules matches. See #3156.
+    """
+    rule_1 = r.Rule("/<dummy:value>", endpoint="rule_1")
+    rule_2 = r.Rule("/<string:value>", endpoint="rule_2")
+    map = r.Map(
+        [rule_1, rule_2],
+        converters={"dummy": r.BaseConverter},
+    )
+    adapter = map.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+    map = r.Map(
+        [
+            r.Rule("/<string:value>/no_match", endpoint="no_match"),
+            rule_1.empty(),
+            rule_2.empty(),
+        ],
+        converters={"dummy": r.BaseConverter},
+    )
+    adapter = map.bind("example.org", "/")
+    assert adapter.match("/foo") == ("rule_1", {"value": "foo"})
+
+
 def test_converter_with_tuples():
     """Tuple values should be passed to the converter, rather than being
     interpreted as MultiDict query values.


### PR DESCRIPTION
Two rules with the same converter weight are supposed to keep registration order. An earlier unrelated rule that happens to share a converter currently gets merged into the same dynamic transition, so matching tries that path first and the later equal-priority rule wins.

Within a weight class this now tries every matching transition and picks the rule that was registered first. Unrelated earlier rules no longer change which of two equal-priority rules matches.

Fixes #3156