### PR TITLE
[rejected AI] Create the werkzeug logger exactly once under concurrency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,9 @@ Version 3.2.0
     The private ``gen_salt`` method is removed. :pr:`3167`
 -   The test ``Client`` has a ``query`` method for the ``QUERY`` request method.
 -   ``unquote_etag`` and ``ETags.from_header`` discard invalid unquoted values.
+-   The ``werkzeug`` logger is created exactly once when several threads
+    log for the first time simultaneously, rather than installing a
+    duplicate handler. :pr:`3258`
 
 
 Version 3.1.9

--- a/src/werkzeug/_internal.py
+++ b/src/werkzeug/_internal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import sys
+import threading
 import typing as t
 from datetime import datetime
 from datetime import timezone
@@ -13,6 +14,11 @@ if t.TYPE_CHECKING:
     from .wrappers.request import Request
 
 _logger: logging.Logger | None = None
+# _log() creates the logger on first use.  Both the `_logger is None` test and
+# the _has_level_handler() test are check-then-act, so without this lock two
+# threads logging their first message at the same time each add a handler and
+# every subsequent werkzeug log line is emitted once per extra handler.
+_logger_lock = threading.Lock()
 
 
 class _Missing:
@@ -86,13 +92,19 @@ def _log(type: str, message: str, *args: t.Any, **kwargs: t.Any) -> None:
     global _logger
 
     if _logger is None:
-        _logger = logging.getLogger("werkzeug")
+        with _logger_lock:
+            if _logger is None:
+                logger = logging.getLogger("werkzeug")
 
-        if _logger.level == logging.NOTSET:
-            _logger.setLevel(logging.INFO)
+                if logger.level == logging.NOTSET:
+                    logger.setLevel(logging.INFO)
 
-        if not _has_level_handler(_logger):
-            _logger.addHandler(_ColorStreamHandler())
+                if not _has_level_handler(logger):
+                    logger.addHandler(_ColorStreamHandler())
+
+                # published last, so another thread never sees a logger that
+                # is not yet configured
+                _logger = logger
 
     getattr(_logger, type)(message.rstrip(), *args, **kwargs)
 

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,5 +1,9 @@
+import logging
+import threading
+
 import pytest
 
+import werkzeug._internal as _internal
 from werkzeug._internal import _plain_int
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
@@ -57,3 +61,61 @@ def test_plain_int(value: str, base: int, expect: int | None) -> None:
             _plain_int(value, base)
     else:
         assert _plain_int(value, base) == expect
+
+
+def test_log_installs_exactly_one_handler_under_concurrency():
+    """The lazy logger setup in _log() must not run more than once.
+
+    Both `_logger is None` and `_has_level_handler()` are check-then-act, so
+    threads emitting their first werkzeug log line at the same moment could
+    each add a handler, after which every log line is emitted once per extra
+    handler.
+    """
+    logger = logging.getLogger("werkzeug")
+    root = logging.getLogger()
+    original = (logger.handlers[:], logger.level, root.handlers[:], _internal._logger)
+
+    n_threads = 4
+    go = threading.Event()
+
+    try:
+        for _ in range(50):
+            # _has_level_handler() walks up to the root logger, and under
+            # pytest the root already has a capture handler -- which would
+            # make werkzeug correctly decline to add its own. Clear it so the
+            # branch under test actually runs.
+            root.handlers.clear()
+            logger.handlers.clear()
+            logger.setLevel(logging.NOTSET)
+            _internal._logger = None
+
+            def worker() -> None:
+                # An Event rather than a Barrier, so a runner that can only
+                # give us some of the threads still runs.
+                go.wait()
+                _internal._log("info", "hello")
+
+            threads = []
+            for _ in range(n_threads):
+                thread = threading.Thread(target=worker)
+                try:
+                    thread.start()
+                except RuntimeError:
+                    break
+                threads.append(thread)
+
+            if len(threads) < 2:
+                go.set()
+                for thread in threads:
+                    thread.join()
+                pytest.skip("could not start enough threads to test for the race")
+
+            go.set()
+            for thread in threads:
+                thread.join()
+            go.clear()
+
+            assert len(logger.handlers) == 1
+    finally:
+        go.set()
+        logger.handlers[:], logger.level, root.handlers[:], _internal._logger = original


### PR DESCRIPTION
### The problem

`_log()` in `src/werkzeug/_internal.py` lazily creates the module logger:

```python
global _logger

if _logger is None:
    _logger = logging.getLogger("werkzeug")          # published immediately

    if _logger.level == logging.NOTSET:
        _logger.setLevel(logging.INFO)

    if not _has_level_handler(_logger):              # check-then-act
        _logger.addHandler(_ColorStreamHandler())
```

There are two check-then-act races stacked here — `_logger is None` and `_has_level_handler(_logger)` — plus a publication bug: `_logger` is assigned *before* the level and handler are configured, so another thread can pick up a logger that is not yet set up and log through it.

When several threads emit their first werkzeug log line at the same moment they each observe "no handler yet" and each add one, after which every werkzeug log line is emitted once per extra handler. Measured on a free-threaded 3.14.4 build with 16 threads, 300 trials: 4/300 trials ended up with two handlers. With `PYTHON_GIL=1` on the same interpreter: 0/300.

This is not new in the free-threaded build — it was always reachable — but PEP 779 makes it much easier to hit.

### The change

Double-checked locking with a module-level `threading.Lock`, and `_logger` assigned **last**, after the level and handler are configured.

### Tests

`test_log_installs_exactly_one_handler_under_concurrency` in `tests/test_internal.py`. It fails 5/5 runs without the change and passes with it.

The test clears the root logger's handlers for the duration, because `_has_level_handler()` walks up the hierarchy and pytest's own capture handler on the root would otherwise make werkzeug correctly decline to add a handler at all — which would make the branch under test unreachable. Everything is restored in a `finally`.

It also waits on an `Event` rather than a `Barrier` and skips if fewer than two threads can be started, so a thread-constrained runner degrades rather than deadlocks.

| | Result |
| --- | --- |
| Full suite (excluding `test_serving.py` / `test_debug.py`, which fail to collect in my environment for unrelated reasons — missing `fsevents`, unregistered pytest mark) | **996 passed** |
| `tests/test_internal.py` with `PYTHON_GIL=1` | 15 passed |

Environment: CPython 3.14.4 free-threaded, macOS 15 / arm64.
