### PR TITLE
deprecated data structures and mixins that are unused within Werkzeug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Version 3.2.0
     -   ``ImmutableDict`` and ``ImmutableDictMixin`` are deprecated. Use
         ``Mapping`` and ``MutableMapping`` for typing.
     -   ``UpdateDictMixin`` is deprecated. Use ``CallbackDict`` instead.
+    -   ``TypeConversionDict`` and ``ImmutableTypeConversionDict`` are
+        deprecated. Type converting ``get`` is still available on ``MultiDict``
+        and ``ImmutableMultiDict``.
 
 -   All structured header classes in ``werkzeug.datastructures`` have a
     ``from_header`` class method, and a ``to_header`` method. Corresponding

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,10 +14,14 @@ Version 3.2.0
 -   The CSP ``prefetch_src``, ``navigate_to``, and ``plugin_types`` properties
     are deprecated. Their corresponding directives have been deprecated or
     removed from the spec. :pr:`3114`
--   Deprecate data structures and mixins that are unused within Werkzeug.
+-   Deprecate data structures and mixins that are unused within Werkzeug. Type
+    annotations should be used to indicate mutability.
 
-    -   ``ImmutableList`` and ``ImmutableListMixin``. ``Accept`` inherits
-        ``Sequence`` instead.
+    -   ``ImmutableList`` and ``ImmutableListMixin`` are deprecated. ``Accept``
+        inherits ``Sequence`` instead. Use ``tuple``, ``Sequence``, and
+        ``MutableSequence`` for typing.
+    -   ``ImmutableDict`` and ``ImmutableDictMixin`` are deprecated. Use
+        ``Mapping`` and ``MutableMapping`` for typing.
 
 -   All structured header classes in ``werkzeug.datastructures`` have a
     ``from_header`` class method, and a ``to_header`` method. Corresponding

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ Version 3.2.0
 -   The CSP ``prefetch_src``, ``navigate_to``, and ``plugin_types`` properties
     are deprecated. Their corresponding directives have been deprecated or
     removed from the spec. :pr:`3114`
+-   Deprecate data structures and mixins that are unused within Werkzeug.
+
+    -   ``ImmutableList`` and ``ImmutableListMixin``. ``Accept`` inherits
+        ``Sequence`` instead.
+
 -   All structured header classes in ``werkzeug.datastructures`` have a
     ``from_header`` class method, and a ``to_header`` method. Corresponding
     parsing functions in ``werkzeug.http`` are deprecated: ``dump_csp_header``,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,14 @@ Version 3.2.0
     ``Sequence``. These were previously overridable to allow ordered data
     structures when needed, but Python's ``dict`` now guarantees order. This
     improves static typing. :pr:`3169`
+-   ``RequestCacheControl`` and ``ResponseCacheControl`` inherit ``Mapping`` and
+    ``MutableMapping`` instead of ``ImmutableDict`` and ``dict``.
+-   The ``cache_control_property`` function and ``RequestCacheControl`` and
+    ``ResponseCacheControl`` ``cache_property`` methods are deprecated. Use
+    indexing ``cc[key]`` for unknown directives.
+-   Passing an iterable to ``RequestCacheControl`` and ``ResponseCacheControl``
+    is deprecated. Pass a mapping, which is what ``parse_dict_header`` returns
+    and what their ``from_header`` method uses.
 -   The ``Request.autocorrect_location_header`` attribute is deprecated. Set
     ``response.location`` directly if you need an absolute URL. :issue:`3247`
 -   ``HTTP_STATUS_CODES`` is deprecated. Use Python's built-in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Version 3.2.0
         ``MutableSequence`` for typing.
     -   ``ImmutableDict`` and ``ImmutableDictMixin`` are deprecated. Use
         ``Mapping`` and ``MutableMapping`` for typing.
+    -   ``UpdateDictMixin`` is deprecated. Use ``CallbackDict`` instead.
 
 -   All structured header classes in ``werkzeug.datastructures`` have a
     ``from_header`` class method, and a ``to_header`` method. Corresponding

--- a/docs/datastructures.rst
+++ b/docs/datastructures.rst
@@ -62,12 +62,10 @@ HTTP Related
 
 .. autoclass:: RequestCacheControl
     :members:
-    :inherited-members: ImmutableDictMixin, CallbackDict
     :member-order: groupwise
 
 .. autoclass:: ResponseCacheControl
     :members:
-    :inherited-members: CallbackDict
     :member-order: groupwise
 
 .. autoclass:: ETags

--- a/src/werkzeug/datastructures/__init__.py
+++ b/src/werkzeug/datastructures/__init__.py
@@ -17,7 +17,6 @@ from .headers import EnvironHeaders as EnvironHeaders
 from .headers import Headers as Headers
 from .mixins import ImmutableHeadersMixin as ImmutableHeadersMixin
 from .mixins import ImmutableMultiDictMixin as ImmutableMultiDictMixin
-from .mixins import UpdateDictMixin as UpdateDictMixin
 from .range import ContentRange as ContentRange
 from .range import IfRange as IfRange
 from .range import Range as Range
@@ -54,6 +53,7 @@ def __getattr__(name: str) -> t.Any:
         "ImmutableList": (structures, "collections.abc.Sequence"),
         "ImmutableDictMixin": (mixins, "collections.abc.Mapping"),
         "ImmutableDict": (structures, "collections.abc.Mapping"),
+        "UpdateDictMixin": (mixins, "CallbackDict"),
     }
 
     if name in alts:

--- a/src/werkzeug/datastructures/__init__.py
+++ b/src/werkzeug/datastructures/__init__.py
@@ -17,7 +17,6 @@ from .headers import EnvironHeaders as EnvironHeaders
 from .headers import Headers as Headers
 from .mixins import ImmutableDictMixin as ImmutableDictMixin
 from .mixins import ImmutableHeadersMixin as ImmutableHeadersMixin
-from .mixins import ImmutableListMixin as ImmutableListMixin
 from .mixins import ImmutableMultiDictMixin as ImmutableMultiDictMixin
 from .mixins import UpdateDictMixin as UpdateDictMixin
 from .range import ContentRange as ContentRange
@@ -27,7 +26,6 @@ from .structures import CallbackDict as CallbackDict
 from .structures import CombinedMultiDict as CombinedMultiDict
 from .structures import HeaderSet as HeaderSet
 from .structures import ImmutableDict as ImmutableDict
-from .structures import ImmutableList as ImmutableList
 from .structures import ImmutableMultiDict as ImmutableMultiDict
 from .structures import ImmutableTypeConversionDict as ImmutableTypeConversionDict
 from .structures import iter_multi_items as iter_multi_items
@@ -49,5 +47,25 @@ def __getattr__(name: str) -> t.Any:
             stacklevel=2,
         )
         return _CharsetAccept
+
+    from . import mixins
+    from . import structures
+
+    alts = {
+        "ImmutableListMixin": (mixins, "collections.abc.Sequence"),
+        "ImmutableList": (structures, "collections.abc.Sequence"),
+    }
+
+    if name in alts:
+        import warnings
+
+        mod, alt = alts[name]
+        warnings.warn(
+            f"The '{name}' class is deprecated and will be removed in"
+            f" Werkzeug 3.3. Use '{alt}' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(mod, f"_{name}")
 
     raise AttributeError(name)

--- a/src/werkzeug/datastructures/__init__.py
+++ b/src/werkzeug/datastructures/__init__.py
@@ -24,10 +24,8 @@ from .structures import CallbackDict as CallbackDict
 from .structures import CombinedMultiDict as CombinedMultiDict
 from .structures import HeaderSet as HeaderSet
 from .structures import ImmutableMultiDict as ImmutableMultiDict
-from .structures import ImmutableTypeConversionDict as ImmutableTypeConversionDict
 from .structures import iter_multi_items as iter_multi_items
 from .structures import MultiDict as MultiDict
-from .structures import TypeConversionDict as TypeConversionDict
 
 
 def __getattr__(name: str) -> t.Any:
@@ -54,6 +52,8 @@ def __getattr__(name: str) -> t.Any:
         "ImmutableDictMixin": (mixins, "collections.abc.Mapping"),
         "ImmutableDict": (structures, "collections.abc.Mapping"),
         "UpdateDictMixin": (mixins, "CallbackDict"),
+        "ImmutableTypeConversionDict": (structures, "ImmutableMultiDict"),
+        "TypeConversionDict": (structures, "MultiDict"),
     }
 
     if name in alts:

