### PR TITLE
[rejected AI] Preserve registration order for equal-weight routing rules

### DIFF
--- a/src/werkzeug/routing/matcher.py
+++ b/src/werkzeug/routing/matcher.py
@@ -29,14 +29,18 @@ class State:
     dynamic: list[tuple[RulePart, State]] = field(default_factory=list)
     rules: list[Rule] = field(default_factory=list)
     static: dict[str, State] = field(default_factory=dict)
+    match_order: int | None = None
 
 
 class StateMachineMatcher:
     def __init__(self, merge_slashes: bool) -> None:
         self._root = State()
         self.merge_slashes = merge_slashes
+        self._rule_order = 0
 
     def add(self, rule: Rule) -> None:
+        rule_order = self._rule_order
+        self._rule_order += 1
         state = self._root
         for part in rule._parts:
             if part.static:
@@ -57,6 +61,8 @@ class StateMachineMatcher:
                 raise DuplicateRuleError(existing, rule)
 
         state.rules.append(rule)
+        if state.match_order is None:
+            state.match_order = rule_order
 
     def update(self) -> None:
         # For every state the dynamic transitions should be sorted by
@@ -64,7 +70,14 @@ class StateMachineMatcher:
         state = self._root
 
         def _update_state(state: State) -> None:
-            state.dynamic.sort(key=lambda entry: entry[0].weight)
+            state.dynamic.sort(
+                key=lambda entry: (
+                    entry[0].weight,
+                    entry[1].match_order
+                    if entry[1].match_order is not None
+                    else float("inf"),
+                )
+            )
             for new_state in state.static.values():
                 _update_state(new_state)
             for _, new_state in state.dynamic:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -326,6 +326,19 @@ def test_no_duplicate_different_converters() -> None:
     )
 
 
+def test_equal_weight_rule_order_is_not_affected_by_unrelated_rules() -> None:
+    rule_1 = r.Rule("/<any(foo, bar):value>", endpoint="rule_1")
+    rule_2 = r.Rule("/<string:value>", endpoint="rule_2")
+    map = r.Map(
+        [r.Rule("/<string:value>/no_match", endpoint="no_match"), rule_1, rule_2]
+    )
+
+    assert map.bind("example.org", "/").match("/foo") == (
+        "rule_1",
+        {"value": "foo"},
+    )
+
+
 def test_duplicate_method_overlap() -> None:
     """Rules with overlapping methods are duplicates."""
     with pytest.raises(DuplicateRuleError):


### PR DESCRIPTION
## Changes

When equal-weight dynamic rules share a state, adding an unrelated rule could change which existing rule matched. The matcher now keeps the earliest terminal rule order as the tie-breaker for equal-weight transitions.

## Tests

- `pytest tests/test_routing.py -q` (188 passed)
- `pytest -q` (1,046 passed)
- `ruff check src/werkzeug/routing/matcher.py tests/test_routing.py`
