### PR TITLE
deprecate testapp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Version 3.2.0
 -   The ``accept_charsets`` header property on ``Request``, and the
     ``CharsetAccept`` class, are deprecated. The header has not been used for a
     long time. :pr:`3161`
+-   The ``testapp`` module and its ``test_app`` are deprecated.
 -   ``redirect`` returns a ``303`` status code by default instead of ``302``.
     This tells the client to always switch to ``GET``, rather than only
     switching ``POST`` to ``GET``. This preserves the current behavior of

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -12,16 +12,19 @@ application without starting a server. The client has methods for making
 different types of requests, as well as managing cookies across
 requests.
 
->>> from werkzeug.test import Client
->>> from werkzeug.testapp import test_app
->>> c = Client(test_app)
->>> response = c.get("/")
->>> response.status_code
-200
->>> response.headers
-Headers([('Content-Type', 'text/html; charset=utf-8'), ('Content-Length', '5211')])
->>> response.get_data(as_text=True)
-'<!doctype html>...'
+.. code-block:: python
+
+    from werkzeug import Request, Response, Client
+
+    @Request.application
+    def app(request: Request) -> Response:
+        return Response("Hello, World!")
+
+    c = Client(app)
+    r = c.get("/")
+    assert r.status_code == 200
+    assert r.headers["Content-Type"] == "text/plain"
+    assert r.text == "Hello, World!"
 
 The client's request methods return instances of :class:`TestResponse`.
 This provides extra attributes and methods on top of

--- a/src/werkzeug/testapp.py
+++ b/src/werkzeug/testapp.py
@@ -8,12 +8,21 @@ import importlib.metadata
 import os
 import sys
 import typing as t
+import warnings
 from textwrap import wrap
 
 from markupsafe import escape
 
 from .wrappers.request import Request
 from .wrappers.response import Response
+
+warnings.warn(
+    "The 'testapp' module is deprecated and will be removed in Werkzeug 3.3."
+    " Use your Python package manager to list installed package versions, and"
+    " the Python shell to inspect ``sys``.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 TEMPLATE = """\
 <!doctype html>
@@ -126,6 +135,9 @@ def test_app(req: Request) -> Response:
 
     The application displays important information from the WSGI environment,
     the Python interpreter and the installed libraries.
+
+    .. deprecated:: 3.2
+        Will be removed in Werkzeug 3.3.
     """
     try:
         import pkg_resources


### PR DESCRIPTION
This was likely more useful when Python package management was not mature. Now, `pip list`, `uv tree`, etc will give you packages and versions (and this will fail anyway since it depends on `pkg_resources` still). Virtualenvs will isolate the path for you, and installers will choose the right platform wheels. `wsgiref.utils.demo_app` can be used if you really need something to echo the environ or demo a server implementation.