--- a/src/werkzeug/datastructures/__init__.py
+++ b/src/werkzeug/datastructures/__init__.py
@@ -15,7 +15,6 @@ from .file_storage import FileMultiDict as FileMultiDict
 from .file_storage import FileStorage as FileStorage
 from .headers import EnvironHeaders as EnvironHeaders
 from .headers import Headers as Headers
-from .mixins import ImmutableDictMixin as ImmutableDictMixin
 from .mixins import ImmutableHeadersMixin as ImmutableHeadersMixin
 from .mixins import ImmutableMultiDictMixin as ImmutableMultiDictMixin
 from .mixins import UpdateDictMixin as UpdateDictMixin
@@ -25,7 +24,6 @@ from .range import Range as Range
 from .structures import CallbackDict as CallbackDict
 from .structures import CombinedMultiDict as CombinedMultiDict
 from .structures import HeaderSet as HeaderSet
-from .structures import ImmutableDict as ImmutableDict
 from .structures import ImmutableMultiDict as ImmutableMultiDict
 from .structures import ImmutableTypeConversionDict as ImmutableTypeConversionDict
 from .structures import iter_multi_items as iter_multi_items
@@ -34,9 +32,9 @@ from .structures import TypeConversionDict as TypeConversionDict
 
 
 def __getattr__(name: str) -> t.Any:
-    if name == "CharsetAccept":
-        import warnings
+    import warnings
 
+    if name == "CharsetAccept":
         from .accept import _CharsetAccept
 
         warnings.warn(
@@ -54,6 +52,8 @@ def __getattr__(name: str) -> t.Any:
     alts = {
         "ImmutableListMixin": (mixins, "collections.abc.Sequence"),
         "ImmutableList": (structures, "collections.abc.Sequence"),
+        "ImmutableDictMixin": (mixins, "collections.abc.Mapping"),
+        "ImmutableDict": (structures, "collections.abc.Mapping"),
     }
 
     if name in alts:

--- a/src/werkzeug/datastructures/accept.py
+++ b/src/werkzeug/datastructures/accept.py
@@ -8,7 +8,6 @@ import typing as t
 from ..http import dump_options_header
 from ..http import parse_list_header
 from ..http import parse_options_header
-from .structures import ImmutableList
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
@@ -16,10 +15,14 @@ if t.TYPE_CHECKING:
 _q_value_re = re.compile(r"-?[0-9]+(\.[0-9]+)?", re.ASCII)
 
 
-class Accept(ImmutableList[tuple[str, float]]):
-    """An :class:`Accept` object is just a list subclass for lists of
-    ``(value, quality)`` tuples.  It is automatically sorted by specificity
-    and quality.
+class Accept(cabc.Sequence[tuple[str, float]]):
+    """A sequence of ``(value: str, quality: float)`` tuples sorted by
+    specificity and quality.
+
+    This class is for the ``Accept-Encoding`` header. The
+    :class:`.MIMEAccept` subclass is used for the ``Accept`` header. The
+    :class:`.LanguageAccept` subclass is used for the ``Accept-Language``
+    header.
 
     All :class:`Accept` objects work similar to a list but provide extra
     functionality for working with the data.  Containment checks are
@@ -42,31 +45,24 @@ class Accept(ImmutableList[tuple[str, float]]):
     >>> a['utf7']
     0
 
+    .. versionchanged:: 3.2
+        Inherits ``Sequence`` instead of ``ImmutableList``.
+
+    .. versionchanged:: 1.0
+        Items with equal quality preserve initial order instead of being ordered
+        alphabetically.
+
     .. versionchanged:: 0.5
-       :class:`Accept` objects are forced immutable now.
-
-    .. versionchanged:: 1.0.0
-       :class:`Accept` internal values are no longer ordered
-       alphabetically for equal quality tags. Instead the initial
-       order is preserved.
-
+        Immutability is enforced.
     """
 
-    def __init__(
-        self, values: Accept | cabc.Iterable[tuple[str, float]] | None = ()
-    ) -> None:
+    def __init__(self, values: cabc.Iterable[tuple[str, float]] | None = None) -> None:
         if values is None:
-            super().__init__()
-            self.provided = False
-        elif isinstance(values, Accept):
-            self.provided = values.provided
-            super().__init__(values)
-        else:
-            self.provided = True
-            values = sorted(
-                values, key=lambda x: (self._specificity(x[0]), x[1]), reverse=True
-            )
-            super().__init__(values)
+            values = ()
+
+        self._items = tuple(
+            sorted(values, key=lambda x: (self._specificity(x[0]), x[1]), reverse=True)
+        )
 
     def _specificity(self, value: str) -> tuple[bool, ...]:
         """Returns a tuple describing the value's specificity."""
@@ -81,17 +77,17 @@ class Accept(ImmutableList[tuple[str, float]]):
     @t.overload
     def __getitem__(self, key: t.SupportsIndex) -> tuple[str, float]: ...
     @t.overload
-    def __getitem__(self, key: slice) -> list[tuple[str, float]]: ...
+    def __getitem__(self, key: slice) -> tuple[tuple[str, float]]: ...
     def __getitem__(
         self, key: str | t.SupportsIndex | slice
-    ) -> float | tuple[str, float] | list[tuple[str, float]]:
+    ) -> float | tuple[str, float] | tuple[tuple[str, float]]:
         """Besides index lookup (getting item n) you can also pass it a string
         to get the quality for the item.  If the item is not in the list, the
         returned quality is ``0``.
         """
         if isinstance(key, str):
             return self.quality(key)
-        return list.__getitem__(self, key)
+        return self._items[key]  # type: ignore[return-value]
 
     def quality(self, key: str) -> float:
         """Returns the quality of the key.
@@ -111,6 +107,18 @@ class Accept(ImmutableList[tuple[str, float]]):
                 return True
         return False
 
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> cabc.Iterator[tuple[str, float]]:
+        return iter(self._items)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+
+        return self._items == other._items
+
     def __repr__(self) -> str:
         pairs_str = ", ".join(f"({x!r}, {y})" for x, y in self)
         return f"{type(self).__name__}([{pairs_str}])"
@@ -129,7 +137,7 @@ class Accept(ImmutableList[tuple[str, float]]):
                 if self._value_matches(key, item):
                     return idx
             raise ValueError(key)
-        return list.index(self, key)
+        return self._items.index(key)
 
     def find(self, key: str | tuple[str, float]) -> int:
         """Get the position of an entry or return -1.

--- a/src/werkzeug/datastructures/cache_control.py
+++ b/src/werkzeug/datastructures/cache_control.py
@@ -4,111 +4,118 @@ import collections.abc as cabc
 import typing as t
 from inspect import cleandoc
 
+from .._internal import _plain_int
 from ..http import dump_header
 from ..http import parse_dict_header
