### PR TITLE
[rejected AI] remove Response.autocorrect_location_header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Version 3.2.0
 -------------
 
 -   Drop support for Python 3.9. :pr:`3098`
+-   Remove ``Response.autocorrect_location_header``. :issue:`3247`
 -   Remove previous deprecated code: :pr:`3099`
 
     -   ``OrderedMultiDict`` and ``ImmutableOrderedMultiDict are removed.

--- a/src/werkzeug/test.py
+++ b/src/werkzeug/test.py
@@ -1019,8 +1019,7 @@ class Client:
             builder.url_scheme = scheme
             builder.host = netloc
         else:
-            # A local redirect with autocorrect_location_header=False
-            # doesn't have a host, so use the request's host.
+            # A local redirect doesn't have a host, so use the request's host.
             to_name_parts = from_name_parts
 
         # Explain why a redirect to a different server name won't be followed.

--- a/src/werkzeug/wrappers/response.py
+++ b/src/werkzeug/wrappers/response.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import typing as t
 from http import HTTPStatus
-from urllib.parse import urljoin
 
 from .._internal import _get_environ
 from ..datastructures import ETags
@@ -18,7 +17,6 @@ from ..urls import iri_to_uri
 from ..utils import cached_property
 from ..wsgi import _RangeWrapper
 from ..wsgi import ClosingIterator
-from ..wsgi import get_current_url
 
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse
@@ -115,16 +113,6 @@ class Response(_SansIOResponse):
     #:    (Notice the typo).  If you did use this feature, you have to adapt
     #:    your code to the name change.
     implicit_sequence_conversion = True
-
-    #: If a redirect ``Location`` header is a relative URL, make it an
-    #: absolute URL, including scheme and domain.
-    #:
-    #: .. versionchanged:: 2.1
-    #:     This is disabled by default, so responses will send relative
-    #:     redirects.
-    #:
-    #: .. versionadded:: 0.8
-    autocorrect_location_header = False
 
     #: Should this response object automatically set the content-length
     #: header if possible?  This is true by default.
@@ -478,15 +466,7 @@ class Response(_SansIOResponse):
                 content_length = value
 
         if location is not None:
-            location = iri_to_uri(location)
-
-            if self.autocorrect_location_header:
-                # Make the location header an absolute URL.
-                current_url = get_current_url(environ, strip_querystring=True)
-                current_url = iri_to_uri(current_url)
-                location = urljoin(current_url, location)
-
-            headers["Location"] = location
+            headers["Location"] = iri_to_uri(location)
 
         # make sure the content location is a URL
         if content_location is not None:

--- a/tests/middleware/test_proxy_fix.py
+++ b/tests/middleware/test_proxy_fix.py
@@ -7,7 +7,6 @@ from werkzeug.test import Client
 from werkzeug.test import create_environ
 from werkzeug.utils import redirect
 from werkzeug.wrappers import Request
-from werkzeug.wrappers import Response
 
 
 @pytest.mark.parametrize(
@@ -159,9 +158,7 @@ from werkzeug.wrappers import Response
         ),
     ),
 )
-def test_proxy_fix(monkeypatch, kwargs, base, url_root):
-    monkeypatch.setattr(Response, "autocorrect_location_header", True)
-
+def test_proxy_fix(kwargs, base, url_root):
     @Request.application
     def app(request):
         # for header
@@ -170,14 +167,12 @@ def test_proxy_fix(monkeypatch, kwargs, base, url_root):
         assert request.url_root == url_root
 
         urls = url_map.bind_to_environ(request.environ)
-        parrot_url = urls.build("parrot")
+        parrot_url = urls.build("parrot", force_external=True)
         # build includes prefix
         assert urls.build("parrot") == "/".join((request.script_root, "parrot"))
         # match doesn't include prefix
         assert urls.match("/parrot")[0] == "parrot"
 
-        # With autocorrect_location_header enabled, location header will
-        # start with url_root
         return redirect(parrot_url)
 
     url_map = Map([Rule("/parrot", endpoint="parrot")])

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -458,13 +458,10 @@ def test_follow_redirect():
 
 
 def test_follow_local_redirect():
-    class LocalResponse(Response):
-        autocorrect_location_header = False
-
     def local_redirect_app(environ, start_response):
         req = Request(environ)
         if "/from/location" in req.url:
-            response = redirect("/to/location", Response=LocalResponse)
+            response = redirect("/to/location")
         else:
             response = Response(f"current path: {req.path}")
         return response(environ, start_response)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -250,35 +250,28 @@ def test_header_set_duplication_bug():
 
 
 @pytest.mark.parametrize(
-    ("path", "base_url", "absolute_location"),
+    ("path", "base_url", "expect"),
     [
-        ("foo", "http://example.org/app", "http://example.org/app/foo/"),
-        ("/foo", "http://example.org/app", "http://example.org/app/foo/"),
-        ("/foo/bar", "http://example.org/", "http://example.org/foo/bar/"),
-        ("/foo/bar", "http://example.org/app", "http://example.org/app/foo/bar/"),
-        ("/foo?baz", "http://example.org/", "http://example.org/foo/?baz"),
-        ("/foo/", "http://example.org/", "http://example.org/foo/"),
-        ("/foo/", "http://example.org/app", "http://example.org/app/foo/"),
-        ("/", "http://example.org/", "http://example.org/"),
-        ("/", "http://example.org/app", "http://example.org/app/"),
+        ("foo", "http://example.org/app", "foo/"),
+        ("/foo", "http://example.org/app", "foo/"),
+        ("/foo/bar", "http://example.org/", "bar/"),
+        ("/foo/bar", "http://example.org/app", "bar/"),
+        ("/foo?baz", "http://example.org/", "foo/?baz"),
+        ("/foo/", "http://example.org/", "./"),
+        ("/foo/", "http://example.org/app", "./"),
+        ("/", "http://example.org/", "./"),
+        ("/", "http://example.org/app", "./"),
     ],
 )
-@pytest.mark.parametrize("autocorrect", [False, True])
-def test_append_slash_redirect(autocorrect, path, base_url, absolute_location):
+def test_append_slash_redirect(path, base_url, expect):
     @Request.application
     def app(request):
-        rv = utils.append_slash_redirect(request.environ)
-        rv.autocorrect_location_header = autocorrect
-        return rv
+        return utils.append_slash_redirect(request.environ)
 
     client = Client(app)
     response = client.get(path, base_url=base_url)
     assert response.status_code == 308
-
-    if not autocorrect:
-        assert response.headers["Location"].count("/") == 1
-    else:
-        assert response.headers["Location"] == absolute_location
+    assert response.headers["Location"] == expect
 
 
 def test_cached_property_doc():

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1095,18 +1095,17 @@ def test_disabled_auto_content_length():
 
 
 @pytest.mark.parametrize(
-    ("auto", "location", "expect"),
+    ("location", "expect"),
     (
-        (False, "/test", "/test"),
-        (False, "/\\\\test.example?q", "/%5C%5Ctest.example?q"),
-        (True, "/test", "http://localhost/test"),
-        (True, "test", "http://localhost/a/b/test"),
-        (True, "./test", "http://localhost/a/b/test"),
-        (True, "../test", "http://localhost/a/test"),
+        ("/test", "/test"),
+        ("/\\\\test.example?q", "/%5C%5Ctest.example?q"),
+        ("test", "test"),
+        ("./test", "./test"),
+        ("../test", "../test"),
+        ("http://example.com/test", "http://example.com/test"),
     ),
 )
-def test_location_header_autocorrect(monkeypatch, auto, location, expect):
-    monkeypatch.setattr(wrappers.Response, "autocorrect_location_header", auto)
+def test_location_header(location, expect):
     env = create_environ("/a/b/c")
     resp = wrappers.Response("Hello World!")
     resp.headers["Location"] = location


### PR DESCRIPTION
Removes `Response.autocorrect_location_header` as planned for 3.2.0.

- Removed `autocorrect_location_header` attribute and relative-to-absolute URL correction in `Response.get_wsgi_headers`.
- Removed unused `urljoin` and `get_current_url` imports in `src/werkzeug/wrappers/response.py`.
- Updated test cases in `test_wrappers.py`, `test_proxy_fix.py`, `test_test.py`, and `test_utils.py`.
- Added entry to `CHANGES.rst`.

fixes #3247