-from .mixins import ImmutableDictMixin
-from .structures import CallbackDict
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
 
 
-def cache_control_property(
-    key: str, empty: t.Any, type: type[t.Any] | None, *, doc: str | None = None
+def _deprecated_cache_control_property(
+    key: str,
+    empty: t.Any,
+    type: type[t.Any] | None,
+    *,
+    doc: str | None = None,
 ) -> t.Any:
-    """Return a new property object for a cache header. Useful if you
-    want to add support for a cache extension in a subclass.
+    """Create a property for a ``Cache-Control`` directive.
 
-    :param key: The attribute name present in the parsed cache-control header dict.
-    :param empty: The value to use if the key is present without a value.
-    :param type: The type to convert the string value to instead of a string. If
-        conversion raises a ``ValueError``, the returned value is ``None``.
+    :param key: The directive name.
+    :param empty: The value when the directive is present without a value.
+    :param convert: The type to convert the value to. A ``ValueError`` returns ``None``.
     :param doc: The docstring for the property. If not given, it is generated
         based on the other params.
 
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3. Use indexing ``cc[key]`` for unknown
+        directives.
+
     .. versionchanged:: 3.1
-        Added the ``doc`` param.
+        Added the ``doc`` parameter.
 
     .. versionchanged:: 2.0
         Renamed from ``cache_property``.
     """
-    if doc is None:
-        parts = [f"The ``{key}`` attribute."]
+    import warnings
 
-        if type is bool:
-            parts.append("A ``bool``, either present or not.")
+    warnings.warn(
+        "The 'cache_property' and 'cache_control_property' functions are"
+        " deprecated and will be removed in Werkzeug 3.3. Use indexing"
+        " 'cc[key]' for unknown directives.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return _cache_control_property(key, type, empty=empty, mutable=True, doc=doc)
+
+
+def _cache_control_property(
+    key: str,
+    convert: type[t.Any] | None = None,
+    *,
+    empty: t.Any = None,
+    mutable: bool = False,
+    doc: str | None = None,
+) -> t.Any:
+    """Create a property for a ``Cache-Control`` directive.
+
+    :meta private:
+
+    :param key: The directive name.
+    :param empty: The value when the directive is present without a value.
+    :param convert: The type to convert the value to. A ``ValueError`` returns ``None``.
+    :param doc: The docstring for the property. If not given, it is generated
+        based on the other params.
+    :param mutable: Whether the property has a setter and a deleter.
+    """
+    if doc is None:
+        parts = [f"The ``{key}`` directive."]
+
+        if convert is bool:
+            parts.append("A ``bool``, ``True`` if present, ``False`` if not.")
         else:
-            if type is None:
+            if convert is None:
                 parts.append("A ``str``,")
             else:
-                parts.append(f"A ``{type.__name__}``,")
+                parts.append(f"A ``{convert.__name__}``,")
 
             if empty is not None:
-                parts.append(f"``{empty!r}`` if present with no value,")
+                parts.append(f"or ``{empty!r}`` if present with no value,")
 
             parts.append("or ``None`` if not present.")
 
         doc = " ".join(parts)
 
+    doc = cleandoc(doc)
+    get_convert = _plain_int if convert is int else convert
+
+    if not mutable:
+        return property(lambda x: x._get_directive(key, empty, get_convert), doc=doc)
+
     return property(
-        lambda x: x._get_cache_value(key, empty, type),
-        lambda x, v: x._set_cache_value(key, v, type),
-        lambda x: x._del_cache_value(key),
-        doc=cleandoc(doc),
+        lambda x: x._get_directive(key, empty, get_convert),
+        lambda x, v: x._set_directive(key, v, convert),
+        lambda x: x._del_directive(key),
+        doc=doc,
     )
 
 
-class _CacheControl(CallbackDict[str, str | None]):
-    """Subclass of a dict that stores values for a Cache-Control header.  It
-    has accessors for all the cache-control directives specified in RFC 2616.
-    The class does not differentiate between request and response directives.
+class _CacheControl(cabc.Mapping[str, str | None]):
+    _data: cabc.Mapping[str, str | None]
 
-    Because the cache-control directives in the HTTP header use dashes the
-    python descriptors use underscores for that.
+    def __getitem__(self, key: str, /) -> str | None:
+        return self._data[key]
 
-    To get a header of the :class:`CacheControl` object again you can convert
-    the object into a string or call the :meth:`to_header` method.  If you plan
-    to subclass it and add your own items have a look at the sourcecode for
-    that class.
+    def __len__(self) -> int:
+        return len(self._data)
 
-    .. versionchanged:: 3.2
-        The ``on_update`` parameter was removed.
+    def __iter__(self) -> cabc.Iterator[str]:
+        return iter(self._data)
 
-    .. versionchanged:: 3.1
-        Dict values are always ``str | None``. Setting properties will
-        convert the value to a string. Setting a non-bool property to
-        ``False`` is equivalent to setting it to ``None``. Getting typed
-        properties will return ``None`` if conversion raises
-        ``ValueError``, rather than the string.
-
-    .. versionchanged:: 2.1
-        Setting int properties such as ``max_age`` will convert the
-        value to an int.
-
-    .. versionchanged:: 0.4
-       Setting ``no_cache`` or ``private`` to ``True`` will set the
-       implicit value ``"*"``.
-    """
-
-    no_store: bool = cache_control_property("no-store", None, bool)
-    max_age: int | None = cache_control_property("max-age", None, int)
-    no_transform: bool = cache_control_property("no-transform", None, bool)
-    stale_if_error: int | None = cache_control_property("stale-if-error", None, int)
-
-    def __init__(
-        self,
-        values: cabc.Mapping[str, t.Any]
-        | cabc.Iterable[tuple[str, t.Any]]
-        | None = None,
-    ):
-        super().__init__(values)
-        self.provided = values is not None
-
-    def _get_cache_value(
-        self, key: str, empty: t.Any, type: type[t.Any] | None
+    def _get_directive(
+        self, key: str, empty: t.Any, convert: t.Callable[[str], t.Any] | None
     ) -> t.Any:
-        """Used internally by the accessor properties."""
-        if type is bool:
+        if convert is bool:
             return key in self
 
         if key not in self:
@@ -117,37 +124,13 @@ class _CacheControl(CallbackDict[str, str | None]):
         if (value := self[key]) is None:
             return empty
 
-        if type is not None:
-            try:
-                value = type(value)
-            except ValueError:
-                return None
+        if convert is None:
+            return value
 
-        return value
-
-    def _set_cache_value(
-        self, key: str, value: t.Any, type: type[t.Any] | None
-    ) -> None:
-        """Used internally by the accessor properties."""
-        if type is bool:
-            if value:
-                self[key] = None
-            else:
-                self.pop(key, None)
-        elif value is None or value is False:
-            self.pop(key, None)
-        elif value is True:
-            self[key] = None
-        else:
-            if type is not None:
-                value = type(value)
-
-            self[key] = str(value)
-
-    def _del_cache_value(self, key: str) -> None:
-        """Used internally by the accessor properties."""
-        if key in self:
-            del self[key]
+        try:
+            return convert(value)
+        except ValueError:
+            return None
 
     @classmethod
     def from_header(cls, value: str | None) -> te.Self:
@@ -158,30 +141,39 @@ class _CacheControl(CallbackDict[str, str | None]):
         if not value:
             return cls()
 
-        return cls(parse_dict_header(value))
+        return cls(parse_dict_header(value))  # type: ignore[call-arg]
 
     def to_header(self) -> str:
         """Convert to a ``Cache-Control`` header value."""
-        return dump_header(self)
+        return dump_header(self._data)
 
     def __str__(self) -> str:
         return self.to_header()
 
     def __repr__(self) -> str:
-        kv_str = " ".join(f"{k}={v!r}" for k, v in sorted(self.items()))
+        kv_str = " ".join(f"{k}={v!r}" for k, v in sorted(self._data.items()))
         return f"<{type(self).__name__} {kv_str}>"
 
-    cache_property = staticmethod(cache_control_property)
+    cache_property = staticmethod(_deprecated_cache_control_property)
 
 
-class RequestCacheControl(ImmutableDictMixin[str, str | None], _CacheControl):  # type: ignore[misc]
-    """A cache control for requests.  This is immutable and gives access
-    to all the request-relevant cache control headers.
+class RequestCacheControl(_CacheControl):
+    """The ``Cache-Control`` request header. This is immutable, values received
+    in the request cannot be modified.
 
-    To get a header of the :class:`RequestCacheControl` object again you can
-    convert the object into a string or call the :meth:`to_header` method.  If
-    you plan to subclass it and add your own items have a look at the sourcecode
-    for that class.
+    Typically, you'll access the various directive properties. It also allows
+    indexing `cc[directive]` to access unknown directives that do not have
+    corresponding properties.
+
+    :param values: Values parsed from the request header.
+
+    .. versionchanged:: 3.2
+        Inherits ``Mapping`` instead of ``ImmutableDict``.
+
+        The ``on_update`` parameter was removed.
+
+        The ``cache_property`` method is deprecated and will be removed in
+        Werkzeug 3.3. Use indexing ``cc[key]`` for unknown directives.
 
     .. versionchanged:: 3.1
         Dict values are always ``str | None``. Setting properties will
@@ -190,23 +182,18 @@ class RequestCacheControl(ImmutableDictMixin[str, str | None], _CacheControl):  
         properties will return ``None`` if conversion raises
         ``ValueError``, rather than the string.
 
-    .. versionchanged:: 3.1
        ``max_age`` is ``None`` if present without a value, rather
        than ``-1``.
 
-    .. versionchanged:: 3.1
         ``no_cache`` is a boolean, it is ``True`` instead of ``"*"``
         when present.
 
-    .. versionchanged:: 3.1
         ``max_stale`` is ``True`` if present without a value, rather
         than ``"*"``.
 
-    .. versionchanged:: 3.1
        ``no_transform`` is a boolean. Previously it was mistakenly
        always ``None``.
 
-    .. versionchanged:: 3.1
        ``min_fresh`` is ``None`` if present without a value, rather
        than ``"*"``.
 
@@ -218,25 +205,56 @@ class RequestCacheControl(ImmutableDictMixin[str, str | None], _CacheControl):  
         Response-only properties are not present on this request class.
     """
 
-    no_cache: bool = cache_control_property("no-cache", None, bool)
-    max_stale: int | t.Literal[True] | None = cache_control_property(
-        "max-stale",
-        True,
-        int,
+    def __init__(
+        self,
+        values: cabc.Mapping[str, str | None]
+        | cabc.Iterable[tuple[str, str | None]]
+        | None = None,
+    ) -> None:
+        if values is None:
+            values = {}
+        elif not isinstance(values, cabc.Mapping):
+            import warnings
+
+            warnings.warn(
+                "Passing an iterable instead of a mapping is deprecated and"
+                " will be removed in Werkzeug 3.3.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            values = dict(values)
+
+        self._data = values
+
+    max_age = _cache_control_property("max-age", int)
+    max_stale: int | t.Literal[True] | None = _cache_control_property(
+        "max-stale", int, empty=True
     )
-    min_fresh: int | None = cache_control_property("min-fresh", None, int)
-    only_if_cached: bool = cache_control_property("only-if-cached", None, bool)
+    min_fresh: int | None = _cache_control_property("min-fresh", int)
+    no_cache: bool = _cache_control_property("no-cache", bool)
+    no_store: bool = _cache_control_property("no-store", bool)
+    no_transform: bool = _cache_control_property("no-transform", bool)
+    only_if_cached: bool = _cache_control_property("only-if-cached", bool)
+    stale_if_error: int | None = _cache_control_property("stale-if-error", int)
 
 
-class ResponseCacheControl(_CacheControl):
-    """A cache control for responses.  Unlike :class:`RequestCacheControl`
-    this is mutable and gives access to response-relevant cache control
-    headers.
+class ResponseCacheControl(cabc.MutableMapping[str, str | None], _CacheControl):
+    """The ``Cache-Control`` response header. This is mutable to allow updating
+    the response before sending.
 
-    To get a header of the :class:`ResponseCacheControl` object again you can
-    convert the object into a string or call the :meth:`to_header` method.  If
-    you plan to subclass it and add your own items have a look at the sourcecode
-    for that class.
+    Typically, you'll use the various directive properties. It also allows
+    indexing `cc[directive]` to get, set, or delete unknown directives that do
+    not have corresponding properties.
+
+    :param values: Initial values to set.
+
+    .. versionchanged:: 3.2
+        Inherits ``MutableMapping`` instead of ``dict``.
+
+        The ``on_update`` parameter was removed.
+
+        The ``cache_property`` method is deprecated and will be removed in
+        Werkzeug 3.3. Use indexing ``cc[key]`` for unknown directives.
 
     .. versionchanged:: 3.1
         Dict values are always ``str | None``. Setting properties will
@@ -245,19 +263,15 @@ class ResponseCacheControl(_CacheControl):
         properties will return ``None`` if conversion raises
         ``ValueError``, rather than the string.
 
-    .. versionchanged:: 3.1
         ``no_cache`` is ``True`` if present without a value, rather than
         ``"*"``.
 
-    .. versionchanged:: 3.1
         ``private`` is ``True`` if present without a value, rather than
         ``"*"``.
 
-    .. versionchanged:: 3.1
        ``no_transform`` is a boolean. Previously it was mistakenly
        always ``None``.
 
-    .. versionchanged:: 3.1
         Added the ``must_understand``, ``stale_while_revalidate``, and
         ``stale_if_error`` properties.
 
@@ -270,24 +284,121 @@ class ResponseCacheControl(_CacheControl):
 
     .. versionadded:: 0.5
        Request-only properties are not present on this response class.
+
+    .. versionchanged:: 0.4
+       Setting ``no_cache`` or ``private`` to ``True`` will set the
+       implicit value ``"*"``.
     """
 
+    _data: cabc.MutableMapping[str, str | None]
+
+    def __init__(
+        self,
+        values: cabc.Mapping[str, str | None]
+        | cabc.Iterable[tuple[str, str | None]]
+        | None = None,
+    ) -> None:
+        if values is None:
+            values = {}
+        elif isinstance(values, cabc.Mapping):
+            if not isinstance(values, cabc.MutableMapping):
+                values = dict(values)
+        else:
+            import warnings
+
+            warnings.warn(
+                "Passing an iterable instead of a mapping is deprecated and"
+                " will be removed in Werkzeug 3.3.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            values = dict(values)
+
+        self._data = values
+        self._on_update: t.Callable[[ResponseCacheControl], None] | None = None
+
+    def _trigger_on_update(self) -> None:
+        if self._on_update is not None:
+            self._on_update(self)
+
+    def __setitem__(self, key: str, value: str | None, /) -> None:
+        self._data[key] = value
+        self._trigger_on_update()
+
+    def __delitem__(self, key: str, /) -> None:
+        del self._data[key]
+        self._trigger_on_update()
+
+    def _set_directive(
+        self, key: str, value: t.Any, convert: type[t.Any] | None
+    ) -> None:
+        if convert is bool:
+            if value:
+                self._data[key] = None
+            else:
+                self._data.pop(key, None)
+        elif value is None or value is False:
+            self._data.pop(key, None)
+        elif value is True:
+            self._data[key] = None
+        else:
+            if convert is not None:
+                value = convert(value)
+
+            self._data[key] = str(value)
+
+        self._trigger_on_update()
+
+    def _del_directive(self, key: str) -> None:
+        self._data.pop(key, None)
+        self._trigger_on_update()
+
+    max_age: int | None = _cache_control_property("max-age", int, mutable=True)
+    s_maxage: int | None = _cache_control_property("s-maxage", int, mutable=True)
     # https://httpwg.org/specs/rfc9111.html#cache-response-directive.no-cache
     # This can be with or without a value, not mentioned on MDN.
-    no_cache: str | t.Literal[True] | None = cache_control_property(
-        "no-cache", True, None
+    no_cache: str | t.Literal[True] | None = _cache_control_property(
+        "no-cache", str, empty=True, mutable=True
     )
-    public: bool = cache_control_property("public", None, bool)
+    no_store: bool = _cache_control_property("no-store", bool, mutable=True)
+    no_transform: bool = _cache_control_property("no-transform", bool, mutable=True)
+    must_revalidate: bool = _cache_control_property(
+        "must-revalidate", bool, mutable=True
+    )
+    proxy_revalidate: bool = _cache_control_property(
+        "proxy-revalidate", bool, mutable=True
+    )
+    must_understand: bool = _cache_control_property(
+        "must-understand", bool, mutable=True
+    )
     # https://httpwg.org/specs/rfc9111.html#cache-response-directive.private
     # This can be with or without a value, not mentioned on MDN.
-    private: str | t.Literal[True] | None = cache_control_property(
-        "private", True, None
+    private: str | t.Literal[True] | None = _cache_control_property(
+        "private", str, empty=True, mutable=True
     )
-    must_revalidate: bool = cache_control_property("must-revalidate", None, bool)
-    proxy_revalidate: bool = cache_control_property("proxy-revalidate", None, bool)
-    s_maxage: int | None = cache_control_property("s-maxage", None, int)
-    immutable: bool = cache_control_property("immutable", None, bool)
-    must_understand: bool = cache_control_property("must-understand", None, bool)
-    stale_while_revalidate: int | None = cache_control_property(
-        "stale-while-revalidate", None, int
+    public: bool = _cache_control_property("public", bool, mutable=True)
+    immutable: bool = _cache_control_property("immutable", bool, mutable=True)
+    stale_while_revalidate: int | None = _cache_control_property(
+        "stale-while-revalidate", int, mutable=True
     )
+    stale_if_error: int | None = _cache_control_property(
+        "stale-if-error", int, mutable=True
+    )
+
+
+if not t.TYPE_CHECKING:
+
+    def __getattr__(name: str) -> t.Any:
+        if name == "cache_control_property":
+            import warnings
+
+            warnings.warn(
+                "The 'cache_control_property' function is deprecated and will"
+                " be removed in Werkzeug 3.3. Use indexing 'cc[key]' for"
+                " unknown directives.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return _deprecated_cache_control_property
+
+        raise AttributeError(name)

--- a/src/werkzeug/datastructures/csp.py
+++ b/src/werkzeug/datastructures/csp.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections.abc as cabc
 import typing as t
 
 from .structures import CallbackDict
@@ -77,13 +76,6 @@ class ContentSecurityPolicy(CallbackDict[str, str]):
     # removed directives
     navigate_to: str | None = csp_property("navigate-to", deprecated="3.3")
     plugin_types: str | None = csp_property("plugin-types", deprecated="3.3")
-
-    def __init__(
-        self,
-        values: cabc.Mapping[str, str] | cabc.Iterable[tuple[str, str]] | None = None,
-    ) -> None:
-        super().__init__(values)
-        self.provided = values is not None
 
     def _get_value(self, key: str, deprecated: str | None = None) -> str | None:
         """Used internally by the accessor properties."""

--- a/src/werkzeug/datastructures/mixins.py
+++ b/src/werkzeug/datastructures/mixins.py
@@ -20,8 +20,12 @@ def _immutable_error(self: t.Any) -> t.NoReturn:
     raise TypeError(f"{type(self).__name__!r} objects are immutable")
 
 
-class ImmutableListMixin:
+class _ImmutableListMixin:
     """Makes a :class:`list` immutable.
+
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3. Use ``collections.abc.Sequence``
+        instead.
 
     .. versionadded:: 0.5
 
@@ -315,3 +319,24 @@ class UpdateDictMixin(dict[K, V]):
         self, other: cabc.Mapping[K, V] | cabc.Iterable[tuple[K, V]]
     ) -> te.Self:
         return super().__ior__(other)
+
+
+if not t.TYPE_CHECKING:
+
+    def __getattr__(name: str) -> t.Any:
+        alts = {
+            "ImmutableListMixin": "collections.abc.Sequence",
+        }
+
+        if name in alts:
+            import warnings
+
+            warnings.warn(
+                f"The '{name}' class is deprecated and will be removed in"
+                f" Werkzeug 3.3. Use '{alts[name]}' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return globals()[f"_{name}"]
+
+        raise AttributeError(name)

--- a/src/werkzeug/datastructures/mixins.py
+++ b/src/werkzeug/datastructures/mixins.py
@@ -240,7 +240,7 @@ class ImmutableHeadersMixin:
 
 def _always_update(f: F) -> F:
     def wrapper(
-        self: UpdateDictMixin[t.Any, t.Any], /, *args: t.Any, **kwargs: t.Any
+        self: _UpdateDictMixin[t.Any, t.Any], /, *args: t.Any, **kwargs: t.Any
     ) -> t.Any:
         rv = f(self, *args, **kwargs)
 
@@ -252,8 +252,11 @@ def _always_update(f: F) -> F:
     return update_wrapper(wrapper, f)  # type: ignore[return-value]
 
 
-class UpdateDictMixin(dict[K, V]):
+class _UpdateDictMixin(dict[K, V]):
     """Makes dicts call `self.on_update` on modifications.
+
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3. Use ``CallbackDict`` instead.
 
     .. versionchanged:: 3.1
         Implement ``|=`` operator.
@@ -333,6 +336,7 @@ if not t.TYPE_CHECKING:
         alts = {
             "ImmutableListMixin": "collections.abc.Sequence",
             "ImmutableDictMixin": "collections.abc.Mapping",
+            "UpdateDictMixin": "CallbackDict",
         }
 
         if name in alts:

--- a/src/werkzeug/datastructures/mixins.py
+++ b/src/werkzeug/datastructures/mixins.py
@@ -77,8 +77,12 @@ class _ImmutableListMixin:
         _immutable_error(self)
 
 
-class ImmutableDictMixin(t.Generic[K, V]):
+class _ImmutableDictMixin(t.Generic[K, V]):
     """Makes a :class:`dict` immutable.
+
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3. Use ``collections.abc.Mapping``
+        instead.
 
     .. versionchanged:: 3.1
         Disallow ``|=`` operator.
@@ -94,14 +98,16 @@ class ImmutableDictMixin(t.Generic[K, V]):
     @t.overload
     def fromkeys(
         cls, keys: cabc.Iterable[K], value: None
-    ) -> ImmutableDictMixin[K, t.Any | None]: ...
+    ) -> _ImmutableDictMixin[K, t.Any | None]: ...
     @classmethod
     @t.overload
-    def fromkeys(cls, keys: cabc.Iterable[K], value: V) -> ImmutableDictMixin[K, V]: ...
+    def fromkeys(
+        cls, keys: cabc.Iterable[K], value: V
+    ) -> _ImmutableDictMixin[K, V]: ...
     @classmethod
     def fromkeys(
         cls, keys: cabc.Iterable[K], value: V | None = None
-    ) -> ImmutableDictMixin[K, t.Any | None] | ImmutableDictMixin[K, V]:
+    ) -> _ImmutableDictMixin[K, t.Any | None] | _ImmutableDictMixin[K, V]:
         instance = super().__new__(cls)
         instance.__init__(zip(keys, repeat(value)))  # type: ignore[misc]
         return instance
@@ -143,7 +149,7 @@ class ImmutableDictMixin(t.Generic[K, V]):
         _immutable_error(self)
 
 
-class ImmutableMultiDictMixin(ImmutableDictMixin[K, V]):
+class ImmutableMultiDictMixin(_ImmutableDictMixin[K, V]):
     """Makes a :class:`MultiDict` immutable.
 
     .. versionadded:: 0.5
@@ -326,6 +332,7 @@ if not t.TYPE_CHECKING:
     def __getattr__(name: str) -> t.Any:
         alts = {
             "ImmutableListMixin": "collections.abc.Sequence",
+            "ImmutableDictMixin": "collections.abc.Mapping",
         }
 
         if name in alts:

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -8,8 +8,8 @@ from .. import exceptions
 from .._internal import _missing
 from ..http import dump_header
 from ..http import parse_list_header
+from .mixins import _ImmutableDictMixin
 from .mixins import _ImmutableListMixin
-from .mixins import ImmutableDictMixin
 from .mixins import ImmutableMultiDictMixin
 from .mixins import UpdateDictMixin
 
@@ -122,7 +122,7 @@ class TypeConversionDict(dict[K, V]):
             return default
 
 
-class ImmutableTypeConversionDict(ImmutableDictMixin[K, V], TypeConversionDict[K, V]):  # type: ignore[misc]
+class ImmutableTypeConversionDict(_ImmutableDictMixin[K, V], TypeConversionDict[K, V]):  # type: ignore[misc]
     """Works like a :class:`TypeConversionDict` but does not support
     modifications.
 
@@ -697,8 +697,12 @@ class CombinedMultiDict(ImmutableMultiDictMixin[K, V], MultiDict[K, V]):  # type
         return f"{type(self).__name__}({self.dicts!r})"
 
 
-class ImmutableDict(ImmutableDictMixin[K, V], dict[K, V]):  # type: ignore[misc]
+class _ImmutableDict(_ImmutableDictMixin[K, V], dict[K, V]):  # type: ignore[misc]
     """An immutable :class:`dict`.
+
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3. Use ``collections.abc.Mapping``
+        instead.
 
     .. versionadded:: 0.5
     """
@@ -925,6 +929,7 @@ if not t.TYPE_CHECKING:
     def __getattr__(name: str) -> t.Any:
         alts = {
             "ImmutableList": "collections.abc.Sequence",
+            "ImmutableDict": "collections.abc.Mapping",
         }
 
         if name in alts:

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -11,7 +11,6 @@ from ..http import parse_list_header
 from .mixins import _ImmutableDictMixin
 from .mixins import _ImmutableListMixin
 from .mixins import ImmutableMultiDictMixin
-from .mixins import UpdateDictMixin
 
 if t.TYPE_CHECKING:
     import typing_extensions as te
@@ -738,14 +737,18 @@ class ImmutableMultiDict(ImmutableMultiDictMixin[K, V], MultiDict[K, V]):  # typ
         return self
 
 
-class CallbackDict(UpdateDictMixin[K, V], dict[K, V]):
-    """A dict that calls a function passed every time something is changed.
-    The function is passed the dict instance.
+class CallbackDict(dict[K, V]):
+    """A dict that calls a function every time it is mutated.
+
+    :param initial: Initial data.
+    :param on_update: A function to call every time this dict is mutated. The
+        dict is passed as the first argument.
     """
 
     def __init__(
-        self,
+        self: te.Self,
         initial: cabc.Mapping[K, V] | cabc.Iterable[tuple[K, V]] | None = None,
+        /,
         on_update: cabc.Callable[[te.Self], None] | None = None,
     ) -> None:
         if initial is None:
@@ -757,6 +760,85 @@ class CallbackDict(UpdateDictMixin[K, V], dict[K, V]):
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__} {super().__repr__()}>"
+
+    def _trigger_on_update(self: te.Self) -> None:
+        if self.on_update is not None:
+            self.on_update(self)
+
+    def setdefault(
+        self,
+        key: K,
+        default: V = None,  # type: ignore[assignment]
+        /,
+    ) -> V:
+        modified = key not in self
+        rv = super().setdefault(key, default)
+
+        if modified:
+            self._trigger_on_update()
+
+        return rv
+
+    @t.overload
+    def pop(self, key: K, /) -> V: ...
+    @t.overload
+    def pop(self, key: K, default: V, /) -> V: ...
+    @t.overload
+    def pop(self, key: K, default: T, /) -> T: ...
+    def pop(
+        self: te.Self,
+        key: K,
+        default: V | T = _missing,  # type: ignore[assignment]
+        /,
+    ) -> V | T:
+        modified = key in self
+
+        if default is _missing:
+            rv: V | T = super().pop(key)
+        else:
+            rv = super().pop(key, default)
+
+        if modified:
+            self._trigger_on_update()
+
+        return rv
+
+    def __setitem__(self, key: K, value: V) -> None:
+        super().__setitem__(key, value)
+        self._trigger_on_update()
+
+    def __delitem__(self, key: K) -> None:
+        super().__delitem__(key)
+        self._trigger_on_update()
+
+    def clear(self) -> None:
+        super().clear()
+        self._trigger_on_update()
+
+    def popitem(self) -> tuple[K, V]:
+        rv = super().popitem()
+        self._trigger_on_update()
+        return rv
+
+    def update(  # type: ignore[override]
+        self,
+        arg: cabc.Mapping[K, V] | cabc.Iterable[tuple[K, V]] | None = None,
+        /,
+        **kwargs: V,
+    ) -> None:
+        if arg is None:
+            super().update(**kwargs)  # type: ignore[call-overload]
+        else:
+            super().update(arg, **kwargs)
+
+        self._trigger_on_update()
+
+    def __ior__(  # type: ignore[override, misc]
+        self, other: cabc.Mapping[K, V] | cabc.Iterable[tuple[K, V]]
+    ) -> te.Self:
+        rv = super().__ior__(other)
+        self._trigger_on_update()
+        return rv
 
 
 class HeaderSet(cabc.MutableSet[str]):

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -59,7 +59,7 @@ class _ImmutableList(_ImmutableListMixin, list[V]):  # type: ignore[misc]
         return f"{type(self).__name__}({list.__repr__(self)})"
 
 
-class TypeConversionDict(dict[K, V]):
+class _TypeConversionDict(dict[K, V]):
     """Works like a regular dict but the :meth:`get` method can perform
     type conversions.  :class:`MultiDict` and :class:`CombinedMultiDict`
     are subclasses of this class and provide the same feature.
@@ -121,25 +121,27 @@ class TypeConversionDict(dict[K, V]):
             return default
 
 
-class ImmutableTypeConversionDict(_ImmutableDictMixin[K, V], TypeConversionDict[K, V]):  # type: ignore[misc]
+class _ImmutableTypeConversionDict(  # type: ignore[misc]
+    _ImmutableDictMixin[K, V], _TypeConversionDict[K, V]
+):
     """Works like a :class:`TypeConversionDict` but does not support
     modifications.
 
     .. versionadded:: 0.5
     """
 
-    def copy(self) -> TypeConversionDict[K, V]:
+    def copy(self) -> _TypeConversionDict[K, V]:
         """Return a shallow mutable copy of this object.  Keep in mind that
         the standard library's :func:`copy` function is a no-op for this class
         like for any other python immutable type (eg: :class:`tuple`).
         """
-        return TypeConversionDict(self)
+        return _TypeConversionDict(self)
 
     def __copy__(self) -> te.Self:
         return self
 
 
-class MultiDict(TypeConversionDict[K, V]):
+class MultiDict(dict[K, V]):
     """A :class:`MultiDict` is a dictionary subclass customized to deal with
     multiple values for the same key which is for example used by the parsing
     functions in the wrappers.  This is necessary because some HTML form
@@ -259,6 +261,45 @@ class MultiDict(TypeConversionDict[K, V]):
         :param value: the value to add.
         """
         super().setdefault(key, []).append(value)  # type: ignore[arg-type,attr-defined]
+
+    @t.overload  # type: ignore[override]
+    def get(self, key: K) -> V | None: ...
+    @t.overload
+    def get(self, key: K, default: V) -> V: ...
+    @t.overload
+    def get(self, key: K, default: T) -> V | T: ...
+    @t.overload
+    def get(self, key: str, type: cabc.Callable[[V], T]) -> T | None: ...
+    @t.overload
+    def get(self, key: str, default: T, type: cabc.Callable[[V], T]) -> T: ...
+    def get(  # type: ignore[misc]
+        self,
+        key: K,
+        default: V | T | None = None,
+        type: cabc.Callable[[V], T] | None = None,
+    ) -> V | T | None:
+        """Get the first value for the key, or a default if it's not set.
+
+        :param key: The key to get.
+        :param default: The value to return if the key is not set.
+        :param type: Convert the value using this function. If it raises a
+            ``TypeError`` or ``ValueError``, return ``default``.
+
+        .. versionchanged:: 3.0.2
+           Returns the default value on :exc:`TypeError`, too.
+        """
+        try:
+            rv = self[key]
+        except KeyError:
+            return default
+
+        if type is None:
+            return rv
+
+        try:
+            return type(rv)
+        except (ValueError, TypeError):
+            return default
 
     @t.overload
     def getlist(self, key: K) -> list[V]: ...
@@ -1012,6 +1053,8 @@ if not t.TYPE_CHECKING:
         alts = {
             "ImmutableList": "collections.abc.Sequence",
             "ImmutableDict": "collections.abc.Mapping",
+            "ImmutableTypeConversionDict": "ImmutableMultiDict",
+            "TypeConversionDict": "MultiDict",
         }
 
         if name in alts:

--- a/src/werkzeug/datastructures/structures.py
+++ b/src/werkzeug/datastructures/structures.py
@@ -8,8 +8,8 @@ from .. import exceptions
 from .._internal import _missing
 from ..http import dump_header
 from ..http import parse_list_header
+from .mixins import _ImmutableListMixin
 from .mixins import ImmutableDictMixin
-from .mixins import ImmutableListMixin
 from .mixins import ImmutableMultiDictMixin
 from .mixins import UpdateDictMixin
 
@@ -44,8 +44,12 @@ def iter_multi_items(
         yield from mapping
 
 
-class ImmutableList(ImmutableListMixin, list[V]):  # type: ignore[misc]
+class _ImmutableList(_ImmutableListMixin, list[V]):  # type: ignore[misc]
     """An immutable :class:`list`.
+
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3. Use ``collections.abc.Sequence``
+        instead.
 
     .. versionadded:: 0.5
 
@@ -914,3 +918,24 @@ class HeaderSet(cabc.MutableSet[str]):
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self._headers!r})"
+
+
+if not t.TYPE_CHECKING:
+
+    def __getattr__(name: str) -> t.Any:
+        alts = {
+            "ImmutableList": "collections.abc.Sequence",
+        }
+
+        if name in alts:
+            import warnings
+
+            warnings.warn(
+                f"The '{name}' class is deprecated and will be removed in"
+                f" Werkzeug 3.3. Use '{alts[name]}' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return globals()[f"_{name}"]
+
+        raise AttributeError(name)

--- a/src/werkzeug/http.py
+++ b/src/werkzeug/http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import email.utils
 import hashlib
 import re
@@ -324,7 +325,7 @@ def dump_options_header(header: str | None, options: t.Mapping[str, t.Any]) -> s
     return "; ".join(segments)
 
 
-def dump_header(iterable: dict[str, t.Any] | t.Iterable[t.Any]) -> str:
+def dump_header(iterable: cabc.Mapping[str, t.Any] | cabc.Iterable[t.Any]) -> str:
     """Produce a header value from a list of items or ``key=value`` pairs, separated by
     commas ``,``.
 
@@ -356,7 +357,7 @@ def dump_header(iterable: dict[str, t.Any] | t.Iterable[t.Any]) -> str:
     .. versionchanged:: 2.2.3
         If a key ends with ``*``, its value will not be quoted.
     """
-    if isinstance(iterable, dict):
+    if isinstance(iterable, cabc.Mapping):
         items = []
 
         for key, value in iterable.items():
@@ -833,7 +834,10 @@ def _parse_cache_control_header(
         cls = t.cast(type[_TAnyCC], ds.RequestCacheControl)
 
     obj = cls.from_header(value)
-    obj.on_update = on_update
+
+    if hasattr(obj, "_on_update"):
+        obj._on_update = on_update
+
     return obj
 
 

--- a/src/werkzeug/routing/converters.py
+++ b/src/werkzeug/routing/converters.py
@@ -322,15 +322,3 @@ class UUIDConverter(BaseConverter):
 
     def to_url(self, value: uuid.UUID) -> str:
         return str(value)
-
-
-#: the default converter mapping for the map.
-DEFAULT_CONVERTERS: t.Mapping[str, type[BaseConverter]] = {
-    "default": UnicodeConverter,
-    "string": UnicodeConverter,
-    "any": AnyConverter,
-    "path": PathConverter,
-    "int": IntegerConverter,
-    "float": FloatConverter,
-    "uuid": UUIDConverter,
-}

--- a/src/werkzeug/routing/map.py
+++ b/src/werkzeug/routing/map.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections.abc as cabc
 import typing as t
 import warnings
 from pprint import pformat
@@ -9,7 +10,6 @@ from urllib.parse import urljoin
 from urllib.parse import urlunsplit
 
 from .._internal import _wsgi_decoding_dance
-from ..datastructures import ImmutableDict
 from ..datastructures import MultiDict
 from ..exceptions import BadHost
 from ..exceptions import HTTPException
@@ -18,7 +18,8 @@ from ..exceptions import NotFound
 from ..urls import _urlencode
 from ..wrappers.request import Request
 from ..wsgi import get_host
-from .converters import DEFAULT_CONVERTERS
+from . import BaseConverter
+from . import converters
 from .exceptions import BuildError
 from .exceptions import NoMatch
 from .exceptions import RequestAliasRedirect
@@ -33,7 +34,6 @@ if t.TYPE_CHECKING:
     from _typeshed.wsgi import WSGIApplication
     from _typeshed.wsgi import WSGIEnvironment
 
-    from .converters import BaseConverter
     from .rules import RuleFactory
 
 
@@ -90,8 +90,20 @@ class Map:
         The ``sort_parameters`` and ``sort_key``  parameters were added.
     """
 
-    #: A dict of default converters to be used.
-    default_converters = ImmutableDict(DEFAULT_CONVERTERS)
+    default_converters: t.ClassVar[cabc.Mapping[str, type[BaseConverter]]] = {
+        "default": converters.UnicodeConverter,
+        "string": converters.UnicodeConverter,
+        "any": converters.AnyConverter,
+        "path": converters.PathConverter,
+        "int": converters.IntegerConverter,
+        "float": converters.FloatConverter,
+        "uuid": converters.UUIDConverter,
+    }
+    """Default converters available for variable parts in rules.
+
+    Do not modify this directly. Use the ``converters`` parameter or modify the
+    :attr:`converters` attribute when creating the map.
+    """
 
     #: The type of lock to use when updating.
     #:
@@ -105,7 +117,7 @@ class Map:
         strict_slashes: bool = True,
         merge_slashes: bool = True,
         redirect_defaults: bool = True,
-        converters: t.Mapping[str, type[BaseConverter]] | None = None,
+        converters: dict[str, type[BaseConverter]] | None = None,
         sort_parameters: bool = False,
         sort_key: t.Callable[[t.Any], t.Any] | None = None,
         host_matching: bool = False,
@@ -123,7 +135,8 @@ class Map:
         self.subdomain_matching = subdomain_matching and not host_matching
         self.host_matching = host_matching
 
-        self.converters = self.default_converters.copy()
+        self.converters = dict(self.default_converters)
+
         if converters:
             self.converters.update(converters)
 

--- a/src/werkzeug/sansio/request.py
+++ b/src/werkzeug/sansio/request.py
@@ -188,11 +188,11 @@ class Request:
         Otherwise, this only contains :attr:`remote_addr`, or is empty.
         """
         if "X-Forwarded-For" in self.headers:
-            items = parse_list_header(self.headers["X-Forwarded-For"])
+            items = tuple(parse_list_header(self.headers["X-Forwarded-For"]))
         elif self.remote_addr is not None:
-            items = [self.remote_addr]
+            items = (self.remote_addr,)
         else:
-            items = []
+            items = ()
 
         if self.list_storage_class is not None:
             import warnings

--- a/src/werkzeug/sansio/response.py
+++ b/src/werkzeug/sansio/response.py
@@ -533,7 +533,7 @@ class Response:
                 self.headers["Cache-Control"] = cache_control.to_header()
 
         obj = ResponseCacheControl.from_header(self.headers.get("Cache-Control"))
-        obj.on_update = on_update
+        obj._on_update = on_update
         return obj
 
     def set_etag(self, etag: str, weak: bool = False) -> None:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -304,31 +304,6 @@ class TestImmutableTypeConversionDict(_ImmutableDictTests):
     storage_class = ds.ImmutableTypeConversionDict
 
 
-class TestImmutableMultiDict(_ImmutableDictTests):
-    storage_class = ds.ImmutableMultiDict
-
-    def test_multidict_is_hashable(self):
-        cls = self.storage_class
-        immutable = cls({"a": [1, 2], "b": 2})
-        immutable2 = cls({"a": [1], "b": 2})
-        x = {immutable}
-        assert immutable in x
-        assert immutable2 not in x
-        x.discard(immutable)
-        assert immutable not in x
-        assert immutable2 not in x
-        x.add(immutable2)
-        assert immutable not in x
-        assert immutable2 in x
-        x.add(immutable)
-        assert immutable in x
-        assert immutable2 in x
-
-
-class TestImmutableDict(_ImmutableDictTests):
-    storage_class = ds.ImmutableDict
-
-
 class TestMultiDict(_MutableMultiDictTests):
     storage_class = ds.MultiDict
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -753,7 +753,7 @@ class TestCallbackDict:
     def test_callback_dict_reads(self):
         assert_calls, func = make_call_asserter()
         initial = {"a": "foo", "b": "bar"}
-        dct = self.storage_class(initial=initial, on_update=func)
+        dct = self.storage_class(initial, on_update=func)
         with assert_calls(0, "callback triggered by read-only method"):
             # read-only methods
             dct["a"]
@@ -765,19 +765,19 @@ class TestCallbackDict:
         with assert_calls(0, "callback triggered without modification"):
             # methods that may write but don't
             dct.pop("z", None)
-            dct.setdefault("a")
+            dct.setdefault("a", "z")
 
     def test_callback_dict_writes(self):
         assert_calls, func = make_call_asserter()
         initial = {"a": "foo", "b": "bar"}
-        dct = self.storage_class(initial=initial, on_update=func)
+        dct = self.storage_class(initial, on_update=func)
         with assert_calls(9, "callback not triggered by write method"):
             # always-write methods
             dct["z"] = 123
             dct["z"] = 123  # must trigger again
             del dct["z"]
             dct.pop("b", None)
-            dct.setdefault("x")
+            dct.setdefault("x", "y")
             dct.popitem()
             dct.update([])
             dct.clear()

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -300,10 +300,6 @@ class _ImmutableDictTests:
             a |= {"y": 2}
 
 
-class TestImmutableTypeConversionDict(_ImmutableDictTests):
-    storage_class = ds.ImmutableTypeConversionDict
-
-
 class TestMultiDict(_MutableMultiDictTests):
     storage_class = ds.MultiDict
 
@@ -372,25 +368,6 @@ class TestMultiDict(_MutableMultiDictTests):
 
         with pytest.raises(KeyError):
             md["empty"]
-
-
-class TestTypeConversionDict:
-    storage_class = ds.TypeConversionDict
-
-    def test_value_conversion(self):
-        d = self.storage_class(foo="1")
-        assert d.get("foo", type=int) == 1
-
-    def test_return_default_when_conversion_is_not_possible(self):
-        d = self.storage_class(foo="bar", baz=None)
-        assert d.get("foo", default=-1, type=int) == -1
-        assert d.get("baz", default=-1, type=int) == -1
-
-    def test_propagate_exceptions_in_conversion(self):
-        d = self.storage_class(foo="bar")
-        switch = {"a": 1}
-        with pytest.raises(KeyError):
-            d.get("foo", type=lambda x: switch[x])
 
 
 class TestCombinedMultiDict:

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -745,16 +745,6 @@ class TestHeaderSet:
         assert not hs
 
 
-class TestImmutableList:
-    storage_class = ds.ImmutableList
-
-    def test_list_hashable(self):
-        data = (1, 2, 3, 4)
-        store = self.storage_class(data)
-        assert hash(data) == hash(store)
-        assert data != store
-
-
 def make_call_asserter(func=None):
     """Utility to assert a certain number of function calls.
 

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -815,11 +815,11 @@ class TestCallbackDict:
 
 class TestCacheControl:
     def test_repr(self):
-        cc = ds.RequestCacheControl([("max-age", "0"), ("private", "True")])
+        cc = ds.RequestCacheControl({"max-age": "0", "private": "True"})
         assert repr(cc) == "<RequestCacheControl max-age='0' private='True'>"
 
     def test_set_none(self):
-        cc = ds.ResponseCacheControl([("max-age", "0")])
+        cc = ds.ResponseCacheControl({"max-age": "0"})
         assert cc.no_cache is None
         cc.no_cache = None
         assert cc.no_cache is None
@@ -827,33 +827,33 @@ class TestCacheControl:
         assert cc.no_cache is None
 
     def test_no_transform(self):
-        cc = ds.RequestCacheControl([("no-transform", None)])
+        cc = ds.RequestCacheControl({"no-transform": None})
         assert cc.no_transform is True
         cc = ds.RequestCacheControl()
         assert cc.no_transform is False
 
     def test_min_fresh(self):
-        cc = ds.RequestCacheControl([("min-fresh", "0")])
+        cc = ds.RequestCacheControl({"min-fresh": "0"})
         assert cc.min_fresh == 0
-        cc = ds.RequestCacheControl([("min-fresh", None)])
+        cc = ds.RequestCacheControl({"min-fresh": None})
         assert cc.min_fresh is None
         cc = ds.RequestCacheControl()
         assert cc.min_fresh is None
 
     def test_must_understand(self):
-        cc = ds.ResponseCacheControl([("must-understand", None)])
+        cc = ds.ResponseCacheControl({"must-understand": None})
         assert cc.must_understand is True
         cc = ds.ResponseCacheControl()
         assert cc.must_understand is False
 
     def test_stale_while_revalidate(self):
-        cc = ds.ResponseCacheControl([("stale-while-revalidate", "1")])
+        cc = ds.ResponseCacheControl({"stale-while-revalidate": "1"})
         assert cc.stale_while_revalidate == 1
         cc = ds.ResponseCacheControl()
         assert cc.stale_while_revalidate is None
 
     def test_stale_if_error(self):
-        cc = ds.ResponseCacheControl([("stale-if-error", "1")])
+        cc = ds.ResponseCacheControl({"stale-if-error": "1"})
         assert cc.stale_if_error == 1
         cc = ds.ResponseCacheControl()
         assert cc.stale_while_revalidate is None

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9,7 +9,6 @@ import uuid
 import pytest
 
 from werkzeug import routing as r
-from werkzeug.datastructures import ImmutableDict
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import MethodNotAllowed
 from werkzeug.exceptions import NotFound
@@ -819,10 +818,9 @@ def test_complex_routing_rules():
 
 def test_default_converters():
     class MyMap(r.Map):
-        default_converters = r.Map.default_converters.copy()
+        default_converters = dict(r.Map.default_converters)
         default_converters["foo"] = r.UnicodeConverter
 
-    assert isinstance(r.Map.default_converters, ImmutableDict)
     m = MyMap(
         [
             r.Rule("/a/<foo:a>", endpoint="a"),

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -110,7 +110,7 @@ def test_access_route():
         headers={"X-Forwarded-For": "192.168.1.2, 192.168.1.1"},
         environ_base={"REMOTE_ADDR": "192.168.1.3"},
     )
-    assert req.access_route == ["192.168.1.2", "192.168.1.1"]
+    assert req.access_route == ("192.168.1.2", "192.168.1.1")
     assert req.remote_addr == "192.168.1.3"
 
     req = wrappers.Request.from_values(environ_base={"REMOTE_ADDR": "192.168.1.3"})


### PR DESCRIPTION
This is part of https://github.com/pallets/werkzeug/discussions/3111. None of these are used by Werkzeug itself. They add a lot of code and tests that I constantly have to scan through to find the stuff we actually use. They're not good with type checking.

The immutable mixins are better handled by type annotations. `ImmutableList` is `Sequence` (or `tuple`), `ImmutableDict` is `Mapping`. In typing, the mutable variants inherit from the immutable ones, in order to add the mutation methods. The mixins would raise errors, meaning that completions and typing were unhelpful.

`Accept` inherits `Sequence` instead of `ImmutableList` and stores a `tuple` of values internally.

`RequestCacheControl` inherits `Mapping`, while `ResponseCacheControl` inherits `MutableMapping`. The `cache_property` function and static method are deprecated, in favor of using `cc[key]` for new or custom keys (and making a feature request for new specs). Its signature was really confusing, and trying to add mutable to it was annoying.

`UpdateDictMixin` was basically the entire implementation of `CallbackDict`, so use that directly instead.

Regarding immutable and typing, the thing I didn't address in this PR is `MultiDict` and `ImmutableMultiDict` (and the immutable `CombinedMultiDict`). `ImmutableMultiDictMixin` causes mutation methods to error. `ImmutableMultiDict` inherits `MultidDict`, rather than the other way around. I'll do this reshuffling in another PR.